### PR TITLE
#655 - Fix view live post URL for Artist

### DIFF
--- a/client/src/components/ManageArtist/ManagePost.tsx
+++ b/client/src/components/ManageArtist/ManagePost.tsx
@@ -75,7 +75,7 @@ const ManagePost: React.FC<{}> = () => {
                 align-items: center;
               `}
             >
-              <Link to={`/post/${post.id}`}>
+              <Link to={`/${artist?.urlSlug}/posts/${post.id}`}>
                 <Button type="button">{t("viewLive")}</Button>
               </Link>
             </div>


### PR DESCRIPTION
While editing a post on `/manage/artists/1/post/1`, the URL for the `View live` button previously went to `/post/:id`. It has been changed to link to `/:artistSlug/posts/:id`.

NOTE: I noticed that the manage posts page for artists (`/manage/artists/1/posts`) has the same issue. Should that be updated as well?