### PR TITLE
Fix postgres healthcheck-related warnings

### DIFF
--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -100,7 +100,7 @@ services:
       - ./data/pgsql:/var/lib/postgresql/data
       - ./data/pgsql_backups:/backups
     healthcheck:
-      test: ["CMD", "pg_isready"]
+      test: ["CMD", "pg_isready", "-U", "$POSTGRES_USER"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This removes `FATAL:  role "root" does not exist` warnings printed in the postgres logs due to its healthcheck script not knowing the configured user.