### PR TITLE
655 - Use post URL utility on Manage Artist Posts page

### DIFF
--- a/client/src/components/ManageArtist/ManageArtistPosts.tsx
+++ b/client/src/components/ManageArtist/ManageArtistPosts.tsx
@@ -10,6 +10,7 @@ import { useSnackbar } from "state/SnackbarContext";
 import PostForm from "./PostForm";
 import Modal from "components/common/Modal";
 import { useTranslation } from "react-i18next";
+import { getPostURLReference } from "utils/artist";
 import { FaPlus } from "react-icons/fa";
 import { useArtistContext } from "state/ArtistContext";
 import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
@@ -111,7 +112,7 @@ const ManageArtistPosts: React.FC<{}> = () => {
               `}
             >
               <Link
-                to={`/post/${p.id}`}
+                to={getPostURLReference({...p, artist})}
                 className={css`
                   width: 80%;
                   display: flex;


### PR DESCRIPTION
This PR updates the URL on the Manage Artist Posts page to match how the URL is being formed elsewhere, with the `getPostURLReference` utility.

Ref: https://github.com/funmusicplace/mirlo/issues/655#issuecomment-2043529690