### PR TITLE
Reduced max-height to fit H1 line-height

### DIFF
--- a/client/src/components/Artist/ArtistHeaderDescription.tsx
+++ b/client/src/components/Artist/ArtistHeaderDescription.tsx
@@ -88,7 +88,7 @@ const ArtistHeaderDescription: React.FC = () => {
               ${isCollapsed ? `max-height: 4rem;` : ""}
 
               @media screen and (max-width: ${bp.medium}px) {
-                ${isCollapsed ? `max-height: 3rem;` : ""}
+                ${isCollapsed ? `max-height: 2rem;` : ""}
               }
             `}
           />

--- a/client/src/components/common/MarkdownWrapper.tsx
+++ b/client/src/components/common/MarkdownWrapper.tsx
@@ -28,6 +28,10 @@ const MarkdownWrapper = styled.div`
     margin: 1rem 0;
   }
 
+  li {
+    margin-left: 1.2rem;
+  }
+
   ul {
     margin-left: 1rem;
     margin-bottom: 1rem;


### PR DESCRIPTION
H1 was cut because 3rem was half of a line, now it's 2rem on mobile 4rem on desktop allowing for either 1 line of H1 title or 2 lines of normal text, which works better in most situations.