### PR TITLE
Pause button slightly offset

### DIFF
--- a/client/src/components/common/TrackRow.tsx
+++ b/client/src/components/common/TrackRow.tsx
@@ -82,11 +82,9 @@ const FirstTD = styled.td`
   }
   @media screen and (max-width: ${bp.small}px) {
     button {
-      padding: 0.5rem 0.65rem 0.5rem 0.1rem !important;
       background: none;
     }
     button:hover {
-      padding: 0.5rem 0.65rem 0.5rem 0.1rem !important;
       background: none !important;
     }
   }

--- a/client/src/components/common/TrackRow.tsx
+++ b/client/src/components/common/TrackRow.tsx
@@ -73,11 +73,9 @@ const FirstTD = styled.td`
   height: 30px;
 
   button {
-    padding: 0.5rem 0.65rem 0.5rem 0.4rem !important;
     background: none;
   }
   button:hover {
-    padding: 0.5rem 0.65rem 0.5rem 0.4rem !important;
     background: none !important;
   }
   @media screen and (max-width: ${bp.small}px) {


### PR DESCRIPTION
Not sure why we had these set for smaller screen widths, it seems that removing them eliminates the issue? I'm only seeing this issue pop up on the smaller screen width breakpoints.

<img width="564" alt="Screenshot 2024-08-10 at 9 34 55 PM" src="https://github.com/user-attachments/assets/28fe59ab-4cb6-4da6-85d2-be9ca7b93563">

Closes #798