### PR TITLE
Edit artist page refactor

### DIFF
--- a/client/src/components/Artist/ArtistContainer.tsx
+++ b/client/src/components/Artist/ArtistContainer.tsx
@@ -1,18 +1,25 @@
 import { css } from "@emotion/css";
 import React from "react";
-import { Outlet, useParams } from "react-router-dom";
+import { Link, Outlet, useParams } from "react-router-dom";
 import ArtistHeaderSection from "../common/ArtistHeaderSection";
 import { useTranslation } from "react-i18next";
 import { ArtistPageWrapper } from "components/ManageArtist/ManageArtistContainer";
 import { useArtistContext } from "state/ArtistContext";
+import Button from "components/common/Button";
+import { FaPen } from "react-icons/fa";
+import { useGlobalStateContext } from "state/GlobalState";
+import { bp } from "../../constants";
 
-const ArtistContainer: React.FC<{}> = () => {
+const ArtistContainer: React.FC<{ isManage: boolean }> = (isManage) => {
   const { t } = useTranslation("translation", { keyPrefix: "manageArtist" });
 
   const { trackGroupId, postId } = useParams();
   const {
     state: { artist },
   } = useArtistContext();
+  const {
+    state: { user },
+  } = useGlobalStateContext();
 
   const artistBanner = artist?.banner?.sizes;
 
@@ -24,6 +31,47 @@ const ArtistContainer: React.FC<{}> = () => {
 
   return (
     <>
+      {isManage && user?.id === artist.userId && !trackGroupId && (
+        <Link
+          to={`/manage/artists/${artist.id}`}
+          className={css`
+            z-index: 999999;
+            top: 75px;
+            right: 1rem;
+            color: var(--mi-warning-text-color);
+            position: fixed;
+            box-shadow: 0.2rem 0.2rem 0.3rem rgba(0, 0, 0, 0.5);
+
+            @media screen and (max-width: ${bp.medium}px) {
+              left: 1rem;
+              bottom: 75px;
+              top: auto;
+              right: auto;
+            }
+          `}
+        >
+          <Button
+            startIcon={<FaPen />}
+            compact
+            type="button"
+            variant="dashed"
+            className={css`
+              background-color: rgba(255, 255, 255, 0.9) !important;
+              color: black !important;
+              padding: 1.2rem !important;
+              :hover {
+                background-color: rgba(0, 0, 0, 0.7) !important;
+                color: white !important;
+              }
+              @media screen and (max-width: ${bp.medium}px) {
+                padding: 1rem !important;
+              }
+            `}
+          >
+            {t("editPage")}
+          </Button>
+        </Link>
+      )}
       {!isPostOrRelease && (
         <>
           <ArtistPageWrapper artistBanner={!!artistBanner}>

--- a/client/src/components/ManageArtist/TrackGroupCard.tsx
+++ b/client/src/components/ManageArtist/TrackGroupCard.tsx
@@ -167,7 +167,7 @@ const TrackGroupCard: React.FC<{
           `}
         >
           <Link to={`/manage/artists/${album.artistId}/release/${album.id}`}>
-            <Button compact variant="outlined">
+            <Button compact thin variant="outlined">
               {t("manageAlbum")}
             </Button>
           </Link>

--- a/client/src/components/common/ArtistHeaderSection.tsx
+++ b/client/src/components/common/ArtistHeaderSection.tsx
@@ -1,12 +1,8 @@
 import { css } from "@emotion/css";
-import { Link } from "react-router-dom";
 import { bp } from "../../constants";
 import { MetaCard } from "components/common/MetaCard";
 import styled from "@emotion/styled";
 import FollowArtist from "./FollowArtist";
-import { useGlobalStateContext } from "state/GlobalState";
-import Button from "./Button";
-import { useTranslation } from "react-i18next";
 import SpaceBetweenDiv from "./SpaceBetweenDiv";
 import ArtistFormLinks from "components/ManageArtist/ArtistFormLinks";
 import Avatar from "components/Artist/Avatar";
@@ -14,7 +10,6 @@ import ArtistFormLocation from "components/ManageArtist/ArtistFormLocation";
 import ArtistHeaderDescription from "components/Artist/ArtistHeaderDescription";
 import { useArtistContext } from "state/ArtistContext";
 import LoadingBlocks from "components/Artist/LoadingBlocks";
-import { FaPen } from "react-icons/fa";
 
 const H1 = styled.h1<{ artistAvatar: boolean }>`
   font-size: 2.4rem;
@@ -92,10 +87,6 @@ const ArtistHeaderSection: React.FC<{ artist: Artist; isManage?: boolean }> = ({
   const {
     state: { artist, isLoading },
   } = useArtistContext();
-  const { t } = useTranslation("translation", { keyPrefix: "artist" });
-  const {
-    state: { user },
-  } = useGlobalStateContext();
 
   const artistAvatar = artist?.avatar;
 
@@ -195,18 +186,6 @@ const ArtistHeaderSection: React.FC<{ artist: Artist; isManage?: boolean }> = ({
                     </div>
                     <ArtistActions>
                       {!isManage && <FollowArtist artistId={artist.id} />}
-                      {!isManage && user?.id === artist.userId && (
-                        <Link to={`/manage/artists/${artist.id}`}>
-                          <Button
-                            startIcon={<FaPen />}
-                            compact
-                            type="button"
-                            variant="dashed"
-                          >
-                            {t("edit")}
-                          </Button>
-                        </Link>
-                      )}
                     </ArtistActions>
                   </div>
                 </SpaceBetweenDiv>

--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -129,6 +129,7 @@ const CustomButton = styled.button<Compactable>`
             : `var(--mi-${props.role ?? "primary"}-color)`
         };
           padding: ${props.compact ? ".3rem .5rem" : "1rem"};
+          ${props.compact ? "height: 1.5rem;" : ""}
           font-weight: bold; 
 
           &:hover:not(:disabled) {

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -177,6 +177,7 @@
     "deleteArtist": "Delete artist",
     "addNewAlbum": "Add new album",
     "edit": "Edit",
+    "editPage": "Edit Artist Page",
     "delete": "Delete",
     "addNewPost": "Add new post",
     "posts": "Posts",


### PR DESCRIPTION
Moved "Edit Artist Page" button out of the body, so that you can view your page much closer to what it will look like to viewer, and also so that the "Edit Page" button is visible at all time when you're on your own page.