### PR TITLE
Modal Component improvement

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -147,6 +147,7 @@ function App() {
                       padding: var(--mi-side-paddings-xsmall);
                       padding-top: 0.5rem;
                       padding-bottom: 0.5rem;
+                      width: 100%;
                     }
                   }
                 `}

--- a/client/src/components/Artist/ArtistSupport.tsx
+++ b/client/src/components/Artist/ArtistSupport.tsx
@@ -91,7 +91,15 @@ const ArtistSupport: React.FC<{ artist: Artist }> = ({ artist }) => {
         >
           {t("support", { artist: artist.name })}
         </h2>
-        <FollowArtist artistId={artist.id} />
+        <div
+          className={css`
+            @media (max-width: ${bp.small}px) {
+              margin-top: 0.15rem;
+            }
+          `}
+        >
+          <FollowArtist artistId={artist.id} />
+        </div>
       </HeaderDiv>
       {artist.subscriptionTiers.length === 0 && (
         <Box

--- a/client/src/components/Artist/ArtistSupportBox.tsx
+++ b/client/src/components/Artist/ArtistSupportBox.tsx
@@ -109,6 +109,7 @@ const ArtistSupportBox: React.FC<{
           className={css`
             padding: 1.5rem;
             border-bottom: solid 1px grey;
