### PR TITLE
Fix button links not being clickable

### DIFF
--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -4,6 +4,7 @@ import styled from "@emotion/styled";
 import LoadingSpinner from "./LoadingSpinner";
 import { css } from "@emotion/css";
 import { bp } from "../../constants";
+import { Link } from "react-router-dom";
 
 export interface Compactable {
   compact?: boolean;
@@ -305,16 +306,13 @@ export const Button: React.FC<ButtonProps> = ({
   );
 };
 
-const CustomButtonLink = CustomButton.withComponent("a");
-
 export const ButtonLink: React.FC<ButtonProps & { to: string }> = ({
-  to,
   ...props
 }) => {
   return (
     <Button
       // Use the "Link" element from react-router as the base element for the button
-      as={CustomButtonLink}
+      as={Link}
       {...props}
     />
   );


### PR DESCRIPTION
This reverts a change in #699 which was an attempt at avoiding an error from styled-components passing unknown props into the react-router `<Link>` component. However, this change resulted in *no* props being passed to the `<Link>` component, which prevents them from working.