### PR TITLE
adding some padding on top to free up space on smartphone

### DIFF
--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -124,6 +124,7 @@ function Home() {
           />
           <div
             className={css`
+              padding-top: 5vh;
               display: flex;
               flex-direction: column;
               gap: 48px;

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -44,6 +44,7 @@ function Login() {
   return (
     <div
       className={css`
+        padding-top: 10vh;
         text-align: center;
         margin: 0 auto;
       `}


### PR DESCRIPTION
When the translation was too long (.ie french) it stuck things on top on home page, and on login it just was on top. Freed up space there so it's slightly more centered.