### PR TITLE
New variable to customize upload prompt description per image type

### DIFF
--- a/client/src/components/ManageArtist/AlbumFormComponents/AlbumFormContent.tsx
+++ b/client/src/components/ManageArtist/AlbumFormComponents/AlbumFormContent.tsx
@@ -44,6 +44,7 @@ const AlbumFormContent: React.FC<{
         )}
         {existingObject && (
           <UploadArtistImage
+            imagetypedescription="an album cover"
             existing={existingObject}
             imageType="cover"
             height="400"

--- a/client/src/components/ManageArtist/AlbumFormComponents/AlbumFormContent.tsx
+++ b/client/src/components/ManageArtist/AlbumFormComponents/AlbumFormContent.tsx
@@ -44,7 +44,7 @@ const AlbumFormContent: React.FC<{
         )}
         {existingObject && (
           <UploadArtistImage
-            imagetypedescription="an album cover"
+            imageTypeDescription="an album cover"
             existing={existingObject}
             imageType="cover"
             height="400"

--- a/client/src/components/ManageArtist/ArtistForm.tsx
+++ b/client/src/components/ManageArtist/ArtistForm.tsx
@@ -14,11 +14,26 @@ import ArtistFormColors from "./ArtistFormColors";
 import ArtistSlugInput from "./ArtistSlugInput";
 import { useCreateArtistMutation, useUpdateArtistMutation } from "queries";
 import { useAuthContext } from "state/AuthContext";
+import styled from "@emotion/styled";
 
 export interface ShareableTrackgroup {
   creatorId: number;
   slug: string;
 }
+
+export const ArtistFormSection = styled.div<{ isOdd?: boolean }>`
+  display: flex;
+  padding: 2rem !important;
+  margin-bottom: 1rem;
+  ${(props) =>
+    !props.isOdd ? "background: var(--mi-lighten-background-color);" : ""}
+  gap: 0;
+
+  @media (max-width: ${bp.medium}px) {
+    flex-direction: column;
+    padding: 1rem !important;
+  }
+`;
 
 type FormData = {
   name: string;
@@ -118,83 +133,172 @@ export const ArtistForm: React.FC<{
 
   return (
     <Modal
+      noPadding
       open={open}
       onClose={onClose}
       title={existing ? "Edit artist" : "Create an artist"}
+      className={css`
+        div:nth-child(1) {
+          margin-bottom: 0;
+        }
+      `}
     >
-      <div
-        className={css`
-          margin-top: 0.5rem;
-        `}
-      >
+      <div>
         <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onValidSubmit)}>
-            <div
-              className={css`
-                display: flex;
-                margin-bottom: 1rem;
-              `}
-            >
-              <div
+            <div>
+              <ArtistFormSection
                 className={css`
-                  flex: 50%;
+                  display: grid !important;
+                  grid-template-columns: repeat(5, 1fr);
+                  grid-template-rows: repeat(3, 1fr);
+                  grid-gap: 5% !important;
                   @media (max-width: ${bp.medium}px) {
-                    flex-direction: column;
+                    grid-template-rows: repeat(10, 0.25fr);
+                    row-gap: 0 !important;
                   }
                 `}
               >
-                {existing && (
-                  <UploadArtistImage
-                    existing={existing}
-                    imageTypeDescription="a background image"
-                    imageType="banner"
-                    height="auto"
-                    width="100%"
-                    maxDimensions="2500x2500"
-                  />
-                )}
-              </div>
+                <div
+                  className={css`
+                    grid-column: 1 / 3;
+                    grid-row: 1 / 5;
+                    @media (max-width: ${bp.medium}px) {
+                      grid-column: 1 / 3;
+                      grid-row: 1 / 5;
+                      input {
+                        display: none;
+                      }
+                    }
+                  `}
+                >
+                  <FormComponent>
+                    {existing && (
+                      <UploadArtistImage
+                        existing={existing}
+                        imageTypeDescription="your avatar"
+                        imageType="avatar"
+                        height="auto"
+                        width="100%"
+                        maxDimensions="1500x1500"
+                      />
+                    )}
+                  </FormComponent>
+                </div>
 
-              <div
+                <div
+                  className={css`
+                    padding-bottom: 1rem;
+                    grid-column: 3 / 6;
+                    grid-row: 1;
+                    @media (max-width: ${bp.medium}px) {
+                      grid-row: 2;
+                    }
+                  `}
+                >
+                  <FormComponent>
+                    <label>{t("displayName")} </label>
+                    <InputEl
+                      {...register("name", { required: true })}
+                      className={css`
+                        font-size: 1.5rem !important;
+                        @media (max-width: ${bp.medium}px) {
+                          font-size: 1rem !important;
+                        }
+                      `}
+                    />
+                  </FormComponent>
+                </div>
+
+                <div
+                  className={css`
+                    grid-column: 3 / 6;
+                    grid-row: 2 / 5;
+                    @media (max-width: ${bp.medium}px) {
+                      grid-column: 1 / 6;
+                      grid-row: 6 / 11;
+                    }
+                  `}
+                >
+                  <FormComponent>
+                    <label>{t("bio")}</label>
+                    <TextArea {...register("bio")} rows={7} />
+                  </FormComponent>
+                </div>
+              </ArtistFormSection>
+              <ArtistFormSection isOdd>
+                <div
+                  className={css`
+                    display: flex;
+                    width: 100%;
+                    margin-bottom: 1rem;
+                    gap: 5%;
+                    @media (max-width: ${bp.medium}px) {
+                      flex-direction: column;
+                    }
+                  `}
+                >
+                  <div
+                    className={css`
+                      flex: 35%;
+                      flex-direction: column;
+                    `}
+                  >
+                    <FormComponent>
+                      {existing && <ArtistFormColors />}
+                    </FormComponent>
+                  </div>
+                  <div
+                    className={css`
+                      flex: 55%;
+                      @media (max-width: ${bp.medium}px) {
+                        flex-direction: column;
+                      }
+                    `}
+                  >
+                    <FormComponent>
+                      <label>Background Image</label>
+                      {existing && (
+                        <UploadArtistImage
+                          existing={existing}
+                          imageTypeDescription="a background image"
+                          imageType="banner"
+                          height="auto"
+                          width="100%"
+                          maxDimensions="2500x2500"
+                        />
+                      )}
+                    </FormComponent>
+                  </div>
+                </div>
+              </ArtistFormSection>
+
+              <ArtistFormSection>
+                <FormComponent
+                  className={css`
+                    width: 100%;
+                  `}
+                >
+                  <label>{t("urlSlug")} </label>
+                  <ArtistSlugInput currentArtistId={existingId} />
+                </FormComponent>
+              </ArtistFormSection>
+
+              <ArtistFormSection
+                isOdd
                 className={css`
-                  flex: 50%;
-                  margin-left: 1rem;
+                  margin-bottom: 0 !important;
                 `}
               >
-                {existing && (
-                  <UploadArtistImage
-                    existing={existing}
-                    imageTypeDescription="your avatar"
-                    imageType="avatar"
-                    height="auto"
-                    width="100%"
-                    maxDimensions="1500x1500"
-                  />
-                )}
-              </div>
-            </div>
-
-            <div>
-              <FormComponent>
-                <label>{t("displayName")} </label>
-                <InputEl {...register("name", { required: true })} />
-              </FormComponent>
-
-              <FormComponent>{existing && <ArtistFormColors />}</FormComponent>
-
-              <FormComponent>
-                <label>{t("urlSlug")} </label>
-                <ArtistSlugInput currentArtistId={existingId} />
-              </FormComponent>
-
-              <FormComponent>
-                <label>{t("bio")}</label>
-                <TextArea {...register("bio")} rows={7} />
-              </FormComponent>
-
-              <Button type="submit" disabled={isPending} isLoading={isPending}>
-                {existing ? t("saveArtist") : t("createArtist")}
-              </Button>
+                <Button
+                  type="submit"
+                  variant="big"
+                  disabled={isPending}
+                  isLoading={isPending}
+                >
+                  {existing ? t("saveArtist") : t("createArtist")}
+                </Button>
+              </ArtistFormSection>
             </div>
           </form>
         </FormProvider>

--- a/client/src/components/ManageArtist/ArtistForm.tsx
+++ b/client/src/components/ManageArtist/ArtistForm.tsx
@@ -33,6 +33,9 @@ export const ArtistFormSection = styled.div<{ isOdd?: boolean }>`
     flex-direction: column;
     padding: 1rem !important;
   }
+  @media (prefers-color-scheme: dark) {
+    ${(props) => (!props.isOdd ? "background: rgba(125, 125, 125, 0.1);" : "")}
+  }
 `;
 
 type FormData = {

--- a/client/src/components/ManageArtist/ArtistForm.tsx
+++ b/client/src/components/ManageArtist/ArtistForm.tsx
@@ -256,6 +256,7 @@ export const ArtistForm: React.FC<{
                       flex: 55%;
                       @media (max-width: ${bp.medium}px) {
                         flex-direction: column;
+                        padding-bottom: 2rem !important;
                       }
                     `}
                   >

--- a/client/src/components/ManageArtist/ArtistForm.tsx
+++ b/client/src/components/ManageArtist/ArtistForm.tsx
@@ -146,7 +146,7 @@ export const ArtistForm: React.FC<{
                 {existing && (
                   <UploadArtistImage
                     existing={existing}
-                    imagetypedescription="a background image"
+                    imageTypeDescription="a background image"
                     imageType="banner"
                     height="auto"
                     width="100%"
@@ -164,7 +164,7 @@ export const ArtistForm: React.FC<{
                 {existing && (
                   <UploadArtistImage
                     existing={existing}
-                    imagetypedescription="your avatar"
+                    imageTypeDescription="your avatar"
                     imageType="avatar"
                     height="auto"
                     width="100%"

--- a/client/src/components/ManageArtist/ArtistForm.tsx
+++ b/client/src/components/ManageArtist/ArtistForm.tsx
@@ -146,6 +146,7 @@ export const ArtistForm: React.FC<{
                 {existing && (
                   <UploadArtistImage
                     existing={existing}
+                    imagetypedescription="a background image"
                     imageType="banner"
                     height="auto"
                     width="100%"
@@ -163,6 +164,7 @@ export const ArtistForm: React.FC<{
                 {existing && (
                   <UploadArtistImage
                     existing={existing}
+                    imagetypedescription="your avatar"
                     imageType="avatar"
                     height="auto"
                     width="100%"

--- a/client/src/components/ManageArtist/ArtistFormColors.tsx
+++ b/client/src/components/ManageArtist/ArtistFormColors.tsx
@@ -12,11 +12,14 @@ const ArtistFormColors = () => {
       <div
         className={css`
           display: flex;
+          width: 100%;
+          height: 100%;
+          flex-direction: column;
           margin-bottom: 0.75rem;
 
           > div {
             margin-right: 1rem;
-            margin-top: 0rem;
+            margin-top: 1rem;
           }
 
           > div > div {
@@ -26,6 +29,7 @@ const ArtistFormColors = () => {
 
           div:last-child {
             margin-right: 0rem;
+            width: 100%;
           }
 
           span {
@@ -40,12 +44,8 @@ const ArtistFormColors = () => {
             margin-top: 0rem !important;
           }
 
-          @media (max-width: ${bp.medium}px) {
-            flex-direction: column;
-
-            div {
-              margin-right: 0;
-            }
+          div {
+            margin-right: 0;
           }
         `}
       >

--- a/client/src/components/ManageArtist/UploadArtistImage.tsx
+++ b/client/src/components/ManageArtist/UploadArtistImage.tsx
@@ -54,14 +54,14 @@ const UploadArtistImage: React.FC<{
   height: string;
   width: string;
   maxDimensions: string;
-  imagetypedescription: string;
+  imageTypeDescription: string;
 }> = ({
   existing,
   imageType,
   height,
   width,
   maxDimensions,
-  imagetypedescription,
+  imageTypeDescription,
 }) => {
   const { t } = useTranslation("translation", { keyPrefix: "artistForm" });
   const snackbar = useSnackbar();
@@ -170,7 +170,7 @@ const UploadArtistImage: React.FC<{
                 width={width}
                 height={height}
                 rounded={rounded}
-                imagetypedescription={imagetypedescription}
+                imageTypeDescription={imageTypeDescription}
               />
             )}
             {(isLoading || isSaving) && <Spinner rounded={rounded} />}

--- a/client/src/components/ManageArtist/UploadArtistImage.tsx
+++ b/client/src/components/ManageArtist/UploadArtistImage.tsx
@@ -54,7 +54,15 @@ const UploadArtistImage: React.FC<{
   height: string;
   width: string;
   maxDimensions: string;
-}> = ({ existing, imageType, height, width, maxDimensions }) => {
+  imagetypedescription: string;
+}> = ({
+  existing,
+  imageType,
+  height,
+  width,
+  maxDimensions,
+  imagetypedescription,
+}) => {
   const { t } = useTranslation("translation", { keyPrefix: "artistForm" });
   const snackbar = useSnackbar();
   const { refresh } = useArtistContext();
@@ -158,7 +166,12 @@ const UploadArtistImage: React.FC<{
             )}
 
             {!existingImage && (
-              <UploadPrompt width={width} height={height} rounded={rounded} />
+              <UploadPrompt
+                width={width}
+                height={height}
+                rounded={rounded}
+                imagetypedescription={imagetypedescription}
+              />
             )}
             {(isLoading || isSaving) && <Spinner rounded={rounded} />}
           </label>

--- a/client/src/components/ManageArtist/UploadArtistImage.tsx
+++ b/client/src/components/ManageArtist/UploadArtistImage.tsx
@@ -181,7 +181,17 @@ const UploadArtistImage: React.FC<{
                   }
                 `}
               >
-                <ReplaceSpan rounded={rounded}>Replace Image</ReplaceSpan>
+                <ReplaceSpan
+                  rounded={rounded}
+                  className={css`
+                    @media (max-width: ${bp.medium}px) {
+                      font-size: var(--mi-font-size-xsmall) !important;
+                      height: 96% !important;
+                    }
+                  `}
+                >
+                  Replace Image
+                </ReplaceSpan>
                 <Img src={existingImage} alt={imageType} rounded={rounded} />
               </div>
             )}

--- a/client/src/components/ManageArtist/UploadArtistImage.tsx
+++ b/client/src/components/ManageArtist/UploadArtistImage.tsx
@@ -148,6 +148,7 @@ const UploadArtistImage: React.FC<{
             align-items: flex-start;
             flex-wrap: wrap;
             flex-direction: column;
+            max-width: 400px;
 
             img {
               flex: 45%;

--- a/client/src/components/ManageArtist/UploadArtistImage.tsx
+++ b/client/src/components/ManageArtist/UploadArtistImage.tsx
@@ -6,10 +6,12 @@ import api from "services/api";
 import useJobStatusCheck from "utils/useJobStatusCheck";
 import { useSnackbar } from "state/SnackbarContext";
 import { InputEl } from "components/common/Input";
+import { AiFillDelete } from "react-icons/ai";
 
-import { Img, Spinner, UploadPrompt } from "./UploadImage";
+import { Img, ReplaceSpan, Spinner, UploadPrompt } from "./UploadImage";
 import Button from "components/common/Button";
 import { useArtistContext } from "state/ArtistContext";
+import { bp } from "../../constants";
 
 type ImageType = "banner" | "avatar" | "cover";
 
@@ -132,6 +134,7 @@ const UploadArtistImage: React.FC<{
     <div
       className={css`
         height: 100%;
+        width: 100%;
       `}
     >
       <div
@@ -157,14 +160,82 @@ const UploadArtistImage: React.FC<{
 
             label {
               position: relative;
+              width: 100%;
+              margin-bottom: 1rem;
             }
           `}
         >
           <label htmlFor={`${imageType}image`}>
             {existingImage && (
-              <Img src={existingImage} alt={imageType} rounded={rounded} />
+              <div
+                className={css`
+                  span {
+                    opacity: 0;
+                    color: rgba(0, 0, 0, 0);
+                  }
+                  &:hover {
+                    span {
+                      opacity: 1;
+                      color: white;
+                    }
+                  }
+                `}
+              >
+                <ReplaceSpan rounded={rounded}>Replace Image</ReplaceSpan>
+                <Img src={existingImage} alt={imageType} rounded={rounded} />
+              </div>
             )}
-
+            {existingImage && (
+              <small
+                className={css`
+                  flex: 100%;
+                  height: 2.5rem;
+                  width: 2.5rem;
+                  bottom: 1rem;
+                  right: 1rem;
+                  border-radius: 100%;
+                  background: rgba(0, 0, 0, 0.5);
+                  display: flex;
+                  justify-content: center;
+                  align-items: center;
+                  position: absolute;
+                  z-index: 999;
+                  text-align: right;
+                  span {
+                    svg {
+                      margin-right: 0.3rem !important;
+                      height: 1.5rem;
+                      width: 1.5rem;
+                    }
+                  }
+                  @media (max-width: ${bp.medium}px) {
+                    bottom: 0.3rem;
+                    right: 0.3rem;
+                    span {
+                      svg {
+                        margin-right: 0.3rem !important;
+                        height: 1rem;
+                        width: 1rem;
+                      }
+                    }
+                  }
+                `}
+              >
+                <div>
+                  <Button
+                    onClick={deleteImage}
+                    variant="link"
+                    compact
+                    onlyIcon
+                    type="button"
+                    startIcon={<AiFillDelete />}
+                    className={css`
+                      color: white !important;
+                    `}
+                  ></Button>
+                </div>
+              </small>
+            )}
             {!existingImage && (
               <UploadPrompt
                 width={width}
@@ -187,28 +258,13 @@ const UploadArtistImage: React.FC<{
               width: 100%;
               flex: 100%;
               margin-top: 0.5rem;
+              @media (max-width: ${bp.medium}px) {
+                font-size: var(--mi-font-size-xsmall);
+              }
             `}
           >
             {t("dimensionsTip", { maxDimensions })}
           </small>
-          {existingImage && (
-            <small
-              className={css`
-                width: 100%;
-                flex: 100%;
-                margin-top: 0.5rem;
-              `}
-            >
-              <Button
-                onClick={deleteImage}
-                variant="link"
-                compact
-                type="button"
-              >
-                {t("deleteImage")}
-              </Button>
-            </small>
-          )}
         </div>
       </div>
     </div>

--- a/client/src/components/ManageArtist/UploadImage.tsx
+++ b/client/src/components/ManageArtist/UploadImage.tsx
@@ -9,6 +9,7 @@ import { FaFileUpload } from "react-icons/fa";
 
 export const Img = styled.img<{ rounded?: boolean }>`
   transition: .25s background-color, .25s filter;
+  aspect-ratio: 1/1;
 
   &:hover {
     filter: brightness(80%);
@@ -38,6 +39,8 @@ export const ReplaceSpan = styled.span<{ rounded?: boolean }>`
   z-index: 999;
   display: block;
   ${({ rounded }) => (rounded ? "border-radius: 100% !important" : "")}}
+
+
 `;
 
 export const Spinner: React.FC<{ rounded?: boolean }> = ({ rounded }) => {
@@ -128,7 +131,6 @@ const UploadImage: React.FC<{
   width?: string;
   height?: string;
   imageTypeDescription?: string;
-  replace?: string;
 }> = ({
   formName,
   existingCover,
@@ -138,7 +140,6 @@ const UploadImage: React.FC<{
   width,
   height,
   imageTypeDescription,
-  replace,
 }) => {
   const [existingImage, setExistingImage] = React.useState(existingCover);
   const formContext = useFormContext();

--- a/client/src/components/ManageArtist/UploadImage.tsx
+++ b/client/src/components/ManageArtist/UploadImage.tsx
@@ -52,8 +52,8 @@ export const UploadPrompt: React.FC<{
   width?: string;
   height?: string;
   rounded?: boolean;
-  imagetypedescription?: string;
-}> = ({ width, height, rounded, imagetypedescription }) => {
+  imageTypeDescription?: string;
+}> = ({ width, height, rounded, imageTypeDescription }) => {
   return (
     <div
       className={css`
@@ -81,7 +81,7 @@ export const UploadPrompt: React.FC<{
       `}
     >
       <FaFileUpload />
-      Click to upload {imagetypedescription}
+      Click to upload {imageTypeDescription}
     </div>
   );
 };
@@ -99,7 +99,7 @@ const UploadImage: React.FC<{
   rounded?: boolean;
   width?: string;
   height?: string;
-  imagetypedescription?: string;
+  imageTypeDescription?: string;
 }> = ({
   formName,
   existingCover,
@@ -108,7 +108,7 @@ const UploadImage: React.FC<{
   rounded,
   width,
   height,
-  imagetypedescription,
+  imageTypeDescription,
 }) => {
   const [existingImage, setExistingImage] = React.useState(existingCover);
   const formContext = useFormContext();
@@ -142,7 +142,7 @@ const UploadImage: React.FC<{
               width={width}
               height={height}
               rounded={rounded}
-              imagetypedescription={imagetypedescription}
+              imageTypeDescription={imageTypeDescription}
             />
           </label>
         )}

--- a/client/src/components/ManageArtist/UploadImage.tsx
+++ b/client/src/components/ManageArtist/UploadImage.tsx
@@ -52,7 +52,8 @@ export const UploadPrompt: React.FC<{
   width?: string;
   height?: string;
   rounded?: boolean;
-}> = ({ width, height, rounded }) => {
+  imagetypedescription?: string;
+}> = ({ width, height, rounded, imagetypedescription }) => {
   return (
     <div
       className={css`
@@ -80,7 +81,7 @@ export const UploadPrompt: React.FC<{
       `}
     >
       <FaFileUpload />
-      Click to upload an image
+      Click to upload {imagetypedescription}
     </div>
   );
 };
@@ -98,6 +99,7 @@ const UploadImage: React.FC<{
   rounded?: boolean;
   width?: string;
   height?: string;
+  imagetypedescription?: string;
 }> = ({
   formName,
   existingCover,
@@ -106,6 +108,7 @@ const UploadImage: React.FC<{
   rounded,
   width,
   height,
+  imagetypedescription,
 }) => {
   const [existingImage, setExistingImage] = React.useState(existingCover);
   const formContext = useFormContext();
@@ -135,7 +138,12 @@ const UploadImage: React.FC<{
         )}
         {!imageUrl && !existingCover && (
           <label htmlFor={`${formName}image`}>
-            <UploadPrompt width={width} height={height} rounded={rounded} />
+            <UploadPrompt
+              width={width}
+              height={height}
+              rounded={rounded}
+              imagetypedescription={imagetypedescription}
+            />
           </label>
         )}
         {isLoading && <Spinner />}

--- a/client/src/components/ManageArtist/UploadImage.tsx
+++ b/client/src/components/ManageArtist/UploadImage.tsx
@@ -8,18 +8,36 @@ import styled from "@emotion/styled";
 import { FaFileUpload } from "react-icons/fa";
 
 export const Img = styled.img<{ rounded?: boolean }>`
-  max-width: 150px;
   transition: .25s background-color, .25s filter;
-  @media (max-width: ${bp.medium}px) {
-    max-width: 100%;
-  }
 
   &:hover {
     filter: brightness(80%);
     cursor: pointer;
   }
+  @media (max-width: ${bp.medium}px) {
+    max-width: 100%;
+  }
 
   ${({ rounded }) => (rounded ? "border-radius: 100%" : "")}}
+`;
+
+export const ReplaceSpan = styled.span<{ rounded?: boolean }>`
+  position: absolute;
+  text-align: center;
+  vertical-align: middle;
+  line-height: 100%;
+  width: 100%;
+  height: 98.5%;
+  cursor: pointer;
+  padding-top: 47%;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  justify-content: center;
+  z-index: 999;
+  display: block;
+  ${({ rounded }) => (rounded ? "border-radius: 100% !important" : "")}}
 `;
 
 export const Spinner: React.FC<{ rounded?: boolean }> = ({ rounded }) => {
@@ -60,8 +78,14 @@ export const UploadPrompt: React.FC<{
         flex-direction: column;
         padding: 2rem;
         text-align: center;
-        width: ${width}px;
-        height: ${height}px;
+        aspect-ratio: 1 / 1;
+        background: radial-gradient(
+          circle,
+          rgba(96, 96, 96, 0.1) 3%,
+          rgba(125, 125, 125, 0.25) 90%
+        );
+        width: ${width};
+        height: ${height};
         display: flex;
         align-items: center;
         justify-content: center;
@@ -77,6 +101,10 @@ export const UploadPrompt: React.FC<{
 
         &:hover {
           background-color: var(--mi-darken-background-color);
+        }
+        @media (max-width: ${bp.medium}px) {
+          padding: 0.2rem;
+          font-size: var(--mi-font-size-small);
         }
       `}
     >
@@ -100,6 +128,7 @@ const UploadImage: React.FC<{
   width?: string;
   height?: string;
   imageTypeDescription?: string;
+  replace?: string;
 }> = ({
   formName,
   existingCover,
@@ -109,6 +138,7 @@ const UploadImage: React.FC<{
   width,
   height,
   imageTypeDescription,
+  replace,
 }) => {
   const [existingImage, setExistingImage] = React.useState(existingCover);
   const formContext = useFormContext();

--- a/client/src/components/ManageArtist/Welcome.tsx
+++ b/client/src/components/ManageArtist/Welcome.tsx
@@ -123,6 +123,7 @@ const Welcome = () => {
             <FormComponent>
               <label>Want to upload an avatar?</label>
               <UploadArtistImage
+                imagetypedescription="your avatar"
                 existing={localArtist}
                 imageType="avatar"
                 height="150"

--- a/client/src/components/ManageArtist/Welcome.tsx
+++ b/client/src/components/ManageArtist/Welcome.tsx
@@ -123,7 +123,7 @@ const Welcome = () => {
             <FormComponent>
               <label>Want to upload an avatar?</label>
               <UploadArtistImage
-                imagetypedescription="your avatar"
+                imageTypeDescription="your avatar"
                 existing={localArtist}
                 imageType="avatar"
                 height="150"

--- a/client/src/components/common/AutoComplete.tsx
+++ b/client/src/components/common/AutoComplete.tsx
@@ -165,9 +165,9 @@ const AutoComplete: React.FC<{
             opacity: 0.7;
           }
           @media (prefers-color-scheme: dark) {
-            color: var(--mi-black) !important;
+            color: var(--mi-white) !important;
             &::placeholder {
-              color: var(--mi-black) !important;
+              color: var(--mi-white) !important;
               opacity: 0.3;
             }
           }

--- a/client/src/components/common/Input.tsx
+++ b/client/src/components/common/Input.tsx
@@ -34,6 +34,10 @@ export const InputEl = styled.input`
   &[type="checkbox"] {
     width: auto;
   }
+
+  @media (prefers-color-scheme: dark) {
+    background-color: rgba(125, 125, 125, 0.2) !important;
+  }
 `;
 
 export const Input: React.FC<Props> = ({ onChange, ...props }) => {

--- a/client/src/components/common/Input.tsx
+++ b/client/src/components/common/Input.tsx
@@ -34,11 +34,6 @@ export const InputEl = styled.input`
   &[type="checkbox"] {
     width: auto;
   }
-
-  @media (prefers-color-scheme: dark) {
-    background-color: rgba(125, 125, 125, 0.2) !important;
-    color: white !important;
-  }
 `;
 
 export const Input: React.FC<Props> = ({ onChange, ...props }) => {

--- a/client/src/components/common/Input.tsx
+++ b/client/src/components/common/Input.tsx
@@ -37,6 +37,7 @@ export const InputEl = styled.input`
 
   @media (prefers-color-scheme: dark) {
     background-color: rgba(125, 125, 125, 0.2) !important;
+    color: white !important;
   }
 `;
 

--- a/client/src/components/common/Modal.tsx
+++ b/client/src/components/common/Modal.tsx
@@ -21,9 +21,9 @@ const wrapper = css`
   align-items: center;
 `;
 
-const ChildrenWrapper = styled.div<{ title?: boolean }>`
+const ChildrenWrapper = styled.div<{ title?: boolean; noPadding?: boolean }>`
   overflow-y: auto;
-  padding: 20px;
+  ${(props) => (props.noPadding ? "padding: 0;" : "padding: 20px;")}
   margin-bottom: 1rem;
   margin-left: 0rem;
   ::-webkit-scrollbar {
@@ -122,6 +122,7 @@ export const Modal: React.FC<{
   size?: "small";
   className?: string;
   contentClassName?: string;
+  noPadding?: boolean;
 }> = ({
   children,
   open,
@@ -130,6 +131,7 @@ export const Modal: React.FC<{
   title,
   className,
   contentClassName,
+  noPadding,
 }) => {
   const [container] = React.useState(() => {
     // This will be executed only on the initial render
@@ -207,7 +209,7 @@ export const Modal: React.FC<{
               aria-label="close"
             ></Button>
           </SpaceBetweenDiv>
-          <ChildrenWrapper className={contentClassName}>
+          <ChildrenWrapper className={contentClassName} noPadding={noPadding}>
             {children}
           </ChildrenWrapper>
         </Content>

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -300,7 +300,7 @@
   },
   "artistForm": {
     "displayName": "Display name",
-    "bio": "Bio",
+    "bio": "Artist Biography",
     "urlSlug": "Text that will appear in the URL",
     "saveArtist": "Save artist",
     "createArtist": "Create artist",


### PR DESCRIPTION
I could have used directly "image type", but two limitations prompted me to create a new variable : 

- Incapacity to customize "a / an" based on the word type ("a background" "an avatar")
- Background is still defined as Banner in the backend, which is something we need to fix but is NOT a trivial rewrite because it's pretty much everywhere in the codebase and could have broken a lot of things. 

New behavior : 
![2024-05-11_170526](https://github.com/funmusicplace/mirlo/assets/77789607/ae1cc7c1-54d9-4d37-a88e-888d01b377de)
![2024-05-11_170550](https://github.com/funmusicplace/mirlo/assets/77789607/acc841db-9028-4db7-aaf1-9daece70d916)
