### PR TITLE
Fixed banner height being eratic on smartphone view based on img width.

### DIFF
--- a/client/src/components/common/PageHeader.tsx
+++ b/client/src/components/common/PageHeader.tsx
@@ -34,8 +34,7 @@ const PageHeader = () => {
             box-shadow: inset 1em -2em 0.8em -1.3em rgba(0, 0, 0, 0.4);
             @media screen and (max-width: ${bp.medium}px) {
               position: relative;
-              //* height: 180px; *//
-              height: 100%;
+              max-height: 20vw;
             }
           `}
         >
@@ -60,7 +59,7 @@ const PageHeader = () => {
                 object-fit: cover;
 
                 @media screen and (max-width: ${bp.medium}px) {
-                  object-fit: contain;
+                  object-fit: cover;
                 }
               `}
             />


### PR DESCRIPTION
There was previously an issue where if the banner width was below 2500px it could render up to full viewport height depending on its ratio, in smartphone view.