### PR TITLE
Keep player open when last track in queue ends

### DIFF
--- a/client/src/state/GlobalState.tsx
+++ b/client/src/state/GlobalState.tsx
@@ -148,7 +148,8 @@ export const stateReducer = produce((draft: GlobalState, action: Actions) => {
       if (atEndOfQueue && draft.looping === "loopQueue") {
         newIndex = 0;
       } else if (atEndOfQueue) {
-        newIndex = undefined;
+        newIndex = draft.currentlyPlayingIndex;
+        draft.playing = false;
       } else {
         newIndex = (draft.currentlyPlayingIndex ?? 0) + 1;
       }


### PR DESCRIPTION
When reaching the end, the player will pause, but stay open 

Closes #823 