### PR TITLE
Album image styling & cache-control headers

### DIFF
--- a/client/src/components/Artist/ArtistSquare.tsx
+++ b/client/src/components/Artist/ArtistSquare.tsx
@@ -24,6 +24,7 @@ const ArtistSquare: React.FC<{
           }
           alt={artist.name}
           size={300}
+          square
         />
 
         <TrackGroupLinks>

--- a/client/src/components/Player/PlayingTrackDetails.tsx
+++ b/client/src/components/Player/PlayingTrackDetails.tsx
@@ -14,6 +14,7 @@ const PlayingTrackDetails: React.FC<{ currentTrack: Track }> = ({
         flex: 40%;
         display: flex;
         align-items: center;
+        gap: 0.5rem;
 
         margin-right: 1rem;
         margin-left: 1rem;
@@ -30,19 +31,17 @@ const PlayingTrackDetails: React.FC<{ currentTrack: Track }> = ({
         }
       `}
     >
-      <div>
-        <ImageWithPlaceholder
-          src={currentTrack?.trackGroup.cover?.sizes?.[120]}
-          size={48}
-          alt={currentTrack?.title ?? "Loading album"}
-          className={css`
-            background-color: #efefef;
-            margin-right: 0.5rem;
-            min-height: 100%;
-            min-width: 48px;
-          `}
-        />
-      </div>
+      <ImageWithPlaceholder
+        src={currentTrack?.trackGroup.cover?.sizes?.[120]}
+        size={48}
+        square
+        alt={currentTrack?.title ?? "Loading album"}
+        className={css`
+          width: 48px;
+          height: 48px;
+          flex-basis: 48px;
+        `}
+      />
       <div
         className={css`
           max-width: 80%;

--- a/client/src/components/common/ClickToPlay.tsx
+++ b/client/src/components/common/ClickToPlay.tsx
@@ -14,11 +14,6 @@ import { getReleaseUrl } from "utils/artist";
 import { useAuthContext } from "state/AuthContext";
 import { Link } from "react-router-dom";
 
-type WrapperProps = {
-  width: number;
-  height: number;
-};
-
 const TrackgroupButtons = styled.div`
   width: 100%;
   position: absolute;
@@ -71,7 +66,7 @@ const TrackgroupButtons = styled.div`
   }
 `;
 
-const PlayWrapper = styled.div<WrapperProps>`
+const PlayWrapper = styled.div`
   display: flex;
   flex-direction: column;
   position: absolute;
@@ -117,10 +112,9 @@ const PlayWrapper = styled.div<WrapperProps>`
   }
 `;
 
-const Wrapper = styled.div<WrapperProps>`
+const Wrapper = styled.div`
   position: relative;
   max-width: 100%;
-  width: ${(props) => props.width}px;
 
   .startIcon {
     font-size: 1.5rem !important;
@@ -153,12 +147,9 @@ const Wrapper = styled.div<WrapperProps>`
     font-size: var(--mi-font-size-small);
   }
   img {
-    width: 100%;
-    height: 100%;
     border: 1px solid rgba(255, 255, 255, 0.05);
     text-align: center;
     display: block;
-    // padding-top: ${(props) => props.height / 2 - 12}px;
   }
 
   @media (max-width: ${bp.large}px) {
@@ -169,11 +160,6 @@ const Wrapper = styled.div<WrapperProps>`
     position: relative;
     p {
       font-size: var(--mi-font-size-xsmall);
-    }
-
-    img {
-      width: ${(props) => (props.width < 420 ? `${props.width}px` : "100%")};
-      height: ${(props) => (props.height < 420 ? `${props.height}px` : "auto")};
     }
   }
 
@@ -253,16 +239,8 @@ const ClickToPlay: React.FC<
 
   return (
     <ClickToPlayWrapper>
-      <Wrapper
-        width={image?.width ?? 0}
-        height={image?.height ?? 0}
-        className={className}
-      >
-        <PlayWrapper
-          width={image?.width ?? 0}
-          height={image?.height ?? 0}
-          className="play-wrapper"
-        >
+      <Wrapper className={className}>
+        <PlayWrapper className="play-wrapper">
           {/*
            * This link is not visible to the user, and should be duplicated by an album link provided in {children}.
            * As such, it is safe to exclude this from the accessibility tree.
@@ -303,6 +281,7 @@ const ClickToPlay: React.FC<
             src={image.url}
             alt={title}
             size={image.width}
+            square
           />
         )}
       </Wrapper>

--- a/client/src/components/common/ClickToPlayAlbum.tsx
+++ b/client/src/components/common/ClickToPlayAlbum.tsx
@@ -1,31 +1,17 @@
 import styled from "@emotion/styled";
 import React from "react";
-import { bp } from "../../constants";
 import { useGlobalStateContext } from "state/GlobalState";
 import api from "services/api";
 
 import PlayControlButton from "./PlayControlButton";
 import { useAuthContext } from "state/AuthContext";
-type WrapperProps = {
-  width: number;
-  height: number;
-};
 
-const Wrapper = styled.div<WrapperProps>`
+const Wrapper = styled.div`
   position: relative;
   max-width: 100%;
-  width: ${(props) => props.width}px;
 
   .startIcon {
     font-size: 1.3rem !important;
-  }
-
-  img {
-    width: 100%;
-    height: 100%;
-    border: 1px solid rgba(255, 255, 255, 0.05);
-    text-align: center;
-    display: block;
   }
 
   button {
@@ -40,17 +26,12 @@ const Wrapper = styled.div<WrapperProps>`
       color: var(--mi-secondary-color);
     }
   }
