### PR TITLE
Add API tests for artist/id/subscribe using stripe-mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log
 __generated__/
 
 *storybook.log
+.idea/

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -31,6 +31,7 @@ services:
       - minio-test
       - stripe-test
     environment:
+      NODE_ENV: test
       API_DOMAIN: http://api:3000
       STRIPE_HOST: stripe-test
       STRIPE_PORT: 12111

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,10 @@
 services:
+  stripe-test:
+    container_name: blackbird-stripe-mock-test
+    image: stripe/stripe-mock
+    networks: !reset [test-network]
+    ports: !reset []
+    profiles: [test]
   redis-test:
     extends:
       file: docker-compose.api.yml
@@ -23,8 +29,13 @@ services:
       - redis-test
       - pgsql-test
       - minio-test
+      - stripe-test
     environment:
       API_DOMAIN: http://api:3000
+      STRIPE_HOST: stripe-test
+      STRIPE_PORT: 12111
+      STRIPE_PROTOCOL: http
+      STRIPE_KEY: sk_test_123
     profiles: [test]
 
   minio-test:
@@ -61,6 +72,7 @@ services:
       - api-test:api
       - minio-test:minio
       - pgsql-test:pgsql
+      - stripe-test:stripe
     ports: !reset []
     depends_on: !reset
       api-test:

--- a/src/utils/stripe.ts
+++ b/src/utils/stripe.ts
@@ -18,12 +18,16 @@ import {
 } from "./handleFinishedTransactions";
 import countryCodesCurrencies from "./country-codes-currencies";
 
