### PR TITLE
Minor UI adjustments

### DIFF
--- a/client/src/components/Artist/ArtistHeaderDescription.tsx
+++ b/client/src/components/Artist/ArtistHeaderDescription.tsx
@@ -10,6 +10,7 @@ import { useSnackbar } from "state/SnackbarContext";
 import { useForm } from "react-hook-form";
 import { FaChevronDown, FaPen, FaSave, FaTimes } from "react-icons/fa";
 import TextArea from "components/common/TextArea";
+import { bp } from "../../constants";
 
 interface FormData {
   bio: string;
@@ -84,28 +85,51 @@ const ArtistHeaderDescription: React.FC = () => {
               overflow: hidden;
               text-overflow: ellipsis;
 
-              ${isCollapsed ? `max-height: 100px` : ""}
+              ${isCollapsed ? `max-height: 4rem;` : ""}
+
+              @media screen and (max-width: ${bp.medium}px) {
+                ${isCollapsed ? `max-height: 3rem;` : ""}
+              }
             `}
           />
           {canCollapse && (
-            <Button
-              variant="link"
-              compact
-              startIcon={<FaChevronDown />}
+            <div
               className={css`
-                margin-top: 0.7rem;
-                margin-bottom: 1rem;
+                width: 100%;
+                margin-top: -1.5rem;
+                padding-top: 0.75rem;
+                z-index: +1;
+                position: relative;
+                ${isCollapsed
+                  ? `background: linear-gradient(180deg, transparent 0%, var(--mi-normal-background-color) 42%);`
+                  : ""}
 
-                svg {
-                  transition: transform 0.2s;
-
-                  ${!isCollapsed ? `transform: rotate(-180deg);` : ""}
+                @media screen and (max-width: ${bp.medium}px) {
+                  ${isCollapsed
+                    ? `background: linear-gradient(180deg, transparent 0%, var(--mi-normal-background-color) 80%); padding-top: 1.2rem;`
+                    : ""}
                 }
               `}
-              onClick={() => setIsCollapsed((val) => !val)}
             >
-              {isCollapsed ? "read more" : "read less"}
-            </Button>
+              <Button
+                variant="link"
+                compact
+                startIcon={<FaChevronDown />}
+                className={css`
+                  margin-top: 0.7rem;
+                  margin-bottom: 0.5rem;
+
+                  svg {
+                    transition: transform 0.2s;
+
+                    ${!isCollapsed ? `transform: rotate(-180deg);` : ""}
+                  }
+                `}
+                onClick={() => setIsCollapsed((val) => !val)}
+              >
+                {isCollapsed ? "read more" : "read less"}
+              </Button>
+            </div>
           )}
         </div>
 

--- a/client/src/components/ManageArtist/ManageArtistContainer.tsx
+++ b/client/src/components/ManageArtist/ManageArtistContainer.tsx
@@ -14,7 +14,7 @@ const Container = styled.div<{ artistBanner: boolean; userId?: number }>`
   ${(props) =>
     !props.artistBanner ? "margin-top: 0px;" : "margin-top: calc(8vh);"}
   ${(props) =>
-    props.userId ? "margin-top: calc(8vh - 39px);" : "margin-top: calc(8vh);"}
+    props.userId ? "margin-top: calc(8vh - 39px);" : "margin-top: calc(1vh);"}
   max-width: var(--mi-container-big);
 
   @media screen and (max-width: ${bp.large}px) {
@@ -26,7 +26,7 @@ const Container = styled.div<{ artistBanner: boolean; userId?: number }>`
     padding: 0rem !important;
     width: 100%;
     ${(props) => (props.artistBanner ? "margin-top: 0px;" : "")}
-    ${(props) => (!props.userId ? "margin-top: 13vh;" : "")}
+    ${(props) => (!props.userId ? "margin-top: calc(7vh);" : "")}
     ${(props) => (!props.artistBanner ? "margin-top: 0px;" : "")}
   }
 `;

--- a/client/src/components/Post/index.tsx
+++ b/client/src/components/Post/index.tsx
@@ -131,6 +131,8 @@ const Post: React.FC = () => {
               <span
                 className={css`
                   margin-right: 0.25rem;
+
+                  line-height: 2.2rem;
                 `}
               >
                 by{" "}

--- a/client/src/components/common/PostCard.tsx
+++ b/client/src/components/common/PostCard.tsx
@@ -1,4 +1,3 @@
-import { bp } from "../../constants";
 import { css } from "@emotion/css";
 import MarkdownContent from "./MarkdownContent";
 import Box from "./Box";
@@ -21,9 +20,6 @@ const PostCard: React.FC<{
         overflow: hidden;
         padding: 0 !important;
         justify-content: space-between;
-        @media screen and (max-width: ${bp.small}px) {
-          font-size: var(--mi-font-size-small) !important;
-        }
 
         @media (prefers-color-scheme: dark) {
           background-color: var(--mi-normal-background-color);


### PR DESCRIPTION
Postcards now display normal text on mobile allowing smaller posts to take full advantage of the height.

Margin-top is no longer way too high when user is logged off on artist profiles

"read more" has a slight gradient indicating there's more to read instead of a cut

Follow button on artist post is centered with artist name