### PR TITLE
Flatten buttons wrapped with links into a single element

### DIFF
--- a/client/src/components/Admin/Users.tsx
+++ b/client/src/components/Admin/Users.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/css";
-import Button from "components/common/Button";
+import { ButtonLink } from "components/common/Button";
 import Table from "components/common/Table";
 import React from "react";
 import { FaCheck, FaEdit } from "react-icons/fa";
@@ -58,9 +58,11 @@ export const AdminUsers: React.FC = () => {
                 </td>
                 <td>{user.stripeAccountId ? <FaCheck /> : ""}</td>
                 <td className="alignRight">
-                  <Link to={`/admin/users/${user.id}`}>
-                    <Button compact startIcon={<FaEdit />} />
-                  </Link>
+                  <ButtonLink
+                    compact
+                    startIcon={<FaEdit />}
+                    to={`/admin/users/${user.id}`}
+                  />
                 </td>
               </tr>
             ))}

--- a/client/src/components/Artist/ArtistAlbums.tsx
+++ b/client/src/components/Artist/ArtistAlbums.tsx
@@ -4,9 +4,9 @@ import { useTranslation } from "react-i18next";
 import ArtistTrackGroup from "./ArtistTrackGroup";
 import { bp } from "../../constants";
 import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { FaPlus } from "react-icons/fa";
-import Button from "components/common/Button";
+import { ButtonLink } from "components/common/Button";
 import TrackgroupGrid from "components/common/TrackgroupGrid";
 import { useAuthContext } from "state/AuthContext";
 import { useQuery } from "@tanstack/react-query";
