### PR TITLE
Add @emotion/babel-plugin for style minification and source maps

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -59,6 +59,7 @@
     ]
   },
   "devDependencies": {
+    "@emotion/babel-plugin": "^11.10.5",
     "@optimize-lodash/rollup-plugin": "^4.0.4",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.4.2",

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -7,7 +7,15 @@ import { optimizeLodashImports } from "@optimize-lodash/rollup-plugin";
 
 export default defineConfig({
   base: "/",
-  plugins: [react(), viteTsconfigPaths(), legacy()],
+  plugins: [
+    react({
+      babel: {
+        plugins: ["@emotion/babel-plugin"],
+      },
+    }),
+    viteTsconfigPaths(),
+    legacy(),
+  ],
   server: {
     open: true,
     port: Number(process.env.PORT) || 8080,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,7 +1489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/babel-plugin@npm:^11.11.0":
+"@emotion/babel-plugin@npm:^11.10.5, @emotion/babel-plugin@npm:^11.11.0":
   version: 11.11.0
   resolution: "@emotion/babel-plugin@npm:11.11.0"
   dependencies:
@@ -2338,6 +2338,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mirlo/client@workspace:client"
   dependencies:
+    "@emotion/babel-plugin": "npm:^11.10.5"
     "@emotion/css": "npm:^11.10.5"
     "@emotion/react": "npm:^11.10.5"
     "@emotion/styled": "npm:^11.10.5"


### PR DESCRIPTION
This configures [@emotion/babel-plugin](https://emotion.sh/docs/@emotion/babel-plugin) in Vite, which primarily minifies the CSS styles - saving a few kbs. However, it also generates source maps for the embedded CSS in dev mode, so that they show up in browser dev tools. It also enables support for [using a component as a CSS selector](https://emotion.sh/docs/styled#targeting-another-emotion-component).