### PR TITLE
feat: add husky and commitizen through pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# yarn test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+- repo: local
+  hooks:
+    - id: husky-run-pre-commit
+      name: husky
+      language: system
+      entry: .husky/pre-commit
+      pass_filenames: false
+- repo: https://github.com/commitizen-tools/commitizen
+  rev: v2.20.0
+  hooks:
+    - id: commitizen
+      stages: [commit-msg]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "cd client && yarn build && cd .. && cp -R client/build/* public && mv public/index.html public/app.html",
     "dev:api": "NODE_ENV=development PORT=3000 nodemon src/index.ts",
     "staging": "NODE_ENV=production nodemon src/index.ts",
-    "dev": "concurrently \"yarn dev:api\" \"cd client && PORT=8080 yarn start\""
+    "dev": "concurrently \"yarn dev:api\" \"cd client && PORT=8080 yarn start\"",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@bull-board/express": "^4.11.0",
@@ -30,6 +31,7 @@
     "express-openapi": "^12.1.0",
     "file-type": "16",
     "fluent-ffmpeg": "^2.1.2",
+    "husky": "^8.0.3",
     "image-size": "^1.0.2",
     "json2csv": "^6.0.0-alpha.2",
     "jsonwebtoken": "^8.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2487,6 +2487,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+
 i18n-locales@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/i18n-locales/-/i18n-locales-0.0.5.tgz#8f587e598ab982511d7c7db910cb45b8d93cd96a"


### PR DESCRIPTION
I'm partial to using [pre-commit](https://pre-commit.com) as mentioned in https://github.com/funmusicplace/mirlo/issues/101 

Currently, I've disabled the husky pre-commit that runs `yarn test` as the tests were failing on my machine (which would not allow me to commit). Let me know if I've done something wrong. I only ran `yarn` to grab all the dependencies. 

In order to to ensure that husky runs `yarn test` before commit, we can un-comment the last line in `.husky/pre-commit` 

I have not used Commitizen before but [this](https://github.com/commitizen/cz-cli/issues/801) issue is where I've copied the pre-commit config from. It appears to be working? 