@@ -41,11 +41,15 @@ const ArtistAlbums: React.FC = () => {
       <SpaceBetweenDiv>
         <div />
         {artist.userId === user?.id && (
-          <Link to={`/manage/artists/${artist.id}/new-release`}>
-            <Button compact transparent startIcon={<FaPlus />} variant="dashed">
-              {t("addNewAlbum")}
-            </Button>
-          </Link>
+          <ButtonLink
+            compact
+            transparent
+            startIcon={<FaPlus />}
+            variant="dashed"
+            to={`/manage/artists/${artist.id}/new-release`}
+          >
+            {t("addNewAlbum")}
+          </ButtonLink>
         )}
       </SpaceBetweenDiv>
       <TrackgroupGrid gridNumber={"3"} wrap>

--- a/client/src/components/Artist/ArtistContainer.tsx
+++ b/client/src/components/Artist/ArtistContainer.tsx
@@ -1,3 +1,4 @@
+import styled from "@emotion/styled";
 import { css } from "@emotion/css";
 import React from "react";
 import { Link, Outlet, useParams } from "react-router-dom";
@@ -10,6 +11,30 @@ import { bp } from "../../constants";
 import { useQuery } from "@tanstack/react-query";
 import { queryArtist } from "queries";
 import { useAuthContext } from "state/AuthContext";
+
+const EditLink = styled(Link)`
+  z-index: 999999;
+  top: 75px;
+  right: 1rem;
+  position: fixed;
+  box-shadow: 0.2rem 0.2rem 0.3rem rgba(0, 0, 0, 0.5);
+
+  background-color: rgba(255, 255, 255, 0.9) !important;
+  color: black !important;
+  padding: 1.2rem !important;
+  :hover {
+    background-color: rgba(0, 0, 0, 0.7) !important;
+    color: white !important;
+  }
+
+  @media screen and (max-width: ${bp.medium}px) {
+    left: 1rem;
+    bottom: 75px;
+    top: auto;
+    right: auto;
+    padding: 1rem !important;
+  }
+`;
 
 const ArtistContainer: React.FC = () => {
   const { t } = useTranslation("translation", { keyPrefix: "manageArtist" });
@@ -28,45 +53,17 @@ const ArtistContainer: React.FC = () => {
   return (
     <>
       {artist && user?.id === artist?.userId && !trackGroupId && (
-        <Link
-          to={`/manage/artists/${artist.id}`}
-          className={css`
-            z-index: 999999;
-            top: 75px;
-            right: 1rem;
-            color: var(--mi-warning-text-color);
-            position: fixed;
-            box-shadow: 0.2rem 0.2rem 0.3rem rgba(0, 0, 0, 0.5);
-
-            @media screen and (max-width: ${bp.medium}px) {
-              left: 1rem;
-              bottom: 75px;
-              top: auto;
-              right: auto;
-            }
-          `}
+        <Button
+          startIcon={<FaPen />}
+          compact
+          type="button"
+          variant="dashed"
+          as={(props) => (
+            <EditLink to={`/manage/artists/${artist.id}`} {...props} />
+          )}
         >
-          <Button
-            startIcon={<FaPen />}
-            compact
-            type="button"
-            variant="dashed"
-            className={css`
-              background-color: rgba(255, 255, 255, 0.9) !important;
-              color: black !important;
-              padding: 1.2rem !important;
-              :hover {
-                background-color: rgba(0, 0, 0, 0.7) !important;
-                color: white !important;
-              }
-              @media screen and (max-width: ${bp.medium}px) {
-                padding: 1rem !important;
-              }
-            `}
-          >
-            {t("editPage")}
-          </Button>
-        </Link>
+          {t("editPage")}
+        </Button>
       )}
       {!isPostOrRelease && (
         <>

--- a/client/src/components/Home/Features.tsx
+++ b/client/src/components/Home/Features.tsx
@@ -4,7 +4,7 @@ import { MetaCard } from "components/common/MetaCard";
 import { WidthWrapper } from "components/common/WidthContainer";
 import { FaArrowDown } from "react-icons/fa";
 import { bp } from "../../constants";
-import Button from "components/common/Button";
+import Button, { ButtonLink } from "components/common/Button";
 import { Link } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 
@@ -183,35 +183,34 @@ const Features = () => {
                 padding-top: 1rem;
               `}
             >
-              <Link to="#features">
-                <Button
-                  variant="big"
-                  className={css`
-                    display: block;
-                    padding: 1.5rem 1rem !important;
-                    background-color: #be3455 !important;
-                    color: var(--mi-white) !important;
+              <ButtonLink
+                to="#features"
+                variant="big"
+                className={css`
+                  display: block;
+                  padding: 1.5rem 1rem !important;
+                  background-color: #be3455 !important;
+                  color: var(--mi-white) !important;
 
-                    &:hover {
-                      text-decoration: underline;
-                    }
+                  &:hover {
+                    text-decoration: underline;
+                  }
 
-                    svg {
-                      margin-left: 0.5rem;
-                    }
-                  `}
-                  onClick={() => {
-                    const features = document.getElementById("features");
-                    if (features) {
-                      features.scrollIntoView({
-                        behavior: "smooth",
-                      });
-                    }
-                  }}
-                >
-                  Learn more <FaArrowDown />
-                </Button>
-              </Link>
+                  svg {
+                    margin-left: 0.5rem;
+                  }
+                `}
+                onClick={() => {
+                  const features = document.getElementById("features");
+                  if (features) {
+                    features.scrollIntoView({
+                      behavior: "smooth",
+                    });
+                  }
+                }}
+              >
+                Learn more <FaArrowDown />
+              </ButtonLink>
             </div>
           </div>
 
@@ -474,23 +473,22 @@ const Features = () => {
             `}
           >
             Excited to get started?{" "}
-            <Link to="/signup">
-              <Button
-                variant="big"
-                className={css`
-                  display: block;
-                  padding: 1.5rem 1rem !important;
-                  background-color: #be3455 !important;
-                  color: var(--mi-white) !important;
+            <ButtonLink
+              to="/signup"
+              variant="big"
+              className={css`
+                display: block;
+                padding: 1.5rem 1rem !important;
+                background-color: #be3455 !important;
+                color: var(--mi-white) !important;
 
-                  &:hover {
-                    text-decoration: underline;
-                  }
-                `}
-              >
-                Join Mirlo!
-              </Button>
-            </Link>
+                &:hover {
+                  text-decoration: underline;
+                }
+              `}
+            >
+              Join Mirlo!
+            </ButtonLink>
           </div>
           <div
             className={css`

--- a/client/src/components/Home/HomeFeatures.tsx
+++ b/client/src/components/Home/HomeFeatures.tsx
@@ -5,8 +5,7 @@ import {
   SplashWrapper,
   TextWrapper,
 } from "./Splash";
-import Button from "components/common/Button";
-import { Link } from "react-router-dom";
+import { ButtonLink } from "components/common/Button";
 import { useTranslation } from "react-i18next";
 import { bp } from "../../constants";
 
@@ -62,28 +61,27 @@ const SupportMirlo = () => {
           >
             <SplashTitle>{t("sustainedBy")}</SplashTitle>
             <SplashButtonWrapper>
-              <Link to="/team/support">
-                <Button
-                  variant="big"
-                  className={css`
-                    display: block;
-                    padding: 1rem;
-                    text-decoration: none;
-                    text-align: center;
-                    &:hover {
-                      text-decoration: underline;
-                    }
+              <ButtonLink
+                to="/team/support"
+                variant="big"
+                className={css`
+                  display: block;
+                  padding: 1rem;
+                  text-decoration: none;
+                  text-align: center;
+                  &:hover {
+                    text-decoration: underline;
+                  }
 
-                    color: var(--mi-white);
-                    @media (prefers-color-scheme: dark) {
-                      background-color: var(--mi-white) !important;
-                      color: var(--mi-black) !important;
-                    }
-                  `}
-                >
-                  {t("supportTeam")}
-                </Button>
-              </Link>
+                  color: var(--mi-white);
+                  @media (prefers-color-scheme: dark) {
+                    background-color: var(--mi-white) !important;
+                    color: var(--mi-black) !important;
+                  }
+                `}
+              >
+                {t("supportTeam")}
+              </ButtonLink>
             </SplashButtonWrapper>
           </div>
         </TextWrapper>

--- a/client/src/components/Home/Splash.tsx
+++ b/client/src/components/Home/Splash.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/css";
 import { Link } from "react-router-dom";
 import Logo from "../common/Logo";
 import { Trans, useTranslation } from "react-i18next";
-import Button from "components/common/Button";
+import { ButtonLink } from "components/common/Button";
 import styled from "@emotion/styled";
 import { bp } from "../../constants";
 import { useAuthContext } from "state/AuthContext";
@@ -85,44 +85,42 @@ const Splash = () => {
           <SplashTitle>{t("support")}</SplashTitle>
           {!user && (
             <SplashButtonWrapper>
-              <Link to="/signup">
-                <Button
-                  variant="big"
-                  className={css`
-                    display: block;
-                    padding: 1.5rem 1rem !important;
-                    background-color: #be3455 !important;
+              <ButtonLink
+                to="/signup"
+                variant="big"
+                className={css`
+                  display: block;
+                  padding: 1.5rem 1rem !important;
+                  background-color: #be3455 !important;
 
-                    &:hover {
-                      text-decoration: underline;
-                    }
-                    color: var(--mi-white) !important;
-                  `}
-                >
-                  {t("signUp")}
-                </Button>
-              </Link>
-              <Link to="/login">
-                <Button
-                  variant="big"
-                  className={css`
-                    color: var(--mi-white) !important;
-                    &:hover {
-                      text-decoration: underline;
-                    }
-                    padding: 1.5rem 1rem !important;
+                  &:hover {
+                    text-decoration: underline;
+                  }
+                  color: var(--mi-white) !important;
+                `}
+              >
+                {t("signUp")}
+              </ButtonLink>
+              <ButtonLink
+                to="/login"
+                variant="big"
+                className={css`
+                  color: var(--mi-white) !important;
+                  &:hover {
+                    text-decoration: underline;
+                  }
+                  padding: 1.5rem 1rem !important;
 
-                    background-color: var(--mi-black) !important;
-                    color: var(--mi-white);
-                    @media (prefers-color-scheme: dark) {
-                      background-color: var(--mi-white) !important;
-                      color: var(--mi-black) !important;
-                    }
-                  `}
-                >
-                  {t("logIn")}
-                </Button>
-              </Link>
+                  background-color: var(--mi-black) !important;
+                  color: var(--mi-white);
+                  @media (prefers-color-scheme: dark) {
+                    background-color: var(--mi-white) !important;
+                    color: var(--mi-black) !important;
+                  }
+                `}
+              >
+                {t("logIn")}
+              </ButtonLink>
             </SplashButtonWrapper>
           )}
           <p

--- a/client/src/components/Home/SupportMirlo.tsx
+++ b/client/src/components/Home/SupportMirlo.tsx
@@ -5,8 +5,7 @@ import {
   SplashWrapper,
   TextWrapper,
 } from "./Splash";
-import Button from "components/common/Button";
-import { Link } from "react-router-dom";
+import { ButtonLink } from "components/common/Button";
 import { useTranslation } from "react-i18next";
 import { bp } from "../../constants";
 
@@ -62,28 +61,27 @@ const SupportMirlo = () => {
           >
             <SplashTitle>{t("sustainedBy")}</SplashTitle>
             <SplashButtonWrapper>
-              <Link to="/team/support">
-                <Button
-                  variant="big"
-                  className={css`
-                    display: block;
-                    padding: 1rem;
-                    text-decoration: none;
-                    text-align: center;
-                    &:hover {
-                      text-decoration: underline;
-                    }
+              <ButtonLink
+                to="/team/support"
+                variant="big"
+                className={css`
+                  display: block;
+                  padding: 1rem;
+                  text-decoration: none;
+                  text-align: center;
+                  &:hover {
+                    text-decoration: underline;
+                  }
 
-                    color: var(--mi-white);
-                    @media (prefers-color-scheme: dark) {
-                      background-color: var(--mi-white) !important;
-                      color: var(--mi-black) !important;
-                    }
-                  `}
-                >
-                  {t("supportTeam")}
-                </Button>
-              </Link>
+                  color: var(--mi-white);
+                  @media (prefers-color-scheme: dark) {
+                    background-color: var(--mi-white) !important;
+                    color: var(--mi-black) !important;
+                  }
+                `}
+              >
+                {t("supportTeam")}
+              </ButtonLink>
             </SplashButtonWrapper>
           </div>
         </TextWrapper>

--- a/client/src/components/ManageArtist/Manage.tsx
+++ b/client/src/components/ManageArtist/Manage.tsx
@@ -2,10 +2,9 @@ import { css } from "@emotion/css";
 import React from "react";
 
 import api from "services/api";
-import Button from "../common/Button";
+import Button, { ButtonLink } from "../common/Button";
 import CreateNewArtistForm from "./ArtistForm";
 import { bp } from "../../constants";
-import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import Box from "components/common/Box";
 import CountrySelect from "./CountrySelectForm";
@@ -79,35 +78,35 @@ export const Manage: React.FC = () => {
               `}
             >
               {artists.map((a) => (
-                <Link
+                <ButtonLink
                   key={a.id}
                   to={`artists/${a.id}`}
+                  variant="outlined"
                   className={css`
                     margin-right: 1rem;
                     margin-bottom: 1rem;
                   `}
                 >
-                  <Button variant="outlined">{a.name}</Button>
-                </Link>
+                  {a.name}
+                </ButtonLink>
               ))}
               <div
                 className={css`
                   width: 100%;
                 `}
               >
-                <Link to="/manage/welcome">
-                  <Button
-                    variant="big"
-                    className={css`
-                      flex-grow: 1;
-                      text-align: center;
-                      border-radius: 6px;
-                      justify-self: none;
-                    `}
-                  >
-                    {t("createNewArtist")}
-                  </Button>
-                </Link>
+                <ButtonLink
+                  to="/manage/welcome"
+                  variant="big"
+                  className={css`
+                    flex-grow: 1;
+                    text-align: center;
+                    border-radius: 6px;
+                    justify-self: none;
+                  `}
+                >
+                  {t("createNewArtist")}
+                </ButtonLink>
               </div>
             </div>
             <CreateNewArtistForm

--- a/client/src/components/ManageArtist/ManageArtist.tsx
+++ b/client/src/components/ManageArtist/ManageArtist.tsx
@@ -1,15 +1,9 @@
 import { css } from "@emotion/css";
-import Button from "components/common/Button";
+import Button, { ButtonLink } from "components/common/Button";
 import React from "react";
 import { bp } from "../../constants";
 import { FaEye, FaPen, FaTrash } from "react-icons/fa";
-import {
-  Link,
-  NavLink,
-  Outlet,
-  useNavigate,
-  useParams,
-} from "react-router-dom";
+import { NavLink, Outlet, useNavigate, useParams } from "react-router-dom";
 import ArtistForm from "./ArtistForm";
 import { useSnackbar } from "state/SnackbarContext";
 import { useTranslation } from "react-i18next";
@@ -106,11 +100,14 @@ const ManageArtist: React.FC<{}> = () => {
           >
             {t("editDetails")}
           </Button>
-          <Link to={`/${artist?.urlSlug?.toLowerCase() ?? artist?.id}`}>
-            <Button variant="big" startIcon={<FaEye />} disabled={!artist}>
-              {t("viewLive")}
-            </Button>
-          </Link>
+          <ButtonLink
+            to={`/${artist?.urlSlug?.toLowerCase() ?? artist?.id}`}
+            variant="big"
+            startIcon={<FaEye />}
+            disabled={!artist}
+          >
+            {t("viewLive")}
+          </ButtonLink>
         </div>
       </MainButtons>
       <ArtistTabs>

--- a/client/src/components/ManageArtist/ManageArtistAlbums.tsx
+++ b/client/src/components/ManageArtist/ManageArtistAlbums.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/css";
-import Button from "components/common/Button";
+import { ButtonLink } from "components/common/Button";
 import React from "react";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import api from "services/api";
 import TrackGroupCard from "./TrackGroupCard";
 import { useTranslation } from "react-i18next";
@@ -53,33 +53,29 @@ const ManageArtistAlbums: React.FC<{}> = () => {
         )}
         {trackGroups.length !== 0 && <div />}
         <div>
-          <Link
+          <ButtonLink
             to={`/manage/artists/${artistId}/releases/tools`}
+            compact
+            transparent
+            startIcon={<FaWrench />}
+            variant="outlined"
+            collapsible
             className={css`
               margin-right: 0.25rem;
             `}
           >
-            <Button
-              compact
-              transparent
-              startIcon={<FaWrench />}
-              variant="outlined"
-              collapsible
-            >
-              {t("tools")}
-            </Button>
-          </Link>
-          <Link to={`/manage/artists/${artistId}/new-release`}>
-            <Button
-              compact
-              transparent
-              startIcon={<FaPlus />}
-              variant="dashed"
-              collapsible
-            >
-              {t("addNewAlbum")}
-            </Button>
-          </Link>
+            {t("tools")}
+          </ButtonLink>
+          <ButtonLink
+            to={`/manage/artists/${artistId}/new-release`}
+            compact
+            transparent
+            startIcon={<FaPlus />}
+            variant="dashed"
+            collapsible
+          >
+            {t("addNewAlbum")}
+          </ButtonLink>
         </div>
       </SpaceBetweenDiv>
       {isLoading && <LoadingBlocks />}

--- a/client/src/components/ManageArtist/ManageArtistPosts.tsx
+++ b/client/src/components/ManageArtist/ManageArtistPosts.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/css";
-import Button from "components/common/Button";
+import Button, { ButtonLink } from "components/common/Button";
 import React from "react";
 import api from "services/api";
 import NewPostForm from "./NewPostForm";
@@ -131,9 +131,12 @@ const ManageArtistPosts: React.FC<{}> = () => {
                   display: flex;
                 `}
               >
-                <Link to={`/manage/artists/${p.artistId}/post/${p.id}`}>
-                  <Button onlyIcon variant="dashed" startIcon={<FaPen />} />
-                </Link>
+                <ButtonLink
+                  to={`/manage/artists/${p.artistId}/post/${p.id}`}
+                  onlyIcon
+                  variant="dashed"
+                  startIcon={<FaPen />}
+                />
                 <Button
                   className={css`
                     margin-left: 0.5rem;

--- a/client/src/components/ManageArtist/ManageArtistSubscriptionTiers.tsx
+++ b/client/src/components/ManageArtist/ManageArtistSubscriptionTiers.tsx
@@ -4,12 +4,12 @@ import ManageSubscriptionTierBox from "./ManageSubscriptionTierBox";
 import SubscriptionForm from "./SubscriptionForm";
 import { useArtistContext } from "state/ArtistContext";
 import useGetUserObjectById from "utils/useGetUserObjectById";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
 import { ManageSectionWrapper } from "./ManageSectionWrapper";
 import Modal from "components/common/Modal";
 import { useTranslation } from "react-i18next";
-import Button from "components/common/Button";
+import Button, { ButtonLink } from "components/common/Button";
 import { FaPlus, FaWrench } from "react-icons/fa";
 import { useAuthContext } from "state/AuthContext";
 
@@ -42,21 +42,18 @@ const ManageArtistSubscriptionTiers: React.FC<{}> = () => {
       <SpaceBetweenDiv>
         <div />
         <div>
-          <Link
+          <ButtonLink
             to="supporters"
             className={css`
               margin-right: 0.25rem;
             `}
+            variant="dashed"
+            compact
+            collapsible
+            startIcon={<FaWrench />}
           >
-            <Button
-              variant="dashed"
-              compact
-              collapsible
-              startIcon={<FaWrench />}
-            >
-              {t("supporters")}
-            </Button>
-          </Link>
+            {t("supporters")}
+          </ButtonLink>
           <Button
             transparent
             onClick={() => {

--- a/client/src/components/ManageArtist/ManagePost.tsx
+++ b/client/src/components/ManageArtist/ManagePost.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useArtistContext } from "state/ArtistContext";
 import useGetUserObjectById from "utils/useGetUserObjectById";
@@ -11,7 +11,7 @@ import LoadingBlocks from "components/Artist/LoadingBlocks";
 import BackToArtistLink from "./BackToArtistLink";
 import PostForm from "./PostForm";
 import Post from "components/Post";
-import Button from "components/common/Button";
+import { ButtonLink } from "components/common/Button";
 import { bp } from "../../constants";
 
 const ManagePost: React.FC<{}> = () => {
@@ -76,9 +76,12 @@ const ManagePost: React.FC<{}> = () => {
                 align-items: center;
               `}
             >
-              <Link to={getPostURLReference({ ...post, artist })}>
-                <Button type="button">{t("viewLive")}</Button>
-              </Link>
+              <ButtonLink
+                to={getPostURLReference({ ...post, artist })}
+                type="button"
+              >
+                {t("viewLive")}
+              </ButtonLink>
             </div>
           )}
         </SpaceBetweenDiv>

--- a/client/src/components/ManageArtist/PublishButton.tsx
+++ b/client/src/components/ManageArtist/PublishButton.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useArtistContext } from "state/ArtistContext";
 import api from "services/api";
 import { useSnackbar } from "state/SnackbarContext";
-import Button from "components/common/Button";
+import Button, { ButtonLink } from "components/common/Button";
 import { css } from "@emotion/css";
 import { getReleaseUrl } from "utils/artist";
 
@@ -80,11 +80,9 @@ const PublishButton: React.FC<{
         {t(trackGroup.published ? privateButton : publishButton)}
       </Button>
       {artist && trackGroup.published && (
-        <Link to={getReleaseUrl(artist, trackGroup)}>
-          <Button variant="big">
-            {t(beforeReleaseDate ? "viewPreorder" : "view")}
-          </Button>
-        </Link>
+        <ButtonLink to={getReleaseUrl(artist, trackGroup)} variant="big">
+          {t(beforeReleaseDate ? "viewPreorder" : "view")}
+        </ButtonLink>
       )}
     </div>
   );

--- a/client/src/components/ManageArtist/TrackGroupCard.tsx
+++ b/client/src/components/ManageArtist/TrackGroupCard.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/css";
 import Box from "components/common/Box";
-import Button from "components/common/Button";
+import Button, { ButtonLink } from "components/common/Button";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { FaCheck, FaTimes, FaTrash } from "react-icons/fa";
@@ -164,17 +164,22 @@ const TrackGroupCard: React.FC<{
               justify-content: space-between !important;
           `}
         >
-          <Link to={`/manage/artists/${album.artistId}/release/${album.id}`}>
-            <Button compact thin variant="outlined">
-              {t("manageAlbum")}
-            </Button>
-          </Link>
+          <ButtonLink
+            to={`/manage/artists/${album.artistId}/release/${album.id}`}
+            compact
+            thin
+            variant="outlined"
+          >
+            {t("manageAlbum")}
+          </ButtonLink>
           {album.artist && album.published && (
-            <Link to={getReleaseUrl(album.artist, album)}>
-              <Button compact variant="outlined">
-                {t("viewLive")}
-              </Button>
-            </Link>
+            <ButtonLink
+              to={getReleaseUrl(album.artist, album)}
+              compact
+              variant="outlined"
+            >
+              {t("viewLive")}
+            </ButtonLink>
           )}
           {!album.published && (
             <Button compact startIcon={<FaTrash />} onClick={deleteTrackGroup}>

--- a/client/src/components/ManageArtist/Welcome.tsx
+++ b/client/src/components/ManageArtist/Welcome.tsx
@@ -3,14 +3,14 @@ import styled from "@emotion/styled";
 import FormComponent from "components/common/FormComponent";
 import { InputEl } from "components/common/Input";
 import { FormProvider, useForm } from "react-hook-form";
-import Button from "components/common/Button";
+import Button, { ButtonLink } from "components/common/Button";
 import React from "react";
 import ArtistSlugInput from "./ArtistSlugInput";
 import api from "services/api";
 import UploadArtistImage from "./UploadArtistImage";
 import { FaArrowRight, FaPlus } from "react-icons/fa";
 import { css } from "@emotion/css";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import useErrorHandler from "services/useErrorHandler";
 import { useAuthContext } from "state/AuthContext";
 
@@ -141,16 +141,15 @@ const Welcome = () => {
             `}
           >
             {steps[step] === "avatar" && localArtist && (
-              <Link to={`/manage/artists/${localArtist.id}/new-release`}>
-                <Button
-                  isLoading={isLoading}
-                  compact
-                  disabled={isButtonDisabled}
-                  startIcon={<FaPlus />}
-                >
-                  {t("addAlbum")}
-                </Button>
-              </Link>
+              <ButtonLink
+                to={`/manage/artists/${localArtist.id}/new-release`}
+                isLoading={isLoading}
+                compact
+                disabled={isButtonDisabled}
+                startIcon={<FaPlus />}
+              >
+                {t("addAlbum")}
+              </ButtonLink>
             )}
             <Button
               isLoading={isLoading}
@@ -165,17 +164,16 @@ const Welcome = () => {
             </Button>
 
             {step > 0 && steps[step] !== "avatar" && (
-              <Link to={localArtistLink}>
-                <Button
-                  isLoading={isLoading}
-                  compact
-                  variant="outlined"
-                  disabled={isButtonDisabled}
-                  endIcon={<FaArrowRight />}
-                >
-                  {t("takeMeToTheArtistPage")}
-                </Button>
-              </Link>
+              <ButtonLink
+                to={localArtistLink}
+                isLoading={isLoading}
+                compact
+                variant="outlined"
+                disabled={isButtonDisabled}
+                endIcon={<FaArrowRight />}
+              >
+                {t("takeMeToTheArtistPage")}
+              </ButtonLink>
             )}
           </div>
         </PageWrapper>

--- a/client/src/components/Post/index.tsx
+++ b/client/src/components/Post/index.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/css";
-import Button from "components/common/Button";
+import { ButtonLink } from "components/common/Button";
 import { MetaCard } from "components/common/MetaCard";
 import parse from "html-react-parser";
 import React from "react";
@@ -138,11 +138,13 @@ const Post: React.FC = () => {
           >
             <h1>{post.title}</h1>
             {(ownedByUser || user?.isAdmin) && (
-              <Link to={`/manage/artists/${post.artistId}/post/${post.id}`}>
-                <Button variant="dashed" startIcon={<FaPen />}>
-                  {t("edit")}
-                </Button>
-              </Link>
+              <ButtonLink
+                to={`/manage/artists/${post.artistId}/post/${post.id}`}
+                variant="dashed"
+                startIcon={<FaPen />}
+              >
+                {t("edit")}
+              </ButtonLink>
             )}
           </div>
           {post.artist && (

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -2,12 +2,12 @@ import { css } from "@emotion/css";
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "state/SnackbarContext";
 import { API_ROOT } from "../../constants";
 
 import api from "../../services/api";
-import Button from "../common/Button";
+import Button, { ButtonLink } from "../common/Button";
 import FormComponent from "../common/FormComponent";
 import { InputEl } from "../common/Input";
 import UserSupports from "./UserSupports";
@@ -129,12 +129,12 @@ function Profile() {
                 artistUserSubscriptions={user.artistUserSubscriptions}
               />
             )}
-            <Link to="/profile/collection" style={{ marginTop: "1rem" }}>
-              <Button style={{ width: "100%" }}>{t("viewCollection")}</Button>
-            </Link>
-            <Link to="/manage" style={{ marginTop: "1rem" }}>
-              <Button style={{ width: "100%" }}>{t("manageArtists")}</Button>
-            </Link>
+            <ButtonLink to="/profile/collection" style={{ marginTop: "1rem" }}>
+              {t("viewCollection")}
+            </ButtonLink>
+            <ButtonLink to="/manage" style={{ marginTop: "1rem" }}>
+              {t("manageArtists")}
+            </ButtonLink>
             <Button
               style={{
                 width: "100%",

--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -4,6 +4,7 @@ import styled from "@emotion/styled";
 import LoadingSpinner from "./LoadingSpinner";
 import { css } from "@emotion/css";
 import { bp } from "../../constants";
+import { Link } from "react-router-dom";
 
 export interface Compactable {
   compact?: boolean;
@@ -254,6 +255,7 @@ export interface ButtonProps extends Compactable {
   isLoading?: boolean;
   collapse?: boolean;
   title?: string;
+  as?: React.ElementType<any, keyof React.JSX.IntrinsicElements>;
 }
 
 export const Button: React.FC<ButtonProps> = ({
@@ -292,6 +294,19 @@ export const Button: React.FC<ButtonProps> = ({
       {!collapse && children}
       {endIcon ? <span className="endIcon">{endIcon}</span> : ""}
     </CustomButton>
+  );
+};
+
+export const ButtonLink: React.FC<ButtonProps & { to: string }> = ({
+  to,
+  ...props
+}) => {
+  return (
+    <Button
+      // Use the "Link" element from react-router as the base element for the button
+      as={(props) => <Link to={to} {...props} />}
+      {...props}
+    />
   );
 };
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -6,7 +6,7 @@ import legacy from "@vitejs/plugin-legacy";
 import { optimizeLodashImports } from "@optimize-lodash/rollup-plugin";
 
 export default defineConfig({
-  base: process.env.VITE_CLIENT_DOMAIN ?? "",
+  base: "/",
   plugins: [react(), viteTsconfigPaths(), legacy()],
   server: {
     open: true,


### PR DESCRIPTION
Many links on the site use a  `<Link> <Button /> </Link>` structure, which renders a styled `<button>` element wrapped with an `<a href="...">` from react-router.

When using keyboard navigation, the inner `<button>` element is also focusable and announced to screen readers, even though it does not have any effect when used.

This PR flattens these components into one `<ButtonLink>`, which renders a single `<a>` element with the button styling.