+            text-align: center;
             h3 {
               font-size: 1rem;
               padding-bottom: 0.5rem;
@@ -118,7 +119,13 @@ const ArtistSupportBox: React.FC<{
             }
           `}
         >
-          <h3>{subscriptionTier.name}</h3>
+          <h3
+            className={css`
+              text-transform: uppercase;
+            `}
+          >
+            {subscriptionTier.name}
+          </h3>
           <Money
             amount={
               subscriptionTier.minAmount ? subscriptionTier.minAmount / 100 : 0
@@ -128,7 +135,7 @@ const ArtistSupportBox: React.FC<{
         </div>
         <div
           className={css`
-            padding: 1.5rem 1.5rem 0 1.5rem;
+            padding: 1.5rem 1.5rem 0.5rem 1.5rem;
             height: 100%;
             p {
               display: flex;

--- a/client/src/components/Artist/ArtistTrackGroup.tsx
+++ b/client/src/components/Artist/ArtistTrackGroup.tsx
@@ -86,14 +86,17 @@ const ArtistTrackGroup: React.FC<{
 
         <div
           className={css`
+            margin-bottom: 0.5rem;
+            padding-top: 0.5rem;
             display: flex;
             justify-content: space-between;
             flex-wrap: nowrap;
             align-items: start;
+            min-height: 2.5rem;
             width: 100%;
-            padding-top: 0.5rem;
-            @media screen and (min-width: ${bp.medium}px) {
-              margin-bottom: 1rem;
+            @media screen and (max-width: ${bp.medium}px) {
+              align-items: start;
+              margin-bottom: 0rem;
             }
           `}
         >
@@ -134,7 +137,21 @@ const ArtistTrackGroup: React.FC<{
               {trackGroup.artist?.name}
             </Link>
           </div>
-          <PurchaseOrDownloadAlbum trackGroup={trackGroup} />
+          <div
+            className={css`
+              button {
+                margin-top: -0.25rem;
+              }
+              @media screen and (max-width: ${bp.small}px) {
+                button {
+                  margin-top: -0.1rem;
+                  color: var(--mi-light-foreground-color);
+                }
+              }
+            `}
+          >
+            <PurchaseOrDownloadAlbum trackGroup={trackGroup} />
+          </div>
         </div>
       </div>
     </div>

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -96,7 +96,7 @@ const Header = () => {
           align-items: center;
           padding: 0.5rem 1rem;
           width: 100%;
-          z-index: 999999;
+          z-index: 99;
           position: sticky;
           top: 0px;
           height: 55px;

--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -298,7 +298,7 @@ function Home() {
                       <h4
                         className={css`
                           padding-bottom: 0.3rem;
-                          text-align: center;
+                          text-align: left;
                         `}
                       >
                         <Link

--- a/client/src/components/ManageArtist/ArtistFormLinks.tsx
+++ b/client/src/components/ManageArtist/ArtistFormLinks.tsx
@@ -109,7 +109,8 @@ const ArtistFormLinks: React.FC<{ isManage: boolean }> = ({ isManage }) => {
             max-width: 50%;
             display: flex;
             align-items: center;
-            margin-bottom: 0.25rem;
+            margin-bottom: 1rem;
+            margin-left: 0.5rem;
 
             > svg {
               margin-right: 0.5rem;
@@ -132,13 +133,18 @@ const ArtistFormLinks: React.FC<{ isManage: boolean }> = ({ isManage }) => {
       ))}
       <div
         className={css`
+          display: flex;
+          align-items: center;
+          margin-bottom: 1rem;
           button {
+            margin-left: 0.2rem;
             margin-right: 0.5rem;
           }
         `}
       >
         <Button
           compact
+          transparent
           onClick={() => append({ url: "" })}
           disabled={addDisabled}
           startIcon={<FaPlus />}

--- a/client/src/components/Releases.tsx
+++ b/client/src/components/Releases.tsx
@@ -44,7 +44,7 @@ const Releases = () => {
           @media screen and (min-width: ${bp.medium}px) {
             position: sticky;
             top: 55px;
-            ${!userId ? "top: 0; padding-top: .5rem;" : ""}
+            ${!userId ? "top: -0.1rem; padding-top: .5rem;" : ""}
             background-color: var(--mi-normal-background-color);
             z-index: +1;
             border-bottom: solid 1px var(--mi-lighter-foreground-color);

--- a/client/src/components/TrackGroup/PurchaseOrDownloadAlbumModal.tsx
+++ b/client/src/components/TrackGroup/PurchaseOrDownloadAlbumModal.tsx
@@ -94,7 +94,7 @@ const PurchaseOrDownloadAlbum: React.FC<{
                   }
                 `}
               >
-                Acheter
+                {t("buy")}
               </Link>
             </div>
           )}

--- a/client/src/components/TrackGroup/PurchaseOrDownloadAlbumModal.tsx
+++ b/client/src/components/TrackGroup/PurchaseOrDownloadAlbumModal.tsx
@@ -1,4 +1,4 @@
-import Button from "components/common/Button";
+import { Link } from "react-router-dom";
 import Modal from "components/common/Modal";
 import React from "react";
 import { bp } from "../../constants";
@@ -83,23 +83,39 @@ const PurchaseOrDownloadAlbum: React.FC<{
                 }
               `}
             >
-              <Button compact onClick={() => setIsPurchasingAlbum(true)}>
-                {t("buy")}
-              </Button>
+              <Link
+                onClick={() => setIsPurchasingAlbum(true)}
+                to={""}
+                className={css`
+                  font-weight: bold;
+                  margin-left: 0.2rem;
+                  @media screen and (max-width: ${bp.small}px) {
+                    font-size: var(--mi-font-size-xsmall);
+                  }
+                `}
+              >
+                Acheter
+              </Link>
             </div>
           )}
         {(userIsTrackGroupArtist || isOwned) && (
           <DownloadAlbumButton trackGroup={trackGroup} />
         )}
       </div>
-      <Modal
-        size="small"
-        open={isPurchasingAlbum}
-        onClose={() => setIsPurchasingAlbum(false)}
-        title={t("buyingTrackGroup", { title: trackGroup.title }) ?? ""}
+      <div
+        className={css`
+          overflow-y: hidden !important;
+        `}
       >
-        <BuyTrackGroup trackGroup={trackGroup} />
-      </Modal>
+        <Modal
+          size="small"
+          open={isPurchasingAlbum}
+          onClose={() => setIsPurchasingAlbum(false)}
+          title={t("buyingTrackGroup", { title: trackGroup.title }) ?? ""}
+        >
+          <BuyTrackGroup trackGroup={trackGroup} />
+        </Modal>
+      </div>
     </>
   );
 };

--- a/client/src/components/TrackGroup/TrackGroup.tsx
+++ b/client/src/components/TrackGroup/TrackGroup.tsx
@@ -248,6 +248,7 @@ function TrackGroup() {
               <div
                 className={css`
                   margin-top: 0.5rem;
+                  margin-bottom: 0.5rem;
                   display: flex;
                   justify-content: space-between;
                   align-items: center;
@@ -257,7 +258,6 @@ function TrackGroup() {
                   className={css`
                     color: var(--mi-light-foreground-color);
                     font-size: 1rem;
-                    height: 1.5rem;
                     em {
                       font-style: normal;
                     }
@@ -281,9 +281,13 @@ function TrackGroup() {
                 <div
                   className={css`
                     display: flex;
+                    align-items: center;
                     button {
                       margin-left: 0.5rem;
                       background: var(--mi-darken-background-color);
+                    }
+                    a {
+                      font-size: var(--mi-font-size-normal);
                     }
                   `}
                 >

--- a/client/src/components/common/ArtistHeaderSection.tsx
+++ b/client/src/components/common/ArtistHeaderSection.tsx
@@ -146,6 +146,7 @@ const ArtistHeaderSection: React.FC<{ artist: Artist; isManage?: boolean }> = ({
                       display: flex;
                       align-items: center;
                       justify-content: space-between;
+                      word-break: break-word;
                       width: 100%;
                       @media screen and (max-width: ${bp.medium}px) {
                         min-height: auto;

--- a/client/src/components/common/Modal.tsx
+++ b/client/src/components/common/Modal.tsx
@@ -40,7 +40,7 @@ const Content = styled.div<ContentProps>`
   border: 1px solid var(--mi-darken-background-color);
   display: flex;
   flex-direction: column;
-  width: ${(props) => (props.size === "small" ? "30%" : "80%")};
+  width: ${(props) => (props.size === "small" ? "40%" : "80%")};
 
   animation: 300ms ease-out forwards slide-up;
   border-radius: var(--mi-border-radius-x);
@@ -62,7 +62,6 @@ const Content = styled.div<ContentProps>`
   }
 
   @media (max-width: ${bp.small}px) {
-    top: 80px;
     width: 100%;
     padding: 1rem;
     padding-top: 0;

--- a/client/src/components/common/Modal.tsx
+++ b/client/src/components/common/Modal.tsx
@@ -11,12 +11,14 @@ import HeaderDiv from "./HeaderDiv";
 const wrapper = css`
   position: fixed;
   pointer-events: none;
-  z-index: 12;
+  z-index: 999;
   left: 0;
   top: 0;
   width: 100%;
   height: 100%;
   overflow: auto;
+  display: flex;
+  align-items: center;
 `;
 
 type ContentProps = {
@@ -27,29 +29,43 @@ const Content = styled.div<ContentProps>`
   pointer-events: auto;
   background-color: var(--mi-normal-background-color);
   position: absolute;
-  top: 20%;
   left: 0;
   right: 0;
-  overflow-y: scroll;
+  overflow-y: auto;
+  max-width: 1080px;
   margin: 0 auto;
-  max-height: 600px;
+  max-height: calc(100vh - 80px);
   padding: 20px;
-  z-index: 999;
+  padding-top: 0;
   border: 1px solid var(--mi-darken-background-color);
   display: flex;
   flex-direction: column;
   width: ${(props) => (props.size === "small" ? "30%" : "80%")};
 
   animation: 300ms ease-out forwards slide-up;
-  border-radius: var(--mi-border-radius);
+  border-radius: var(--mi-border-radius-x);
+
+  ::-webkit-scrollbar {
+    width: 5px;
+  }
+  ::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    border-radius: 5px;
+  }
+  ::-webkit-scrollbar-thumb {
+    border-radius: 5px;
+    -webkit-box-shadow: inset 0 0 6px;
+  }
 
   h1 {
     display: inline-block;
   }
 
   @media (max-width: ${bp.small}px) {
+    top: 80px;
     width: 100%;
     padding: 1rem;
+    padding-top: 0;
   }
 `;
 
@@ -108,7 +124,22 @@ export const Modal: React.FC<{
       <Background onClick={onCloseWrapper} />
       <div className={wrapper} data-cy="modal">
         <Content size={size}>
-          <HeaderDiv>
+          <HeaderDiv
+            className={css`
+            position: sticky;
+            top: 0;
+            padding-top: 1rem;
+            margin-bottom: .5rem;
+            background-color: inherit;
+            border-bottom: solid 1px var(--mi-light-foreground-color);
+            z-index: +1;
+
+            h2 {
+              margin-bottom: 0;
+            }
+              }
+            `}
+          >
             {title && <h2>{title}</h2>}
 
             <IconButton

--- a/client/src/components/common/Modal.tsx
+++ b/client/src/components/common/Modal.tsx
@@ -39,7 +39,6 @@ const Content = styled.div<ContentProps>`
   display: flex;
   flex-direction: column;
   width: ${(props) => (props.size === "small" ? "30%" : "80%")};
-  min-width: 400px;
 
   animation: 300ms ease-out forwards slide-up;
   border-radius: var(--mi-border-radius);

--- a/client/src/components/common/TrackRow.tsx
+++ b/client/src/components/common/TrackRow.tsx
@@ -133,7 +133,7 @@ const TrackRow: React.FC<{
             padding: 0.1rem;
             margin-bottom: 0rem;
             justify-content: space-between;
-            align-items: flex-end;
+            align-items: center;
 
             &:hover {
               cursor: pointer;
@@ -167,6 +167,7 @@ const TrackRow: React.FC<{
               @media screen and (max-width: ${bp.medium}px) {
                 font-size: 0.7rem;
                 font-weight: bold;
+                margin-left: 0.2rem;
                 td {
                   padding: 0.15rem 0.3rem;
                 }
@@ -180,7 +181,6 @@ const TrackRow: React.FC<{
       <td align="right">
         <Button
           compact
-          iconOnly
           transparent
           onClick={(e) => {
             e.stopPropagation();
@@ -189,6 +189,9 @@ const TrackRow: React.FC<{
           }}
           startIcon={<FiLink />}
           className={css`
+            .startIcon {
+              padding-left: 1rem;
+            }
             :hover {
               background: transparent !important;
               opacity: 0.6;

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -23,7 +23,8 @@ const styles = `html {
   --mi-warning-background-color: var(--mi-warning-color);
   --mi-darken-warning-background-color: #df250b;
 
-  --mi-border-radius: 2px;
+  --mi-border-radius: 3px;
+  --mi-border-radius-x: 20px;
   --mi-border-radius-focus: 8px;
 
   --mi-icon-button-background-color: var(--mi-darken-x-background-color);


### PR DESCRIPTION
Modal component had several quirks that made using it frustrating 

- You can now close it anytime (header and close buttons are sticky)
- Height is now based on viewport which allows for a more consistent user experience across varying devices
- Small modal is slightly bigger to avoid it shrinking into a narrow column on medium bp
- scrollbar is now less proeminent in the box to avoid having up to 4 big scrollbars on the same window sometimes.