### PR TITLE
Various Little Fixes

### DIFF
--- a/client/src/components/Artist/ArtistSupport.tsx
+++ b/client/src/components/Artist/ArtistSupport.tsx
@@ -93,7 +93,11 @@ const ArtistSupport: React.FC<{ artist: Artist }> = ({ artist }) => {
   return (
     <>
       <h2>{t("support", { artist: artist.name })}</h2>
-      <div>
+      <div
+        className={css`
+          display: flex;
+        `}
+      >
         {artist.subscriptionTiers?.map((p) => (
           <ArtistSupportBox key={p.id} subscriptionTier={p} artist={artist} />
         ))}

--- a/client/src/components/Artist/ArtistSupportBox.tsx
+++ b/client/src/components/Artist/ArtistSupportBox.tsx
@@ -44,11 +44,23 @@ const ArtistSupportBox: React.FC<{
       <Box
         key={subscriptionTier.id}
         className={css`
+          max-width: 33%;
+          flex: 33%;
           margin-bottom: 1rem;
           margin-top: 1rem;
           padding-top: 1.5rem;
           display: flex;
           flex-direction: column;
+
+          &:nth-child(3n + 1) {
+          border-top: 0;
+          margin-right:.5rem;
+        }
+
+        &:nth-child(3n) {
+          border-top: 0;
+          margin-left: .5rem;
+        }
         `}
       >
         <div

--- a/client/src/components/Artist/ArtistTrackGroup.tsx
+++ b/client/src/components/Artist/ArtistTrackGroup.tsx
@@ -21,7 +21,7 @@ const ArtistTrackGroup: React.FC<{
     <div
       key={trackGroup.id}
       className={css`
-        margin-bottom: 1rem;
+        margin-bottom: .5rem;
         display: inline-block;
         max-width: 33.3%;
         flex: 33.3%;
@@ -92,8 +92,21 @@ const ArtistTrackGroup: React.FC<{
 
               a:first-child {
                 font-weight: normal;
-                margin-bottom: 0.4rem;
+                margin-bottom: .2rem;
               }
+              a:last-child {
+                font-size: .8rem;
+                font-weight: bold;
+              }
+
+              a {
+                text-decoration: none;
+              }
+
+
+              a:hover {
+                  text-decoration: underline;
+                }
             `}
           >
             <Link
@@ -101,12 +114,7 @@ const ArtistTrackGroup: React.FC<{
                 trackGroup.urlSlug ?? trackGroup.id
               }`}
               className={css`
-                text-decoration: none;
                 padding-right: 0.5rem;
-
-                :hover {
-                  text-decoration: underline;
-                }
               `}
             >
               {trackGroup.title}

--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -220,9 +220,9 @@ function Home() {
                 }
               `}
             >
-              <h3>
+              <h5>
                 <Link to={`/post/${p.id}/`}>{p.title}</Link>
-              </h3>
+              </h5>
               {p.artist && (
                 <em>
                   by{" "}

--- a/client/src/components/ManageArtist/Manage.tsx
+++ b/client/src/components/ManageArtist/Manage.tsx
@@ -61,7 +61,7 @@ export const Manage: React.FC = () => {
           }
         `}
       >
-        <h2 className={css``}>{t("manageArtists")}</h2>
+        <h1 className={css``}>{t("manageArtists")}</h1>
 
         <div
           className={css`

--- a/client/src/components/Player.tsx
+++ b/client/src/components/Player.tsx
@@ -187,15 +187,20 @@ const Player = () => {
               align-items: center;
 
               margin-right: 1rem;
-              margin-left: 0.5rem;
-              margin-bottom: 0.5rem;
-              margin-top: 0.5rem;
+              margin-left: 1rem;
+              margin-bottom: 0.3rem;
+              padding-top: 0.5rem;
+
+              @media (max-width: ${bp.small}px) {
+              margin-right: .5rem;
+              margin-left: .5rem;
+            }
             `}
           >
             <div>
               <ImageWithPlaceholder
                 src={currentTrack?.trackGroup.cover?.sizes?.[120]}
-                size={45}
+                size={50}
                 alt={currentTrack?.title ?? "Loading album"}
                 className={css`
                   background-color: #efefef;
@@ -207,9 +212,14 @@ const Player = () => {
             </div>
             <div
               className={css`
-                width: 80%;
+                max-width: 80%;
+                flex: 80%;
                 display: flex;
                 flex-direction: column;
+                @media (max-width: ${bp.small}px) {
+                max-width: 70%;
+                flex: 70%;
+            }
               `}
             >
               <div

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -110,7 +110,7 @@ function Profile() {
           flex-direction: column;
         `}
       >
-        <h2>{t("profile")}</h2>
+        <h1>{t("profile")}</h1>
         <FormComponent>
           {t("email")}
           <InputEl {...register("email")} disabled />

--- a/client/src/components/Releases.tsx
+++ b/client/src/components/Releases.tsx
@@ -18,8 +18,12 @@ const Releases = () => {
   }, []);
 
   return (
-    <div>
-      <h1>{t("recentReleases")}</h1>
+    <div
+        className={css`
+        margin-top: 1rem;
+        `}
+      >
+      <h2>{t("recentReleases")}</h2>
       <div
         className={css`
           display: flex;

--- a/client/src/components/common/MarkdownWrapper.tsx
+++ b/client/src/components/common/MarkdownWrapper.tsx
@@ -4,17 +4,18 @@ const MarkdownWrapper = styled.div`
   margin-top: 0.5rem;
 
   h1 {
-    font-size: 1.2rem;
+    font-size: 2rem;
   }
   h2 {
-    font-size: 1.1rem;
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
   }
   h3 {
     font-size: 1rem;
   }
 
   p {
-    margin-bottom: 0.75rem;
+    margin-bottom: 1.5rem;
   }
 
   iframe {

--- a/client/src/components/common/PauseButton.tsx
+++ b/client/src/components/common/PauseButton.tsx
@@ -19,27 +19,21 @@ export const PauseButton: React.FC = () => {
     [dispatch]
   );
 
-  return (
-    <div
-      className={css`
-          button {
-            font-size: 1.4rem;
-            margin-right: 0.25rem;
-            padding: .75rem .8rem .65rem .8rem;
-            border: solid 1.5px var(--mi-normal-foreground-color);
-            border-color: var(--mi-normal-foreground-color);
-            background-color: var(--mi-normal-foreground-color);
-            color: var(--mi-normal-background-color);
-          }
-          button:hover {
-          }
-      `}
-      >
-    <IconButton onClick={onPause}>
-      <TfiControlPause />
-    </IconButton>
-    </div>
-  );
+  return <div className={css`button {
+          font-size: 1.4rem;
+          margin-right: 0.25rem;
+          padding: 0.75rem 0.7rem 0.65rem 0.7rem;
+          border: solid 1.5px var(--mi-normal-foreground-color);
+          border-color: var(--mi-normal-foreground-color);
+          background-color: var(--mi-normal-foreground-color);
+          color: var(--mi-normal-background-color);
+        }
+        button:hover {
+        }`}>
+      <IconButton onClick={onPause}>
+        <TfiControlPause />
+      </IconButton>
+    </div>;
 };
 
 export default PauseButton;

--- a/client/src/components/common/PlayButton.tsx
+++ b/client/src/components/common/PlayButton.tsx
@@ -17,7 +17,7 @@ export const PlayButton: React.FC = () => {
           button {
             font-size: 1.4rem;
             margin-right: 0.25rem;
-            padding: .7rem .7rem .7rem .9rem;
+            padding: .7rem .6rem .7rem .8rem;
             border: solid 1.5px var(--mi-normal-foreground-color);
             border-color: var(--mi-normal-foreground-color);
             background-color: var(--mi-normal-foreground-color);

--- a/client/src/components/common/TrackRow.tsx
+++ b/client/src/components/common/TrackRow.tsx
@@ -55,6 +55,7 @@ const TrackRow: React.FC<{
         }
         &:hover > td > .play-button {
           display: block;
+          width: 2rem;
         }
         &:hover > td > .track-number {
           display: none;

--- a/client/src/components/common/TrackRowPlayControl.tsx
+++ b/client/src/components/common/TrackRowPlayControl.tsx
@@ -50,7 +50,8 @@ const TrackRowPlayControl: React.FC<{
           compact
           data-cy="track-row-pause-button"
           onClick={onTrackPause}
-        >
+          style={{ width: "2rem", textAlign: "center" }}
+          >
           <TfiControlPause />
         </IconButton>
       )}


### PR DESCRIPTION
Fixes to : 

- Headings (for consistency and readability, titles in FAQ / About / Profile and / Manage sections needed to be more proeminent.
- Only notable difference is "latest release" where I felt the albums needed to be the star of the page vs the title that felt too big and took too much space from the music itself.
- Support boxes are now displayed as "cards" in column, allowing to see them all in one quick glance.
- Replaced "underline" for artists on trackgroups with smaller bold fonts, again to let the artworks shine more while retaining a small differenciation between album name (bigger and normal font) and artist name.
- Play/Pause on track rows caused a little glitch where the name of the track would shift to the side due to inconsistent width with track number.