### PR TITLE
Add configuration for `docker compose --profile=test watch`

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -72,6 +72,11 @@ services:
     command: yarn api:test
     restart: no
     profiles: [test]
+    develop:
+      watch:
+        - action: sync+restart
+          path: ./test
+          target: /var/www/api/test
 
 networks:
   test-network:

--- a/test/README.md
+++ b/test/README.md
@@ -7,6 +7,8 @@ docker compose run test
 ```
 
 > Note: you'll need to recreate the container between each run if you're making changes. You can do so with `docker compose --profile=test run --build test`
+>
+> You can also use `docker compose --profile=test watch` to rerun tests on changes - but you'll need to run `docker compose --profile=test logs -f` separately in order to see the log output.
 
 To clean up these containers afterwards, the `--profile=test` argument needs to be passed to docker:
 


### PR DESCRIPTION
This adds configuration for watching the test dir to automatically rebuild the test containers when changes are made.

With this, `docker compose --profile=test watch` will also pick up changes in the `./test` directory and rerun tests when they occur.