### PR TITLE
#655 - Use artist post reference utility for live preview URL

### DIFF
--- a/client/src/components/ManageArtist/ManagePost.tsx
+++ b/client/src/components/ManageArtist/ManagePost.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useArtistContext } from "state/ArtistContext";
 import useGetUserObjectById from "utils/useGetUserObjectById";
+import { getPostURLReference } from "utils/artist";
 import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
 import ManageSectionWrapper from "./ManageSectionWrapper";
 import { css } from "@emotion/css";
@@ -75,7 +76,7 @@ const ManagePost: React.FC<{}> = () => {
                 align-items: center;
               `}
             >
-              <Link to={`/${artist?.urlSlug}/posts/${post.id}`}>
+              <Link to={getPostURLReference({...post, artist})}>
                 <Button type="button">{t("viewLive")}</Button>
               </Link>
             </div>


### PR DESCRIPTION
This PR addresses comments from #658. It uses the `getPostURLReference` utility to get the live preview URL for managing posts, to maintain more consistency across the codebase, rather than accessing the slug and building the URL directly.