### PR TITLE
Fix track numbering when uploading one at a time.

### DIFF
--- a/client/src/components/ManageArtist/utils.ts
+++ b/client/src/components/ManageArtist/utils.ts
@@ -81,7 +81,7 @@ export const convertMetaData = (
     order: `${
       p.metadata.common.track.no && Number.isFinite(+p.metadata.common.track.no)
         ? Number(p.metadata.common.track.no)
-        : i + 1
+        : trackGroup.tracks.length + i + 1
     }`,
     duration: p.metadata.format.duration,
     file: p.file,


### PR DESCRIPTION
The numbering didn't consider already uploaded files when calculating order.

Closes #728 