-const { STRIPE_KEY, API_DOMAIN } = process.env;
+// STRIPE_HOST, STRIPE_PORT, and STRIPE_PROTOCOL should not be set when not running tests against stripe-mock
+const { STRIPE_KEY, API_DOMAIN, STRIPE_HOST, STRIPE_PORT, STRIPE_PROTOCOL } = process.env;
 
 export const OPTION_JOINER = ";;";
 
 const stripe = new Stripe(STRIPE_KEY ?? "", {
   apiVersion: "2022-11-15",
+  host: STRIPE_HOST,
+  port: STRIPE_PORT,
+  protocol: STRIPE_PROTOCOL === "http" ? "http" : "https"
 });
 
 const calculatePlatformPercent = async (

--- a/src/utils/stripe.ts
+++ b/src/utils/stripe.ts
@@ -18,17 +18,23 @@ import {
 } from "./handleFinishedTransactions";
 import countryCodesCurrencies from "./country-codes-currencies";
 
-// STRIPE_HOST, STRIPE_PORT, and STRIPE_PROTOCOL should not be set when not running tests against stripe-mock
-const { STRIPE_KEY, API_DOMAIN, STRIPE_HOST, STRIPE_PORT, STRIPE_PROTOCOL } = process.env;
+const { STRIPE_KEY, API_DOMAIN } = process.env;
 
 export const OPTION_JOINER = ";;";
 
-const stripe = new Stripe(STRIPE_KEY ?? "", {
-  apiVersion: "2022-11-15",
-  host: STRIPE_HOST,
-  port: STRIPE_PORT,
-  protocol: STRIPE_PROTOCOL === "http" ? "http" : "https"
-});
+let stripeConfig: Stripe.StripeConfig = { apiVersion: "2022-11-15" };
+
+if (process.env.NODE_ENV === "test") {
+  const { STRIPE_HOST, STRIPE_PORT, STRIPE_PROTOCOL } = process.env;
+  stripeConfig = {
+    ...stripeConfig,
+    host: STRIPE_HOST,
+    port: STRIPE_PORT,
+    protocol: STRIPE_PROTOCOL === "http" ? "http" : "https"
+  };
+}
+
+const stripe = new Stripe(STRIPE_KEY ?? "", stripeConfig);
 
 const calculatePlatformPercent = async (
   currency: string,

--- a/test/routers/artists/{id}.subscribe.spec.ts
+++ b/test/routers/artists/{id}.subscribe.spec.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert";
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import { clearTables, createArtist, createUser } from "../../utils";
+import { describe, it } from "mocha";
+import { requestApp } from "../utils";
+import prisma from "@mirlo/prisma";
+import request from "supertest";
+
+describe("artists/{id}/subscribe", () => {
+  beforeEach(async () => {
+    try {
+      await clearTables();
+    } catch (e) {
+      console.error(e);
+    }
+  });
+
+  describe("POST", () => {
+    let createTestData = async (stripeAccountId: string | null = "23") => {
+      const { user: artistUser, accessToken: artistAccessToken} = await createUser({
+        email: "artist@example.com",
+        stripeAccountId: stripeAccountId
+      });
+
+      const { user: followerUser, accessToken: followerAccessToken } = await createUser({
+        email: "follower@example.com"
+      });
+
+      const artist = await createArtist(artistUser.id, {
+        name: "Test artist",
+        userId: artistUser.id,
+        enabled: true,
+        subscriptionTiers: {
+          create: [
+            { name: "Tier 1", isDefaultTier: true },
+            { name: "Tier 2", currency: "eur", minAmount: 4 }
+          ]
+        },
+      });
+
+      return {
+        artist,
+        artistUser,
+        artistAccessToken,
+        followerUser,
+        followerAccessToken
+      }
+    }
+    
+    it("should return 404 when tier doesn't exist", async () => {
+      const response = await requestApp
+        .post("artists/1/subscribe")
+        .send({
+          tierId: 0,
+          email: "user@example.com",
+          amount: 42,
+        })
+        .set("Accept", "application/json");
+
+      assert.equal(response.status, 404);
+    });
+
+    it("should return 400 when artist hasn't set up Stripe", async () => {
+      const { artistUser, artist, followerUser } = await createTestData(null);
+
+      const response = await requestApp
+        .post(`artists/${artistUser.id}/subscribe`)
+        .send({
+          tierId: artist.subscriptionTiers![0].id,
+          email: followerUser.email,
+          amount: 42,
+        })
+        .set("Accept", "application/json");
+
+      assert.equal(response.status, 400);
+    });
+
+    it("should return Stripe checkout URL", async () => {
+      const { artistUser, artist, followerUser } = await createTestData();
+
+      const response = await requestApp
+        .post(`artists/${artistUser.id}/subscribe`)
+        .send({
+          tierId: artist.subscriptionTiers![0].id,
+          email: followerUser.email,
+          amount: 42,
+        })
+        .set("Accept", "application/json");
+
+      assert.equal(response.status, 200);
+      assert.equal(JSON.parse(response.text).sessionUrl, "https://checkout.stripe.com/pay/c/cs_test_a1YS1URlnyQCN5fUUduORoQ7Pw41PJqDWkIVQCpJPqkfIhd6tVY8XB1OLY");
+    });
+
+    it ("should remove user from old subscription tier", async () => {
+      const { artistUser, artist, followerUser, followerAccessToken } = await createTestData();
+      await prisma.artistUserSubscription.create({
+        data: {
+          artistSubscriptionTierId: artist.subscriptionTiers![0].id,
+          userId: followerUser.id,
+          amount: 3
+        },
+      });
+      const newTierId = artist.subscriptionTiers![1].id;
+
+      const response = await requestApp
+        .post(`artists/${artistUser.id}/subscribe`)
+        .send({
+          tierId: newTierId,
+          email: followerUser.email,
+          amount: 0
+        })
+        .set("Accept", "application/json")
+        .set("Cookie", [`jwt=${followerAccessToken}`]);
+      await request(JSON.parse(response.text).sessionUrl).get("");
+
+      const subscriptions = await prisma.artistUserSubscription.findMany({
+        where: {
+          artistSubscriptionTierId: newTierId,
+          userId: followerUser.id
+        }
+      });
+      assert.equal(subscriptions.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
I had to change from `res.status(...)` to `ApiError` for errors. The tests would just hang, waiting for the call to return before I did the change.