-
-  @media (max-width: ${bp.medium}px) {
-    position: relative;
-  }
 `;
 
 const ClickToPlayAlbum: React.FC<{
   trackGroupId: number;
-  image?: { width: number; height: number; url: string };
   className?: string;
-}> = ({ trackGroupId, image, className }) => {
+}> = ({ trackGroupId, className }) => {
   const {
     state: { playing, playerQueueIds, currentlyPlayingIndex },
     dispatch,
@@ -105,11 +86,7 @@ const ClickToPlayAlbum: React.FC<{
     trackIds.includes(playerQueueIds[currentlyPlayingIndex]);
 
   return (
-    <Wrapper
-      width={image?.width ?? 0}
-      height={image?.height ?? 0}
-      className={className}
-    >
+    <Wrapper className={className}>
       <PlayControlButton onPlay={onClickPlay} isPlaying={currentlyPlaying} />
     </Wrapper>
   );

--- a/client/src/components/common/ImageWithPlaceholder.tsx
+++ b/client/src/components/common/ImageWithPlaceholder.tsx
@@ -7,7 +7,7 @@ const ImageContainer = styled.div`
   background-color: var(--mi-darken-background-color);
 
   img {
-    transition: opacity 1s;
+    transition: opacity 0.25s;
     max-width: 100%;
     height: 100%;
   }
@@ -30,6 +30,8 @@ export const ImageWithPlaceholder: React.FC<{
         alt={alt}
         width={size}
         height={size}
+        loading="lazy"
+        decoding="async"
         onLoad={() => setLoading(false)}
         onError={() => setError(true)}
         style={{

--- a/client/src/components/common/ImageWithPlaceholder.tsx
+++ b/client/src/components/common/ImageWithPlaceholder.tsx
@@ -1,68 +1,44 @@
 import React from "react";
+import styled from "@emotion/styled";
+
+const ImageContainer = styled.div`
+  display: block;
+  max-width: 100%;
+  background-color: var(--mi-darken-background-color);
+
+  img {
+    transition: opacity 1s;
+    max-width: 100%;
+    height: 100%;
+  }
+`;
 
 export const ImageWithPlaceholder: React.FC<{
   src?: string;
   alt: string;
   size: number;
   className?: string;
-}> = ({ src, alt, size, className }) => {
-  const [isChecking, setIsChecking] = React.useState(false);
-  const [checkedSrc, setCheckedSrc] = React.useState<string>();
-
-  // FIXME: this is less than elegant. For every image we're
-  // checking if it is a real image or whether it returns a 404.
-  // why is the API returning 404s on images? If they don't
-  // exist we shouldn't be returning them on the API.
-  React.useEffect(() => {
-    const prefetchSrc = async () => {
-      setIsChecking(true);
-      try {
-        if (src) {
-          const img = new Image();
-          img.src = src;
-          img.onload = () => {
-            setCheckedSrc(src);
-          };
-        }
-      } catch {
-        console.error("src returns 404", src);
-      } finally {
-        setIsChecking(false);
-      }
-    };
-
-    prefetchSrc();
-  }, [src]);
+  square?: boolean;
+}> = ({ src, alt, size, square, className }) => {
+  const [isLoading, setLoading] = React.useState(true);
+  const [isError, setError] = React.useState(false);
 
   return (
-    <>
-      {!isChecking && checkedSrc && (
-        <img
-          src={checkedSrc}
-          alt={alt}
-          width={size}
-          height={size}
-          className={className}
-          style={{
-            width: "100%",
-            maxWidth: `${size}px`,
-            height: `100%`,
-          }}
-        />
-      )}
-      {!isChecking && !checkedSrc && (
-        <div
-          style={{
-            backgroundColor: "var(--mi-darken-background-color)",
-            display: "block",
-            width: `100%`,
-            height: `100%`,
-            aspectRatio: "1/1",
-          }}
-          className={className}
-        />
-      )}
-    </>
+    <ImageContainer className={className}>
+      <img
+        src={src}
+        alt={alt}
+        width={size}
+        height={size}
+        onLoad={() => setLoading(false)}
+        onError={() => setError(true)}
+        style={{
+          aspectRatio: square ? "1" : "unset",
+          objectFit: square ? "contain" : "unset",
+          opacity: isLoading || isError ? 0 : 1,
+        }}
+      />
+    </ImageContainer>
   );
 };
 


### PR DESCRIPTION
- Prevents the double image fetching in `<ImageWithPlaceholder>`
  * Since these requests were not cached, this was adding to the API ratelimit when clicking through release pages
- Ensures that image styling is square in release list & player (related: #520)
  * This uses `object-fit: contain;` rather than cropping the image, to ensure that the entire image is visible
  * Added lazy loading (which helps when images are out of view, although it *doesn't* help when they're already visible on the page - so it might be good to add a condition to this later)
  * Also added a fade-in transition when the image loads 
- Adds `Cache-Control` and `Etag` headers to responses from the `/images` endpoint
  * Also added naive support for `If-None-Match`, used with `stale-while-revalidate`