### PR TITLE
Copy ffmpeg with libfdk_aac from jrottenberg/ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
+FROM jrottenberg/ffmpeg:5.1-ubuntu2204 as ffmpeg
+
 FROM node:18-bookworm-slim AS base
 
 # Install ffmpeg
+COPY --from=ffmpeg / /
+
 RUN apt-get update -qq
-RUN apt-get install -qq --no-install-recommends ffmpeg=7:5.1.4-0+deb12u1 >/dev/null
+RUN apt-get install -qq libavdevice59 >/dev/null
 
 # Create app directory
 ENV NODE_APP_DIR=/var/www/api/src \

--- a/client/index.html
+++ b/client/index.html
@@ -86,6 +86,13 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <script>
+      // This is a hacky polyfill for node libs (specifically "readable-stream", a dependency of "music-metadata-browser") referencing .global
+      // which does not exist in the browser environment in dev mode.
+      if (global === undefined) {
+        var global = window;
+      }
+    </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
This hopefully fixes an issue with libfdk_aac not existing in the debian `ffmpeg` binary by copying it from an Ubuntu build of `jrottenberg/ffmpeg` and installing libavdevice59 (a dependency that does not appear to get copied correctly).

This also adds an unrelated fix to `client/index.html` for for an issue that prevented the album upload pages from loading in Vite's dev mode (this does not occur in the built site - possibly thanks to Rollup).