### PR TITLE
Post card a11y and excerpt changes

### DIFF
--- a/client/src/components/Artist/Artist.tsx
+++ b/client/src/components/Artist/Artist.tsx
@@ -78,7 +78,9 @@ function Artist() {
         )}
         {(artist?.posts.length ?? 0) > 0 && (
           <li>
-            <NavLink to="posts">{t("updates")}</NavLink>
+            <NavLink to="posts" id="artist-navlink-updates">
+              {t("updates")}
+            </NavLink>
           </li>
         )}
         {canReceivePayments &&

--- a/client/src/components/Artist/ArtistPosts.tsx
+++ b/client/src/components/Artist/ArtistPosts.tsx
@@ -2,21 +2,19 @@ import { css } from "@emotion/css";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { bp } from "../../constants";
-import { Link } from "react-router-dom";
-import Overlay from "components/common/Overlay";
 import PostCard from "components/common/PostCard";
 import { useArtistContext } from "state/ArtistContext";
 import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
 import { FaRss } from "react-icons/fa";
 import Button from "components/common/Button";
 import styled from "@emotion/styled";
-import { getPostURLReference } from "utils/artist";
 
 export const PostGrid = styled.div<{}>`
   display: grid;
   grid-template-columns: repeat(3, 31.6%);
   gap: 4% 2.5%;
   max-width: 100%;
+  list-style-type: none;
 
   @media screen and (max-width: ${bp.large}px) {
     grid-template-columns: repeat(2, 48.75%);
@@ -53,13 +51,6 @@ const ArtistPosts: React.FC = () => {
       </SpaceBetweenDiv>
       <div
         className={css`
-          display: flex;
-          align-items: center;
-
-          a:hover {
-            text-decoration: none;
-          }
-
           @media screen and (max-width: ${bp.medium}px) {
             padding: 0 0 7.5rem 0 !important;
           }
@@ -72,39 +63,11 @@ const ArtistPosts: React.FC = () => {
         >
           {artist.posts?.length === 0 && <>{t("noUpdates")}</>}
         </div>
-        <PostGrid>
+        <PostGrid as="ul">
           {artist.posts?.map((p) => (
-            <Link
-              to={getPostURLReference({ ...p, artist })}
-              className={css`
-                display: flex;
-                border-radius: 10px;
-                background-color: var(--mi-darken-background-color);
-                position: relative;
-                filter: brightness(98%);
-                width: 100%;
-
-                &:hover {
-                  transition: 0.2s ease-in-out;
-                  text-decoration: none;
-                  background-color: rgba(50, 0, 0, 0.07);
-                  filter: brightness(90%);
-                }
-                @media (prefers-color-scheme: dark) {
-                  :hover {
-                    filter: brightness(90%);
-                  }
-                }
-              `}
-            >
-              <Overlay width="100%" height="100%"></Overlay>
-              <PostCard
-                width="100%"
-                height="350px"
-                dateposition="auto"
-                p={{ ...p, artist: artist }}
-              />
-            </Link>
+            <li key={p.id}>
+              <PostCard p={{ ...p, artist: artist }} />
+            </li>
           ))}
         </PostGrid>
       </div>

--- a/client/src/components/Artist/ArtistPosts.tsx
+++ b/client/src/components/Artist/ArtistPosts.tsx
@@ -2,29 +2,11 @@ import { css } from "@emotion/css";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { bp } from "../../constants";
-import PostCard from "components/common/PostCard";
 import { useArtistContext } from "state/ArtistContext";
 import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
 import { FaRss } from "react-icons/fa";
 import { ButtonAnchor } from "components/common/Button";
-import styled from "@emotion/styled";
-
-export const PostGrid = styled.div<{}>`
-  display: grid;
-  grid-template-columns: repeat(3, 31.6%);
-  gap: 4% 2.5%;
-  max-width: 100%;
-  list-style-type: none;
-
-  @media screen and (max-width: ${bp.large}px) {
-    grid-template-columns: repeat(2, 48.75%);
-  }
-
-  @media screen and (max-width: ${bp.medium}px) {
-    grid-template-columns: repeat(1, 100%);
-    gap: 2%;
-  }
-`;
+import PostGrid from "components/Post/PostGrid";
 
 const ArtistPosts: React.FC = () => {
   const { t } = useTranslation("translation", { keyPrefix: "artist" });
@@ -32,6 +14,10 @@ const ArtistPosts: React.FC = () => {
   const {
     state: { artist },
   } = useArtistContext();
+
+  const posts = React.useMemo(() => {
+    return artist?.posts?.map((p) => ({ ...p, artist }));
+  }, [artist]);
 
   if (!artist || artist.posts.length === 0) {
     return null;
@@ -63,13 +49,7 @@ const ArtistPosts: React.FC = () => {
         >
           {artist.posts?.length === 0 && <>{t("noUpdates")}</>}
         </div>
-        <PostGrid as="ul">
-          {artist.posts?.map((p) => (
-            <li key={p.id}>
-              <PostCard p={{ ...p, artist: artist }} />
-            </li>
-          ))}
-        </PostGrid>
+        <PostGrid posts={posts} ariaLabelledBy="artist-navlink-updates" />
       </div>
     </div>
   );

--- a/client/src/components/Artist/ArtistSupport.tsx
+++ b/client/src/components/Artist/ArtistSupport.tsx
@@ -14,7 +14,7 @@ import { useAuthContext } from "state/AuthContext";
 import { useQueryClient } from "@tanstack/react-query";
 import { QUERY_KEY_AUTH, queryKeyIncludes } from "queries/queryKeys";
 
-export const PostGrid = styled.div<{}>`
+const ArtistSupportGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 31.6%);
   gap: 4% 2.5%;
@@ -143,11 +143,11 @@ const ArtistSupport: React.FC = () => {
           {t("noSubscriptionTiersYet")}
         </Box>
       )}
-      <PostGrid>
+      <ArtistSupportGrid>
         {artist.subscriptionTiers
           ?.filter((p) => !p.isDefaultTier)
           .map((p) => <ArtistSupportBox key={p.id} subscriptionTier={p} />)}
-      </PostGrid>
+      </ArtistSupportGrid>
     </>
   );
 };

--- a/client/src/components/Artist/ArtistSupport.tsx
+++ b/client/src/components/Artist/ArtistSupport.tsx
@@ -1,5 +1,6 @@
 import Box from "components/common/Box";
 import React from "react";
+import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 import ArtistManageSubscription from "./ArtistManageSubscription";
@@ -9,10 +10,26 @@ import { bp } from "../../constants";
 import FollowArtist from "components/common/FollowArtist";
 import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
 import { useArtistContext } from "state/ArtistContext";
-import { PostGrid } from "./ArtistPosts";
 import { useAuthContext } from "state/AuthContext";
 import { useQueryClient } from "@tanstack/react-query";
 import { QUERY_KEY_AUTH, queryKeyIncludes } from "queries/queryKeys";
+
+export const PostGrid = styled.div<{}>`
+  display: grid;
+  grid-template-columns: repeat(3, 31.6%);
+  gap: 4% 2.5%;
+  max-width: 100%;
+  list-style-type: none;
+
+  @media screen and (max-width: ${bp.large}px) {
+    grid-template-columns: repeat(2, 48.75%);
+  }
+
+  @media screen and (max-width: ${bp.medium}px) {
+    grid-template-columns: repeat(1, 100%);
+    gap: 2%;
+  }
+`;
 
 const ArtistSupport: React.FC = () => {
   const { user } = useAuthContext();

--- a/client/src/components/Artist/ArtistTrackGroup.tsx
+++ b/client/src/components/Artist/ArtistTrackGroup.tsx
@@ -95,19 +95,18 @@ const ArtistTrackGroup: React.FC<{
                 <Link
                   to={getReleaseUrl(artist, trackGroup)}
                   aria-label={`${t("goToAlbum")}: ${trackGroup.title || t("untitled")}`}
+                  className={
+                    trackGroup.title.length
+                      ? css`
+                          color: var(--mi-normal-foreground-color);
+                        `
+                      : css`
+                          color: var(--mi-light-foreground-color);
+                          font-style: italic;
+                        `
+                  }
                 >
-                  {trackGroup.title.length ? (
-                    trackGroup.title
-                  ) : (
-                    <span
-                      className={css`
-                        color: var(--mi-light-foreground-color);
-                        font-style: italic;
-                      `}
-                    >
-                      {t("untitled")}
-                    </span>
-                  )}
+                  {trackGroup.title.length ? trackGroup.title : t("untitled")}
                 </Link>
               )}
               {artist && (

--- a/client/src/components/Home/Home.tsx
+++ b/client/src/components/Home/Home.tsx
@@ -18,7 +18,7 @@ export const SectionHeader = styled.div<{ userId?: number }>`
   ${(props) =>
     !props.userId ? "top: -0.1rem; padding: .85rem 0 .65rem 0;" : ""}
 
-  h5 {
+  .section-header__heading {
     text-transform: uppercase;
     margin: var(--mi-side-paddings-xsmall);
     font-weight: normal;
@@ -28,14 +28,14 @@ export const SectionHeader = styled.div<{ userId?: number }>`
 
   @media (prefers-color-scheme: dark) {
     background-color: var(--mi-normal-background-color);
-    h5 {
+    .section-header__heading {
       color: pink;
     }
   }
 
   @media screen and (max-width: ${bp.medium}px) {
     top: -0.1rem;
-    h5 {
+    .section-header__heading {
       margin: var(--mi-side-paddings-xsmall);
     }
   }

--- a/client/src/components/Home/HomeReleases.tsx
+++ b/client/src/components/Home/HomeReleases.tsx
@@ -47,7 +47,9 @@ const Releases = () => {
           `}
         >
           <SectionHeader className={bgcolor}>
-            <h5 id={headingId}>{t("recentReleases")}</h5>
+            <h2 className="h5 section-header__heading" id={headingId}>
+              {t("recentReleases")}
+            </h2>
           </SectionHeader>
           <div
             className={css`

--- a/client/src/components/Home/HomeReleases.tsx
+++ b/client/src/components/Home/HomeReleases.tsx
@@ -37,9 +37,6 @@ const Releases = () => {
             padding-bottom: 1rem;
             width: 100%;
 
-            a {
-              color: var(--mi-normal-foreground-color);
-            }
             @media screen and (max-width: ${bp.medium}px) {
               margin-bottom: 0rem;
               padding-top: 0rem;

--- a/client/src/components/Home/Posts.tsx
+++ b/client/src/components/Home/Posts.tsx
@@ -1,12 +1,10 @@
+import React from "react";
 import { css } from "@emotion/css";
 import { SectionHeader } from "./Home";
 import WidthContainer from "components/common/WidthContainer";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
 import PostCard from "components/common/PostCard";
-import Overlay from "components/common/Overlay";
 import { PostGrid } from "components/Artist/ArtistPosts";
-import { getPostURLReference } from "utils/artist";
 import { useQuery } from "@tanstack/react-query";
 import { queryPosts } from "queries";
 
@@ -18,6 +16,9 @@ const Posts = () => {
     return null;
   }
 
+  const id = React.useId();
+  const headingId = `${id}-community-posts`;
+
   return (
     <>
       <WidthContainer variant="big">
@@ -27,7 +28,9 @@ const Posts = () => {
           `}
         >
           <SectionHeader className={css``}>
-            <h5>{t("latestCommunityPost")}</h5>
+            <h2 className="h5 section-header__heading" id={headingId}>
+              {t("latestCommunityPost")}
+            </h2>
           </SectionHeader>
 
           <div
@@ -38,41 +41,11 @@ const Posts = () => {
               }
             `}
           >
-            <PostGrid>
+            <PostGrid as="ul" role="list" aria-labelledby={headingId}>
               {posts?.results?.map((p) => (
-                <Link
-                  to={getPostURLReference(p)}
-                  className={css`
-                    display: flex;
-                    border-radius: 5px;
-                    background-color: var(--mi-darken-background-color);
-                    position: relative;
-                    filter: brightness(98%);
-                    width: 100%;
-                    text-decoration: none;
-
-                    &:hover {
-                      transition: 0.2s ease-in-out;
-                      background-color: rgba(50, 0, 0, 0.07);
-                      filter: brightness(90%);
-                    }
-
-                    @media (prefers-color-scheme: dark) {
-                      &:hover {
-                        filter: brightness(120%);
-                        background-color: rgba(100, 100, 100, 0.2);
-                      }
-                    }
-                  `}
-                >
-                  <Overlay width="100%" height="100%"></Overlay>
-                  <PostCard
-                    width="100%"
-                    height="350px"
-                    dateposition="100%"
-                    p={p}
-                  ></PostCard>
-                </Link>
+                <li key={p.id}>
+                  <PostCard p={p} />
+                </li>
               ))}
             </PostGrid>
           </div>

--- a/client/src/components/Home/Posts.tsx
+++ b/client/src/components/Home/Posts.tsx
@@ -3,10 +3,10 @@ import { css } from "@emotion/css";
 import { SectionHeader } from "./Home";
 import WidthContainer from "components/common/WidthContainer";
 import { useTranslation } from "react-i18next";
-import PostCard from "components/common/PostCard";
-import { PostGrid } from "components/Artist/ArtistPosts";
+import PostCard from "components/Post/PostCard";
 import { useQuery } from "@tanstack/react-query";
 import { queryPosts } from "queries";
+import PostGrid from "components/Post/PostGrid";
 
 const Posts = () => {
   const { t } = useTranslation("translation", { keyPrefix: "home" });
@@ -36,18 +36,9 @@ const Posts = () => {
           <div
             className={css`
               margin: var(--mi-side-paddings-xsmall);
-              a {
-                color: var(--mi-normal-foreground-color);
-              }
             `}
           >
-            <PostGrid as="ul" role="list" aria-labelledby={headingId}>
-              {posts?.results?.map((p) => (
-                <li key={p.id}>
-                  <PostCard p={p} />
-                </li>
-              ))}
-            </PostGrid>
+            <PostGrid posts={posts?.results} ariaLabelledBy={headingId} />
           </div>
         </div>
       </WidthContainer>

--- a/client/src/components/ManageArtist/ArtistFormLinksView.tsx
+++ b/client/src/components/ManageArtist/ArtistFormLinksView.tsx
@@ -33,6 +33,7 @@ const ArtistFormLinksView: React.FC<{
                 display: inline-flex;
                 align-items: center;
                 margin-right: 0.75rem;
+                color: var(--mi-normal-foreground-color);
 
                 > svg {
                   margin-right: 0.5rem;

--- a/client/src/components/ManageArtist/ManageArtistContainer.tsx
+++ b/client/src/components/ManageArtist/ManageArtistContainer.tsx
@@ -46,9 +46,6 @@ export const ArtistPageWrapper: React.FC<{
           padding: 0 2rem 2rem;
           height: 100%;
 
-          a {
-            color: var(--mi-normal-foreground-color);
-          }
           @media screen and (max-width: ${bp.medium}px) {
             padding: 0rem !important;
           }

--- a/client/src/components/Post/PostCard.tsx
+++ b/client/src/components/Post/PostCard.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import styled from "@emotion/styled";
 import { css } from "@emotion/css";
-import Box from "./Box";
+import Box from "components/common/Box";
 import { Link } from "react-router-dom";
 import { getArtistUrl, getPostURLReference } from "utils/artist";
-import MarkdownWrapper from "./MarkdownWrapper";
+import MarkdownWrapper from "components/common/MarkdownWrapper";
 import Overlay from "components/common/Overlay";
 import { getHtmlExcerpt } from "utils/getHtmlExcerpt";
 import { useLinkContainer } from "utils/useLinkContainer";
@@ -126,6 +126,7 @@ const PostCard: React.FC<{
                     css`
                       font-weight: normal;
                       text-align: center;
+                      color: var(--mi-normal-foreground-color);
                     `
                   }
                 >

--- a/client/src/components/Post/PostCard.tsx
+++ b/client/src/components/Post/PostCard.tsx
@@ -9,7 +9,7 @@ import Overlay from "components/common/Overlay";
 import { getHtmlExcerpt } from "utils/getHtmlExcerpt";
 import { useLinkContainer } from "utils/useLinkContainer";
 
-const PostContainer = styled.div`
+const PostContainer = styled.li`
   display: flex;
   border-radius: 5px;
   background-color: var(--mi-darken-background-color);

--- a/client/src/components/Post/PostGrid.tsx
+++ b/client/src/components/Post/PostGrid.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { bp } from "../../constants";
+import PostCard from "./PostCard";
+
+const PostGridWrapper = styled.ul<{}>`
+  display: grid;
+  grid-template-columns: repeat(3, 31.6%);
+  gap: 4% 2.5%;
+  max-width: 100%;
+  list-style-type: none;
+
+  @media screen and (max-width: ${bp.large}px) {
+    grid-template-columns: repeat(2, 48.75%);
+  }
+
+  @media screen and (max-width: ${bp.medium}px) {
+    grid-template-columns: repeat(1, 100%);
+    gap: 2%;
+  }
+`;
+
+interface PostGridProps {
+  posts?: Post[];
+  ariaLabelledBy: string;
+}
+
+export default function PostGrid(props: PostGridProps) {
+  return (
+    <PostGridWrapper role="list" aria-labelledby={props.ariaLabelledBy}>
+      {props.posts?.map((post) => <PostCard key={post.id} p={post} />)}
+    </PostGridWrapper>
+  );
+}

--- a/client/src/components/Releases.tsx
+++ b/client/src/components/Releases.tsx
@@ -45,9 +45,6 @@ const Releases = () => {
   return (
     <div
       className={css`
-        a {
-          color: var(--mi-normal-foreground-color);
-        }
         @media screen and (max-width: ${bp.medium}px) {
           margin-bottom: 0rem;
         }

--- a/client/src/components/Releases.tsx
+++ b/client/src/components/Releases.tsx
@@ -55,7 +55,7 @@ const Releases = () => {
     >
       <SectionHeader>
         <WidthContainer variant="big" justify="center">
-          <h5 id={headingId}>
+          <h1 className="h5 section-header__heading" id={headingId}>
             {tag ? (
               <Trans
                 t={t}
@@ -66,7 +66,7 @@ const Releases = () => {
             ) : (
               t("recentReleases")
             )}
-          </h5>
+          </h1>
         </WidthContainer>
       </SectionHeader>
       <div

--- a/client/src/components/common/Overlay.tsx
+++ b/client/src/components/common/Overlay.tsx
@@ -22,6 +22,7 @@ const Overlay: React.FC<{
       rgba(0, 0, 0, 0) 30%,
       rgba(0, 0, 0, 0) 100%
     );
+    pointer-events: none;
 
     :hover {
       transition: 0.2s ease-in-out;

--- a/client/src/components/common/PostCard.tsx
+++ b/client/src/components/common/PostCard.tsx
@@ -1,103 +1,135 @@
+import styled from "@emotion/styled";
 import { css } from "@emotion/css";
 import Box from "./Box";
 import { Link } from "react-router-dom";
 import { getArtistUrl, getPostURLReference } from "utils/artist";
 import parse from "html-react-parser";
 import MarkdownWrapper from "./MarkdownWrapper";
+import Overlay from "components/common/Overlay";
+
+const PostContainer = styled.div`
+  display: flex;
+  border-radius: 5px;
+  background-color: var(--mi-darken-background-color);
+  position: relative;
+  filter: brightness(98%);
+  width: 100%;
+  text-decoration: none;
+
+  &:hover {
+    transition: 0.2s ease-in-out;
+    background-color: rgba(50, 0, 0, 0.07);
+    filter: brightness(90%);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    &:hover {
+      filter: brightness(120%);
+      background-color: rgba(100, 100, 100, 0.2);
+    }
+  }
+`;
+
+const LinkOverlay = styled(Link)`
+  display: flex;
+  justify-content: center;
+  position: absolute;
+  z-index: 2;
+  text-align: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  text-decoration: none;
+  text-transform: uppercase;
+  font-size: var(--mi-font-size-small);
+`;
 
 const PostCard: React.FC<{
-  height: string;
-  width: string;
-  dateposition: string;
   p: Post;
-}> = ({ height, width, dateposition, p }) => {
+}> = ({ p }) => {
+  const postUrl = getPostURLReference(p);
+
   return (
-    <Box
-      key={p.id}
-      className={css`
-        height: ${height};
-        width: ${width} !important;
-        border: solid 1px transparent;
-        margin-bottom: 0 !important;
-        overflow: hidden;
-        padding: 0 !important;
-        justify-content: space-between;
-
-        a {
-          text-decoration: none;
-        }
-
-        @media (prefers-color-scheme: dark) {
-          background-color: var(--mi-normal-background-color);
-        }
-      `}
-    >
-      <div
+    <PostContainer>
+      <LinkOverlay to={postUrl} aria-hidden tabIndex={-1} />
+      <Overlay width="100%" height="100%"></Overlay>
+      <Box
+        key={p.id}
         className={css`
-          padding: 1.5rem;
-          margin: 0;
-          width: 100%;
+          height: 350px;
+          width: 100% !important;
+          border: solid 1px transparent;
+          margin-bottom: 0 !important;
           overflow: hidden;
-          transition: 0.2s ease-in-out;
+          padding: 0 !important;
+          justify-content: space-between;
+
+          @media (prefers-color-scheme: dark) {
+            background-color: var(--mi-normal-background-color);
+          }
         `}
       >
-        {p.artist && (
-          <div
-            className={css`
-              padding-bottom: 2rem;
-            `}
-          >
-            <div
-              className={css`
-                white-space: nowrap;
-                width: 90%;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                padding-right: 3rem;
-                position: absolute;
-                z-index: +1;
-              `}
-            >
-              by <Link to={getArtistUrl(p.artist)}>{p.artist?.name}</Link>
-            </div>
-          </div>
-        )}
         <div
           className={css`
+            padding: 1.5rem;
+            margin: 0;
             width: 100%;
+            overflow: hidden;
+            transition: 0.2s ease-in-out;
           `}
         >
+          {p.artist && (
+            <div
+              className={css`
+                padding-bottom: 2rem;
+              `}
+            >
+              <p
+                className={css`
+                  white-space: nowrap;
+                  width: 90%;
+                  text-overflow: ellipsis;
+                  padding-right: 3rem;
+                  position: absolute;
+                  z-index: 3;
+                `}
+              >
+                by <Link to={getArtistUrl(p.artist)}>{p.artist?.name}</Link>
+              </p>
+            </div>
+          )}
           <div
             className={css`
-              display: flex;
-              justify-content: space-between;
-              align-items: center;
-              flex-wrap: wrap;
+              width: 100%;
               margin-bottom: 0.5rem;
             `}
           >
-            <h4
-              className={css`
-                padding-bottom: 0.3rem;
-                text-align: left;
-              `}
+            <h3
+              className={
+                "h4 " +
+                css`
+                  padding-bottom: 0.3rem;
+                  text-align: left;
+                `
+              }
             >
               {p.artist && (
                 <Link
-                  to={getPostURLReference(p)}
+                  to={postUrl}
                   className={css`
                     font-weight: normal;
                     text-align: center;
+                    z-index: 3;
+                    text-decoration: none;
                   `}
                 >
                   {p.title}
                 </Link>
               )}
-            </h4>
-            <span
+            </h3>
+            <p
               className={css`
-                color: grey;
-                width: ${dateposition};
+                color: var(--mi-light-foreground-color);
                 text-transform: uppercase;
                 font-size: var(--mi-font-size-small);
               `}
@@ -107,31 +139,31 @@ const PostCard: React.FC<{
                 month: "short",
                 day: "numeric",
               })}
+            </p>
+          </div>
+          <div
+            className={css`
+              width: 100%;
+            `}
+          >
+            <span
+              className={css`
+                display: block;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                color: var(--mi-normal-foreground-color);
+
+                iframe {
+                  width: auto !important;
+                }
+              `}
+            >
+              <MarkdownWrapper>{parse(p.content)}</MarkdownWrapper>
             </span>
           </div>
         </div>
-        <div
-          className={css`
-            width: 100%;
-          `}
-        >
-          <span
-            className={css`
-              display: block;
-              overflow: hidden;
-              text-overflow: ellipsis;
-              color: var(--mi-normal-foreground-color);
-
-              iframe {
-                width: auto !important;
-              }
-            `}
-          >
-            <MarkdownWrapper>{parse(p.content)}</MarkdownWrapper>
-          </span>
-        </div>
-      </div>
-    </Box>
+      </Box>
+    </PostContainer>
   );
 };
 export default PostCard;

--- a/client/src/components/common/PostCard.tsx
+++ b/client/src/components/common/PostCard.tsx
@@ -7,6 +7,7 @@ import { getArtistUrl, getPostURLReference } from "utils/artist";
 import MarkdownWrapper from "./MarkdownWrapper";
 import Overlay from "components/common/Overlay";
 import { getHtmlExcerpt } from "utils/getHtmlExcerpt";
+import { useLinkContainer } from "utils/useLinkContainer";
 
 const PostContainer = styled.div`
   display: flex;
@@ -15,12 +16,24 @@ const PostContainer = styled.div`
   position: relative;
   filter: brightness(98%);
   width: 100%;
-  text-decoration: none;
+  cursor: pointer;
+
+  .post-container__link {
+    text-decoration: none;
+  }
 
   &:hover {
     transition: 0.2s ease-in-out;
     background-color: rgba(50, 0, 0, 0.07);
     filter: brightness(90%);
+
+    .post-container__link {
+      text-decoration: underline;
+    }
+  }
+
+  &:focus-within {
+    outline: 1px solid var(--mi-normal-foreground-color);
   }
 
   @media (prefers-color-scheme: dark) {
@@ -31,29 +44,15 @@ const PostContainer = styled.div`
   }
 `;
 
-const LinkOverlay = styled(Link)`
-  display: flex;
-  justify-content: center;
-  position: absolute;
-  z-index: 2;
-  text-align: center;
-  align-items: center;
-  width: 100%;
-  height: 100%;
-  text-decoration: none;
-  text-transform: uppercase;
-  font-size: var(--mi-font-size-small);
-`;
-
 const PostCard: React.FC<{
   p: Post;
 }> = ({ p }) => {
   const postUrl = getPostURLReference(p);
   const excerpt = React.useMemo(() => getHtmlExcerpt(p.content), [p.content]);
+  const postContainerProps = useLinkContainer({ to: postUrl });
 
   return (
-    <PostContainer>
-      <LinkOverlay to={postUrl} aria-hidden tabIndex={-1} />
+    <PostContainer {...postContainerProps}>
       <Overlay width="100%" height="100%"></Overlay>
       <Box
         key={p.id}
@@ -93,7 +92,6 @@ const PostCard: React.FC<{
                   text-overflow: ellipsis;
                   padding-right: 3rem;
                   position: absolute;
-                  z-index: 3;
                 `}
               >
                 by <Link to={getArtistUrl(p.artist)}>{p.artist?.name}</Link>
@@ -118,12 +116,13 @@ const PostCard: React.FC<{
               {p.artist && (
                 <Link
                   to={postUrl}
-                  className={css`
-                    font-weight: normal;
-                    text-align: center;
-                    z-index: 3;
-                    text-decoration: none;
-                  `}
+                  className={
+                    "post-container__link " +
+                    css`
+                      font-weight: normal;
+                      text-align: center;
+                    `
+                  }
                 >
                   {p.title}
                 </Link>

--- a/client/src/components/common/PostCard.tsx
+++ b/client/src/components/common/PostCard.tsx
@@ -48,8 +48,13 @@ const PostCard: React.FC<{
   p: Post;
 }> = ({ p }) => {
   const postUrl = getPostURLReference(p);
-  const excerpt = React.useMemo(() => getHtmlExcerpt(p.content), [p.content]);
   const postContainerProps = useLinkContainer({ to: postUrl });
+
+  // Use the first 8 paragraphs of the post as an unformatted excerpt
+  const excerpt = React.useMemo(
+    () => getHtmlExcerpt(p.content).slice(0, 8),
+    [p.content]
+  );
 
   return (
     <PostContainer {...postContainerProps}>

--- a/client/src/components/common/PostCard.tsx
+++ b/client/src/components/common/PostCard.tsx
@@ -1,11 +1,12 @@
+import React from "react";
 import styled from "@emotion/styled";
 import { css } from "@emotion/css";
 import Box from "./Box";
 import { Link } from "react-router-dom";
 import { getArtistUrl, getPostURLReference } from "utils/artist";
-import parse from "html-react-parser";
 import MarkdownWrapper from "./MarkdownWrapper";
 import Overlay from "components/common/Overlay";
+import { getHtmlExcerpt } from "utils/getHtmlExcerpt";
 
 const PostContainer = styled.div`
   display: flex;
@@ -48,6 +49,7 @@ const PostCard: React.FC<{
   p: Post;
 }> = ({ p }) => {
   const postUrl = getPostURLReference(p);
+  const excerpt = React.useMemo(() => getHtmlExcerpt(p.content), [p.content]);
 
   return (
     <PostContainer>
@@ -152,13 +154,13 @@ const PostCard: React.FC<{
                 overflow: hidden;
                 text-overflow: ellipsis;
                 color: var(--mi-normal-foreground-color);
-
-                iframe {
-                  width: auto !important;
-                }
               `}
             >
-              <MarkdownWrapper>{parse(p.content)}</MarkdownWrapper>
+              <MarkdownWrapper>
+                {excerpt.map((text, i) => (
+                  <p key={i}>{text}</p>
+                ))}
+              </MarkdownWrapper>
             </span>
           </div>
         </div>

--- a/client/src/components/common/Tabs.tsx
+++ b/client/src/components/common/Tabs.tsx
@@ -18,6 +18,7 @@ const Tabs = styled.ul`
       font-size: 1.2rem;
       transition: 0.1s border-bottom;
       border-bottom: 4px solid transparent;
+      color: var(--mi-normal-foreground-color);
 
       @media screen and (max-width: ${bp.medium}px) {
         padding: 0rem 0.25rem calc(0.9rem - 4px) 0.25rem;

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -95,58 +95,67 @@ body, root {
   background-color: transparent;
 }
 
-h1 {
+h1, .h1 {
   font-size: 2.5rem;
   line-height: 3rem;
   font-weight: normal;
+  margin-bottom: unset;
 
   a {
     text-decoration: none;
   }
 }
 
-h2 {
+h2, .h2 {
   font-size: 1.5rem;
   line-height: 1.8rem;
   font-weight: normal;
   margin-bottom: .7rem;
 }
 
-h3 {
+h3, .h3 {
   font-size: 1.4rem;
+  line-height: unset;
   font-weight: bold;
+  margin-bottom: unset;
 }
 
-h4 {
+h4, .h4 {
   font-size: 1.3rem;
+  line-height: unset;
   padding-bottom: .75rem;
+  margin-bottom: unset;
 }
 
-h5 {
+h5, .h5 {
   font-size: 1.2rem;
+  line-height: unset;
   padding-bottom: .75rem;
+  margin-bottom: unset;
 }
 
-h6 {
+h6, .h6 {
   font-size: 1.1rem;
+  line-height: unset;
   padding-bottom: .75rem;
+  margin-bottom: unset;
 }
 
 @media (max-width: 768px) {
-  h1 {
+  h1, .h1 {
     font-size: 2rem;
     line-height: 2.5rem;
   }
 
-  h2 {
+  h2, .h2 {
     font-size: 1.3rem;
     margin-bottom: .5rem;
   }
-  h3 {
+  h3, .h3 {
     font-size: 1.2rem;
     padding-bottom: 1rem;
   }
-  h4 {
+  h4, .h4 {
     font-size: 1.3rem;
     padding-bottom: .75rem;
   }
@@ -155,7 +164,7 @@ h6 {
   html {
     font-size: 16px;
   }
-  h5 {
+  h5, .h5 {
     font-size: 1rem;
     margin-bottom: 0rem;
   }

--- a/client/src/utils/getHtmlExcerpt.ts
+++ b/client/src/utils/getHtmlExcerpt.ts
@@ -1,0 +1,60 @@
+/**
+ * Recursively visits all nodes in a DOM tree until one of:
+ * - all nodes have been visited
+ * - the callback returns false
+ *
+ * This is roughly similar to unist-util-visit:
+ * https://github.com/syntax-tree/unist-util-visit
+ *
+ * The filter() function decides which nodes the callback is invoked on.
+ *
+ * The callback() returns one of three cases:
+ * - `true` continues recursion into the current node
+ * - `undefined` skips the current node and continues recursion
+ * - `false` immediately stops all recursion and returns
+ */
+function visit<E extends Node>(
+  node: Node,
+  filter: (node: Node) => node is E,
+  callback: (node: E, index: number, parent: Node) => boolean | void
+): boolean {
+  for (const [childIndex, childNode] of node.childNodes.entries()) {
+    let shouldRecurse = filter(childNode)
+      ? callback(childNode, childIndex, node)
+      : true;
+
+    if (shouldRecurse === undefined) continue;
+    if (shouldRecurse === false) return false;
+    if (!visit(childNode, filter, callback)) return false;
+  }
+
+  return true;
+}
+
+const isElementNode = (node: Node): node is Element =>
+  node.nodeType === Node.ELEMENT_NODE;
+
+const EXCERPT_TAGS = ["H1", "H2", "H3", "H4", "H5", "H6", "P"];
+
+/**
+ * Parses the provided [htmlStr] using DOMParser and returns a list of strings
+ * for each node with text content in the document.
+ */
+export function getHtmlExcerpt(htmlStr: string): string[] {
+  // This *evaluates* htmlStr into a document, but should not execute any script content (unless the resulting nodes are placed in the DOM)
+  // - since this function only returns .textContent, it should avoid any XSS opportunities
+  const htmlDocument = new DOMParser().parseFromString(htmlStr, "text/html");
+  const ret: string[] = [];
+
+  visit(htmlDocument.body, isElementNode, (el) => {
+    if (EXCERPT_TAGS.includes(el.tagName)) {
+      const textContent = el.textContent;
+      if (textContent) ret.push(textContent);
+      return undefined;
+    } else {
+      return true;
+    }
+  });
+
+  return ret;
+}

--- a/client/src/utils/useLinkContainer.ts
+++ b/client/src/utils/useLinkContainer.ts
@@ -1,0 +1,133 @@
+import React from "react";
+import { useHref, useLinkClickHandler } from "react-router-dom";
+
+function isNestedElement(e: React.MouseEvent) {
+  // if the targeted element is nested inside another clickable anchor/button
+  let target = e.target as HTMLElement;
+  while (target !== e.currentTarget) {
+    if (
+      target.tagName.toLowerCase() === "a" ||
+      target.tagName.toLowerCase() === "button"
+    )
+      return true;
+
+    if (target.parentElement) target = target.parentElement;
+    else break;
+  }
+  return false;
+}
+
+/**
+ * This allows items like cards to bind a click event to navigate to a path.
+ *
+ * Handles:
+ * - Left clicks
+ * - Middle clicks
+ * - Ctrl + Left clicks
+ * - Shift + Left clicks
+ * - Meta + Left clicks
+ *
+ *
+ * Ignores:
+ * - Right clicks (used for context menus)
+ * - Alt clicks (used for downloading)
+ * - Clicks where text is selected within the node
+ * - Default prevented events
+ * - Nested <a> tags and <button>s
+ */
+export function useHrefContainer(props: {
+  href?: string;
+  navigate?: (e: React.MouseEvent) => void;
+}) {
+  const navigate = React.useCallback(
+    props.navigate ??
+      (() => {
+        if (props.href) window.location.href = props.href;
+      }),
+    [props.navigate, props.href]
+  );
+
+  // Handle middle click button - should open a new tab (cannot be detected via "click" event)
+  // - prefer the "auxclick" event for this, since it ensures that mousedown/mouseup both occur within the same element
+  //   otherwise, using "mouseup" would activate on mouseup even when dragging between elements, which should not trigger a click
+  const onAuxClick = React.useCallback(
+    (e: React.MouseEvent) => {
+      // only handle middle click events
+      if (e.button !== 1) return;
+
+      if (e.defaultPrevented) return;
+      if (isNestedElement(e)) return;
+
+      e.preventDefault();
+      if (props.href) window.open(props.href, "_blank");
+      return false;
+    },
+    [props.href]
+  );
+
+  const onClick = React.useCallback(
+    (e: React.MouseEvent) => {
+      if (e.defaultPrevented) return;
+      if (isNestedElement(e)) return;
+
+      // only handle left click events
+      if (e.button !== 0) return;
+      // Download
+      if (e.altKey) return;
+
+      e.preventDefault();
+
+      // Open in new tab
+      if (e.metaKey || e.ctrlKey || e.shiftKey) {
+        if (props.href) window.open(props.href, "_blank");
+        return false;
+      }
+
+      // If text is selected, don't activate on mouseup (but ctrl+click should still work)
+      const selection = window.getSelection();
+      if (
+        selection?.toString()?.length &&
+        selection.containsNode(e.target as Node, true)
+      )
+        return;
+
+      navigate(e);
+    },
+    [props.href, navigate]
+  );
+
+  const onMouseDown = React.useCallback((e: React.MouseEvent) => {
+    const isMiddleClick = e.button === 1;
+    if (!isMiddleClick) return;
+    if (e.defaultPrevented) return;
+    if (isNestedElement(e)) return;
+    e.preventDefault();
+  }, []);
+
+  // implement the AuxClick event using MouseUp (only on browsers that don't support auxclick; i.e. safari)
+  const onMouseUp = React.useCallback(
+    (e: React.MouseEvent) => {
+      // if auxclick is supported, do nothing
+      if (e.currentTarget && "onauxclick" in e.currentTarget) return;
+      // otherwise, pass mouseup events to auxclick
+      onAuxClick(e);
+    },
+    [onAuxClick]
+  );
+
+  return {
+    onAuxClick,
+    onClick,
+    onMouseDown,
+    onMouseUp,
+  };
+}
+
+export function useLinkContainer(props: { to: string }) {
+  const href = useHref(props.to);
+  const handleClick = useLinkClickHandler(props.to);
+  return useHrefContainer({
+    href,
+    navigate: handleClick as (e: React.MouseEvent) => void,
+  });
+}


### PR DESCRIPTION
This PR makes a few changes to post cards:
- Removes the wrapping `<a>` tag, and replaces it with `useLinkContainer` to handle click events
  * These mimic the behavior of a link for ctrl+click, middle click, and other mouse interactions, without actually involving an `<a>` element (which otherwise involves working with z-index, and prevents text selection from working as expected)
  * This is mostly reused from [unicorn-utterances/href-container-script.ts](https://github.com/unicorn-utterances/unicorn-utterances/blob/main/src/utils/href-container-script.ts)
- Moved some shared structure between the artist "Updates" page and homepage into the `<PostCard>` component
  * Consequently, the styling of the post cards in these locations is now the same.
- Added a `getHtmlExcerpt` utility to roughly parse out any text content from the post HTML
  * This means that the post excerpts only contain a text summary of the first 8 lines/paragraphs of a post.
  * Previously, tabbable/interactive nodes and headings were included in this preview, which created a lot of items to tab through for longer posts when the entire content is in the DOM.
  * However, this does prevent any formatting (bold, italics, blockquotes, images, etc.) from appearing in the post cards.

And on heading elements:
- Changed section headings to h2 so that the homepage heading levels are in sequential order
- Added `.h1`-`.h6` classes in addition to the element styles that can be used to visually set the heading size without changing the element