### PR TITLE
Misc button-related improvements

### DIFF
--- a/client/src/components/Artist/ArtistContainer.tsx
+++ b/client/src/components/Artist/ArtistContainer.tsx
@@ -1,40 +1,15 @@
-import styled from "@emotion/styled";
 import { css } from "@emotion/css";
 import React from "react";
-import { Link, Outlet, useParams } from "react-router-dom";
+import { Outlet, useParams } from "react-router-dom";
 import ArtistHeaderSection from "../common/ArtistHeaderSection";
 import { useTranslation } from "react-i18next";
 import { ArtistPageWrapper } from "components/ManageArtist/ManageArtistContainer";
-import Button from "components/common/Button";
+import { ButtonLink } from "components/common/Button";
 import { FaPen } from "react-icons/fa";
 import { bp } from "../../constants";
 import { useQuery } from "@tanstack/react-query";
 import { queryArtist } from "queries";
 import { useAuthContext } from "state/AuthContext";
-
-const EditLink = styled(Link)`
-  z-index: 999999;
-  top: 75px;
-  right: 1rem;
-  position: fixed;
-  box-shadow: 0.2rem 0.2rem 0.3rem rgba(0, 0, 0, 0.5);
-
-  background-color: rgba(255, 255, 255, 0.9) !important;
-  color: black !important;
-  padding: 1.2rem !important;
-  :hover {
-    background-color: rgba(0, 0, 0, 0.7) !important;
-    color: white !important;
-  }
-
-  @media screen and (max-width: ${bp.medium}px) {
-    left: 1rem;
-    bottom: 75px;
-    top: auto;
-    right: auto;
-    padding: 1rem !important;
-  }
-`;
 
 const ArtistContainer: React.FC = () => {
   const { t } = useTranslation("translation", { keyPrefix: "manageArtist" });
@@ -53,17 +28,37 @@ const ArtistContainer: React.FC = () => {
   return (
     <>
       {artist && user?.id === artist?.userId && !trackGroupId && (
-        <Button
+        <ButtonLink
+          to={`/manage/artists/${artist.id}`}
           startIcon={<FaPen />}
           compact
-          type="button"
           variant="dashed"
-          as={(props) => (
-            <EditLink to={`/manage/artists/${artist.id}`} {...props} />
-          )}
+          className={css`
+            z-index: 999999;
+            top: 75px;
+            right: 1rem;
+            position: fixed;
+            box-shadow: 0.2rem 0.2rem 0.3rem rgba(0, 0, 0, 0.5);
+
+            background-color: rgba(255, 255, 255, 0.9) !important;
+            color: black !important;
+            padding: 1.2rem !important;
+            :hover {
+              background-color: rgba(0, 0, 0, 0.7) !important;
+              color: white !important;
+            }
+
+            @media screen and (max-width: ${bp.medium}px) {
+              left: 1rem;
+              bottom: 75px;
+              top: auto;
+              right: auto;
+              padding: 1rem !important;
+            }
+          `}
         >
           {t("editPage")}
-        </Button>
+        </ButtonLink>
       )}
       {!isPostOrRelease && (
         <>

--- a/client/src/components/Artist/ArtistPosts.tsx
+++ b/client/src/components/Artist/ArtistPosts.tsx
@@ -8,7 +8,7 @@ import PostCard from "components/common/PostCard";
 import { useArtistContext } from "state/ArtistContext";
 import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
 import { FaRss } from "react-icons/fa";
-import Button from "components/common/Button";
+import { ButtonAnchor } from "components/common/Button";
 import styled from "@emotion/styled";
 import { getPostURLReference } from "utils/artist";
 
@@ -43,13 +43,13 @@ const ArtistPosts: React.FC = () => {
     <div>
       <SpaceBetweenDiv>
         <div></div>
-        <a
+        <ButtonAnchor
           target="_blank"
           href={`${import.meta.env.VITE_API_DOMAIN}/v1/artists/${artist.id}/feed?format=rss`}
           rel="noreferrer"
-        >
-          <Button onlyIcon startIcon={<FaRss />} />
-        </a>
+          onlyIcon
+          startIcon={<FaRss />}
+        />
       </SpaceBetweenDiv>
       <div
         className={css`

--- a/client/src/components/Home/Splash.tsx
+++ b/client/src/components/Home/Splash.tsx
@@ -42,10 +42,6 @@ export const SplashTitle = styled.h2`
 export const SplashButtonWrapper = styled.div`
   display: flex;
   gap: 16px;
-
-  a {
-    background-color: transparent;
-  }
 `;
 
 const Splash = () => {

--- a/client/src/components/ManageArtist/ManageArtistContainer.tsx
+++ b/client/src/components/ManageArtist/ManageArtistContainer.tsx
@@ -48,7 +48,6 @@ export const ArtistPageWrapper: React.FC<{
 
           a {
             color: var(--mi-normal-foreground-color);
-            font-weight: normal;
           }
           @media screen and (max-width: ${bp.medium}px) {
             padding: 0rem !important;

--- a/client/src/components/ManageArtist/ManagePost.tsx
+++ b/client/src/components/ManageArtist/ManagePost.tsx
@@ -76,10 +76,7 @@ const ManagePost: React.FC<{}> = () => {
                 align-items: center;
               `}
             >
-              <ButtonLink
-                to={getPostURLReference({ ...post, artist })}
-                type="button"
-              >
+              <ButtonLink to={getPostURLReference({ ...post, artist })}>
                 {t("viewLive")}
               </ButtonLink>
             </div>

--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -180,22 +180,20 @@ const CustomButton = styled.button<Compactable>`
           }
           padding: ${props.compact ? ".3rem .5rem" : "1rem"};
           padding: ${props.onlyIcon ? ".5rem .5rem" : ".6rem .6rem"};
-          background-color:  var(--mi-${props.buttonRole ?? "secondary"}-color);
+
+          background-color: var(--mi-${props.buttonRole ?? "secondary"}-color);
+          color: var(--mi-primary-color);
 
           ${
             props.transparent
-              ? "background-color:  transparent; font-weight: bold;"
+              ? "background-color:  transparent; font-weight: bold; color: var(--mi-normal-foreground-color);"
               : ""
           };
           ${props.thin ? "font-weight: normal !important;" : ""};
-          color:  var(--mi-${props.buttonRole ?? "primary"}-color);
-          color:  ${
-            props.transparent ? "var(--mi-normal-foreground-color)" : ""
-          };
 
           &:hover:not(:disabled) {
-            background-color: var(--mi-${props.buttonRole ?? "primary"}-color);
-            color: var(--mi-${props.buttonRole ?? "secondary"}-color);
+            background-color: var(--mi-primary-color);
+            color: var(--mi-secondary-color);
           }
           @media screen and (max-width: ${bp.medium}px) {
               ${props.collapsible ? "border-radius: 100%;" : ""}

--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -4,7 +4,11 @@ import styled from "@emotion/styled";
 import LoadingSpinner from "./LoadingSpinner";
 import { css } from "@emotion/css";
 import { bp } from "../../constants";
-import { Link } from "react-router-dom";
+import {
+  RelativeRoutingType,
+  useHref,
+  useLinkClickHandler,
+} from "react-router-dom";
 
 export interface Compactable {
   compact?: boolean;
@@ -55,7 +59,7 @@ const CustomButton = styled.button<Compactable>`
           color: ${
             props.color
               ? props.color
-              : `var(--mi-${props.role ?? "primary"}-color)`
+              : `var(--mi-${props.buttonRole ?? "primary"}-color)`
           };
           margin-right: 0;
           margin-left: .3rem;
@@ -70,7 +74,7 @@ const CustomButton = styled.button<Compactable>`
             color: ${
               props.color
                 ? props.color
-                : `var(--mi-${props.role ?? "primary"}-color)`
+                : `var(--mi-${props.buttonRole ?? "primary"}-color)`
             };
           }
         `;
@@ -81,7 +85,7 @@ const CustomButton = styled.button<Compactable>`
           color: ${
             props.color
               ? props.color
-              : `var(--mi-${props.role ?? "primary"}-color)`
+              : `var(--mi-${props.buttonRole ?? "primary"}-color)`
           };
           ${props.compact ? "" : "height: 2.5rem; min-width: 5rem;"}
           border-radius: 9999px !important;
@@ -97,12 +101,12 @@ const CustomButton = styled.button<Compactable>`
             color: ${
               props.color
                 ? props.color
-                : `var(--mi-${props.role ?? "secondary"}-color)`
+                : `var(--mi-${props.buttonRole ?? "secondary"}-color)`
             };
             background-color:  ${
               props.color
                 ? props.color
-                : `var(--mi-${props.role ?? "primary"}-color)`
+                : `var(--mi-${props.buttonRole ?? "primary"}-color)`
             };
           }
 
@@ -121,13 +125,13 @@ const CustomButton = styled.button<Compactable>`
           color: ${
             props.color
               ? props.color
-              : `var(--mi-${props.role ?? "primary"}-color)`
+              : `var(--mi-${props.buttonRole ?? "primary"}-color)`
           };
           background-color: var(--mi-lighten-background-color);
           border: 1px ${props.variant === "dashed" ? "dashed" : "solid"} ${
             props.color
               ? props.color
-              : `var(--mi-${props.role ?? "primary"}-color)`
+              : `var(--mi-${props.buttonRole ?? "primary"}-color)`
           };
           padding: ${props.compact ? ".3rem .5rem" : "1rem"};
           font-weight: bold;
@@ -136,17 +140,17 @@ const CustomButton = styled.button<Compactable>`
             color: ${
               props.color
                 ? props.color
-                : `var(--mi-${props.role ?? "secondary"}-color)`
+                : `var(--mi-${props.buttonRole ?? "secondary"}-color)`
             };
             background-color: ${
               props.color
                 ? props.color
-                : `var(--mi-${props.role ?? "primary"}-color)`
+                : `var(--mi-${props.buttonRole ?? "primary"}-color)`
             };
             border: 1px ${props.variant === "dashed" ? "dashed" : "solid"} ${
               props.color
                 ? props.color
-                : `var(--mi-${props.role ?? "primary"}-color)`
+                : `var(--mi-${props.buttonRole ?? "primary"}-color)`
             };
           }
 
@@ -176,7 +180,7 @@ const CustomButton = styled.button<Compactable>`
           }
           padding: ${props.compact ? ".3rem .5rem" : "1rem"};
           padding: ${props.onlyIcon ? ".5rem .5rem" : ".6rem .6rem"};
-          background-color:  var(--mi-${props.role ?? "secondary"}-color);
+          background-color:  var(--mi-${props.buttonRole ?? "secondary"}-color);
 
           ${
             props.transparent
@@ -184,14 +188,14 @@ const CustomButton = styled.button<Compactable>`
               : ""
           };
           ${props.thin ? "font-weight: normal !important;" : ""};
-          color:  var(--mi-${props.role ?? "primary"}-color);
+          color:  var(--mi-${props.buttonRole ?? "primary"}-color);
           color:  ${
             props.transparent ? "var(--mi-normal-foreground-color)" : ""
           };
 
           &:hover:not(:disabled) {
-            background-color: var(--mi-${props.role ?? "primary"}-color);
-            color: var(--mi-${props.role ?? "secondary"}-color);
+            background-color: var(--mi-${props.buttonRole ?? "primary"}-color);
+            color: var(--mi-${props.buttonRole ?? "secondary"}-color);
           }
           @media screen and (max-width: ${bp.medium}px) {
               ${props.collapsible ? "border-radius: 100%;" : ""}
@@ -244,22 +248,21 @@ const CustomButton = styled.button<Compactable>`
   }
 `;
 
-export interface ButtonProps
-  extends Compactable,
-    React.HTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends Compactable {
   children?: React.ReactNode;
   startIcon?: React.ReactElement;
   endIcon?: React.ReactElement;
   disabled?: boolean;
   style?: React.CSSProperties;
   className?: string;
-  type?: React.ButtonHTMLAttributes<HTMLButtonElement>["type"];
   isLoading?: boolean;
   collapse?: boolean;
   as?: React.ElementType<any, keyof React.JSX.IntrinsicElements>;
 }
 
-export const Button: React.FC<ButtonProps> = ({
+export const Button: React.FC<
+  ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>
+> = ({
   children,
   onClick,
   startIcon,
@@ -307,18 +310,21 @@ export const Button: React.FC<ButtonProps> = ({
   );
 };
 
-const CustomButtonLink = CustomButton.withComponent(
-  // excluding "onlyIcon" here prevents a react warning about an "unknown event handler"
-  ({ onlyIcon, ...props }: Compactable & { to: string }) => <Link {...props} />
-);
-
-export const ButtonLink: React.FC<ButtonProps & { to: string }> = ({
-  ...props
-}) => {
+export const ButtonLink: React.FC<
+  ButtonProps & {
+    to: string;
+    relative?: RelativeRoutingType;
+  } & React.HTMLAttributes<HTMLAnchorElement>
+> = ({ to, relative, ...props }) => {
+  const handleClick = useLinkClickHandler(to, { relative });
+  const href = useHref(to, { relative });
   return (
     <Button
-      // Use the "Link" element from react-router as the base element for the button
-      as={CustomButtonLink}
+      as="a"
+      onClick={handleClick as any}
+      /*
+      // @ts-ignore Because of as="a", we can pass anchor attributes here - the types just don't like it. */
+      href={href}
       {...props}
     />
   );

--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -308,24 +308,25 @@ export const Button: React.FC<
   );
 };
 
+export const ButtonAnchor: React.FC<
+  ButtonProps & React.AnchorHTMLAttributes<HTMLAnchorElement>
+> = ({ ...props }) => {
+  return (
+    /*
+    // @ts-ignore Because of as="a", we can pass anchor attributes here - the types just don't like it. */
+    <Button as="a" {...props} />
+  );
+};
+
 export const ButtonLink: React.FC<
   ButtonProps & {
     to: string;
     relative?: RelativeRoutingType;
-  } & React.HTMLAttributes<HTMLAnchorElement>
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>
 > = ({ to, relative, ...props }) => {
   const handleClick = useLinkClickHandler(to, { relative });
   const href = useHref(to, { relative });
-  return (
-    <Button
-      as="a"
-      onClick={handleClick as any}
-      /*
-      // @ts-ignore Because of as="a", we can pass anchor attributes here - the types just don't like it. */
-      href={href}
-      {...props}
-    />
-  );
+  return <ButtonAnchor onClick={handleClick} href={href} {...props} />;
 };
 
 export default Button;

--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -26,6 +26,7 @@ const CustomButton = styled.button<Compactable>`
   transition: 0.25s background-color, 0.25s color, 0.25s border-radius,
     0.25s filter;
   font-size: 1rem;
+  text-decoration: none;
   line-height: 1rem;
   height: 2rem;
   ${(props) => (props.onlyIcon ? "height: 2rem;" : "")};
@@ -62,6 +63,7 @@ const CustomButton = styled.button<Compactable>`
           padding: 0 !important;
           background-color: transparent !important;
           font-size: inherit;
+          text-decoration: underline;
           line-height: inherit;
 
           &:hover:not(:disabled) {
@@ -89,7 +91,6 @@ const CustomButton = styled.button<Compactable>`
           display: inline-flex;
           line-height: 1rem;
           padding: 1rem;
-          text-decoration: none;
           text-align: center;
 
           &:hover:not(:disabled) {
@@ -306,13 +307,18 @@ export const Button: React.FC<ButtonProps> = ({
   );
 };
 
+const CustomButtonLink = CustomButton.withComponent(
+  // excluding "onlyIcon" here prevents a react warning about an "unknown event handler"
+  ({ onlyIcon, ...props }: Compactable & { to: string }) => <Link {...props} />
+);
+
 export const ButtonLink: React.FC<ButtonProps & { to: string }> = ({
   ...props
 }) => {
   return (
     <Button
       // Use the "Link" element from react-router as the base element for the button
-      as={Link}
+      as={CustomButtonLink}
       {...props}
     />
   );

--- a/client/src/components/common/ClickToPlay.tsx
+++ b/client/src/components/common/ClickToPlay.tsx
@@ -27,7 +27,7 @@ const TrackgroupButtons = styled.div`
   justify-content: flex-end;
   z-index: 2;
 
-  & > :first-of-type {
+  & > div:first-of-type {
     width: 100%;
     flex-grow: 1;
 
@@ -48,7 +48,7 @@ const TrackgroupButtons = styled.div`
   }
 
   @media (max-width: ${bp.large}px) {
-    & > :first-of-type {
+    & > div:first-of-type {
       button {
         height: 2rem;
         font-size: 1rem;
@@ -62,7 +62,7 @@ const TrackgroupButtons = styled.div`
   }
 
   @media (max-width: ${bp.small}px) {
-    & > :first-of-type {
+    & > div:first-of-type {
       display: none;
     }
     button {

--- a/client/src/components/common/LoopButton.tsx
+++ b/client/src/components/common/LoopButton.tsx
@@ -9,13 +9,19 @@ import Button from "./Button";
 const LoopingIndicator = styled.span`
   position: absolute;
   font-size: 0.5rem;
+  line-height: 0.5rem;
   font-weight: bold;
   padding: 0.15rem 0.25rem;
-  background-color: var(--mi-primary-color);
+  background-color: var(--mi-secondary-color);
   border-radius: 100%;
-  color: white;
+  color: var(--mi-primary-color);
   top: 0.2rem;
   right: 0.2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 0.8rem;
+  height: 0.8rem;
 `;
 
 export const LoopButton: React.FC = () => {

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -13,8 +13,8 @@ const styles = `html {
   --mi-lighter-background-color: #fcfcfc;
 
   --mi-normal-foreground-color: var(--mi-black);
-  --mi-light-foreground-color: #555;
-  --mi-lighter-foreground-color: #888;
+  --mi-light-foreground-color: #454545;
+  --mi-lighter-foreground-color: #515151;
 
   --mi-primary-color: var(--mi-black);
   --mi-secondary-color: pink;
@@ -63,8 +63,8 @@ const styles = `html {
     --mi-lighten-background-color: rgba(255, 255, 255, 0.2);
 
     --mi-normal-foreground-color: var(--mi-white);
-    --mi-light-foreground-color: #a0a0a0;
-    --mi-lighter-foreground-color: #707070;
+    --mi-light-foreground-color: #A0A0A0;
+    --mi-lighter-foreground-color: #9E9E9E;
 
     --mi-light-background-color: #222;
     --mi-lighter-background-color: #282828;

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -13,8 +13,8 @@ const styles = `html {
   --mi-lighter-background-color: #fcfcfc;
 
   --mi-normal-foreground-color: var(--mi-black);
-  --mi-light-foreground-color: #888;
-  --mi-lighter-foreground-color: #bbb;
+  --mi-light-foreground-color: #555;
+  --mi-lighter-foreground-color: #888;
 
   --mi-primary-color: var(--mi-black);
   --mi-secondary-color: pink;
@@ -32,7 +32,7 @@ const styles = `html {
   --mi-border-radius-focus: 8px;
 
   --mi-border: solid 1px rgba(125, 125, 125, 0.5);
-  
+
   --header-cover-sticky-height: 55px;
 
   --mi-icon-button-background-color: var(--mi-darken-x-background-color);
@@ -59,10 +59,13 @@ const styles = `html {
 @media (prefers-color-scheme: dark) {
   html {
     --mi-normal-background-color: var(--mi-black);
-    --mi-normal-foreground-color: var(--mi-white);
     --mi-darken-background-color: rgba(0, 0, 0, 0.03);
     --mi-lighten-background-color: rgba(255, 255, 255, 0.2);
-  
+
+    --mi-normal-foreground-color: var(--mi-white);
+    --mi-light-foreground-color: #a0a0a0;
+    --mi-lighter-foreground-color: #707070;
+
     --mi-light-background-color: #222;
     --mi-lighter-background-color: #282828;
 


### PR DESCRIPTION
- Fixes `<Button>` style props being passed through to react-router's `<Link>` component
  * `@emotion/styled` does have the ability to filter out style props from its components, but it doesn't appear to support this when `as={Link}` is used with a component. As a workaround, I've just implemented [the behavior of react-router's `<Link>`](https://github.com/remix-run/react-router/blob/main/packages/react-router-dom/index.tsx#L931) inside of `<ButtonLink>` and used `as="a"` instead.
- Removes unintentional underlines on `<ButtonLink>` components
- Fixes the homepage "Support mirlo" button inheriting a transparent background on light mode
- Fixes the `.buttonRole` style prop not being applied.
  * It seems like the previous implementation set both `color` and `background-color` to the same value - so I'm not sure if I've done this correctly, but it looks fine on the shuffle/repeat/delete artist buttons at the moment.
- Fixed the "add to wishlist" button on `<ClickToPlay>` unexpectedly inheriting styles from `:first-of-type`
- Increased the color contrast for `--mi-light-foreground-color` and `--mi-lighter-foreground-color`.
- Makes the shuffle button's loop indicator not stretch itself into an ellipsis