### PR TITLE
Avoid treating links with @ symbols as an email

### DIFF
--- a/client/src/components/ManageArtist/ArtistFormLinks.tsx
+++ b/client/src/components/ManageArtist/ArtistFormLinks.tsx
@@ -5,7 +5,9 @@ import Button from "components/common/Button";
 import { css } from "@emotion/css";
 import { FaPlus, FaSave, FaTimes, FaTrash } from "react-icons/fa";
 import React from "react";
-import LinkIconDisplay from "components/common/LinkIconDisplay";
+import LinkIconDisplay, {
+  linkUrlHref,
+} from "components/common/LinkIconDisplay";
 import ArtistFormLinksView from "./ArtistFormLinksView";
 import { useSnackbar } from "state/SnackbarContext";
 
@@ -25,9 +27,6 @@ function transformFromLinks(artist: Pick<Artist, "links">): FormData {
 
 function transformToLinks(data: FormData): Pick<Artist, "links"> {
   const links = data.linkArray.map((link) => {
-    if (link.url.includes("@") && !link.url.startsWith("mailto:")) {
-      return `mailto:${link.url}`;
-    }
     return link.url;
   });
 
@@ -77,6 +76,7 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
     <>
       {fields.map((field, index) => (
         <div
+          key={index}
           className={css`
             max-width: 50%;
             display: flex;
@@ -95,7 +95,7 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
         >
           <LinkIconDisplay url={links[index].url} />
           <InputEl
-            {...register(`linkArray.${index}.url`)}
+            {...register(`linkArray.${index}.url`, { setValueAs: linkUrlHref })}
             placeholder="eg. http://some.url"
             key={field.id}
             type="url"

--- a/client/src/components/ManageArtist/ArtistFormLinksView.tsx
+++ b/client/src/components/ManageArtist/ArtistFormLinksView.tsx
@@ -4,6 +4,7 @@ import { css } from "@emotion/css";
 import React from "react";
 import LinkIconDisplay, {
   linkUrlDisplay,
+  linkUrlHref,
 } from "components/common/LinkIconDisplay";
 import { FaPen } from "react-icons/fa";
 
@@ -26,7 +27,7 @@ const ArtistFormLinksView: React.FC<{
           return (
             <a
               rel="me"
-              href={l}
+              href={linkUrlHref(l)}
               key={l}
               className={css`
                 display: inline-flex;

--- a/client/src/components/common/LinkIconDisplay.test.tsx
+++ b/client/src/components/common/LinkIconDisplay.test.tsx
@@ -1,0 +1,44 @@
+import { test, expect } from "vitest";
+import { isEmailLink, linkUrlHref } from "./LinkIconDisplay";
+
+test("isEmailLink returns true when a link is entered", () => {
+  const result = isEmailLink("test@example.com");
+  expect(result).toBe(true);
+});
+
+test("isEmailLink returns false when a URL is entered", () => {
+  const result = isEmailLink("https://example.com");
+  expect(result).toBe(false);
+});
+
+test("isEmailLink returns false when a URL containing an @ symbol is entered", () => {
+  const result = isEmailLink("example.com/@example.com");
+  expect(result).toBe(false);
+});
+
+test("isEmailLink returns true when any string is prefixed with mailto", () => {
+  const result = isEmailLink(
+    "mailto:https://this.is.actually/@an.email.example.com"
+  );
+  expect(result).toBe(true);
+});
+
+test("linkUrlHref adds an https prefix to links that don't have one", () => {
+  const result = linkUrlHref("example.com");
+  expect(result).toBe("https://example.com");
+});
+
+test("linkUrlHref adds a mailto prefix to emails that don't have one", () => {
+  const result = linkUrlHref("test@example.com");
+  expect(result).toBe("mailto:test@example.com");
+});
+
+test("linkUrlHref doesn't affect links that already have an http prefix", () => {
+  const result = linkUrlHref("http://example.com");
+  expect(result).toBe("http://example.com");
+});
+
+test("linkUrlHref doesn't affect emails that already have a mailto prefix", () => {
+  const result = linkUrlHref("mailto:test@example.com");
+  expect(result).toBe("mailto:test@example.com");
+});

--- a/client/src/components/common/LinkIconDisplay.tsx
+++ b/client/src/components/common/LinkIconDisplay.tsx
@@ -7,9 +7,27 @@ import {
 } from "react-icons/fa";
 import { FiMail } from "react-icons/fi";
 
+// See: https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type%3Demail)
+// This is modified to exclude the "/" symbol if it occurs before an @ sign - which avoids mastodon links being parsed as emails
+const EMAIL_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+export function isEmailLink(link: string): boolean {
+  return link.startsWith("mailto:") || EMAIL_REGEX.test(link);
+}
+
+export function linkUrlHref(link: string): string {
+  if (isEmailLink(link)) {
+    return link.startsWith("mailto:") ? link : `mailto:${link}`;
+  } else {
+    // If the link doesn't start with "http://" or "https://", prefix it
+    return /https?:\/\//.test(link) ? link : `https://${link}`;
+  }
+}
+
 export const linkUrlDisplay = (link: string) => {
   let url;
-  if (link.startsWith("mailto:")) {
+  if (isEmailLink(link)) {
     return "Email";
   }
   try {
@@ -27,7 +45,7 @@ export const linkUrlDisplay = (link: string) => {
 
 const LinkIconDisplay: React.FC<{ url: string }> = ({ url }) => {
   let icon = <FaGlobe />;
-  if (url.includes("mailto")) {
+  if (isEmailLink(url)) {
     icon = <FiMail />;
   } else if (url.includes("twitter.com")) {
     icon = <FaTwitter />;


### PR DESCRIPTION
This uses the simplified [email regex](https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type%3Demail)) used by browsers for input `type=email` validation for an `isEmailLink` function - modified to remove the ability for a `/` to occur before the `@` symbol.

This validation ensures that any link can be explicitly defined as an email or a link by prefixing either `https://` or `mailto:`. If a link does not have the mailto prefix and includes a `/` before an `@` symbol is encountered, then it is treated as a URL.