### PR TITLE
From as casing does not match

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jrottenberg/ffmpeg:5.1-ubuntu2204 as ffmpeg
+FROM jrottenberg/ffmpeg:5.1-ubuntu2204 AS ffmpeg
 
 FROM node:18-bookworm-slim AS base
 


### PR DESCRIPTION
Addresses the warning:

```sh
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```