### PR TITLE
Issue/1093 add track descriptions

### DIFF
--- a/client/src/components/ManageArtist/AlbumFormComponents/EditTrackRow.tsx
+++ b/client/src/components/ManageArtist/AlbumFormComponents/EditTrackRow.tsx
@@ -33,6 +33,7 @@ export interface FormData {
   licenseId: number;
   isrc: string;
   lyrics: string;
+  description: string;
   allowIndividualSale: boolean;
   minPrice: string;
 }
@@ -70,6 +71,7 @@ const EditTrackRow: React.FC<{
       status: track.isPreview ? "preview" : "must-own",
       licenseId: track.licenseId,
       lyrics: track.lyrics,
+      description: track.description,
       isrc: track.isrc,
       minPrice: `${track?.minPrice !== undefined ? track.minPrice / 100 : ""}`,
       allowIndividualSale: track.allowIndividualSale,
@@ -90,6 +92,7 @@ const EditTrackRow: React.FC<{
       licenseId: track.licenseId,
       isrc: track.isrc,
       lyrics: track.lyrics,
+      description: track.description,
       minPrice: `${track?.minPrice !== undefined ? track.minPrice / 100 : ""}`,
       allowIndividualSale: track.allowIndividualSale,
     });
@@ -104,6 +107,7 @@ const EditTrackRow: React.FC<{
           title: formData.title,
           isrc: formData.isrc,
           lyrics: formData.lyrics,
+          description: formData.description,
           isPreview: formData.status === "preview",
           allowIndividualSale: formData.allowIndividualSale,
           minPrice: formData.minPrice
@@ -268,6 +272,21 @@ const EditTrackRow: React.FC<{
           <TextArea
             id="lyrics"
             {...register("lyrics")}
+            className={css`
+              width: 100%;
+            `}
+            rows={8}
+          />
+        </td>
+      </IndentedTR>
+      <IndentedTR>
+        <td colSpan={2}>
+          <label htmlFor="description">{t("description")}</label>
+        </td>
+        <td colSpan={99}>
+          <TextArea
+            id="description"
+            {...register("description")}
             className={css`
               width: 100%;
             `}

--- a/client/src/components/TrackGroup/TrackView.tsx
+++ b/client/src/components/TrackGroup/TrackView.tsx
@@ -165,6 +165,23 @@ function TrackView() {
                     trackGroup={trackGroup}
                   />
                 </TrackListingWrapper>
+                {filteredTrack.description && (
+                  <div
+                    className={css`
+                      padding: 1rem;
+                      white-space: pre-line;
+                    `}
+                  >
+                    <h3
+                      className={css`
+                        margin-bottom: 1rem;
+                      `}
+                    >
+                      Description
+                    </h3>
+                    {filteredTrack.description}
+                  </div>
+                )}
                 {filteredTrack.lyrics && (
                   <div
                     className={css`

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -474,6 +474,7 @@
     "addALicense": "Add a license",
     "isrcCode": "ISRC Code",
     "lyrics": "Lyrics",
+    "description": "Description",
     "addIt": "Add it",
     "selectALicense": "Select a license",
     "allowIndividualSale": "Allow individual sale",

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -32,6 +32,7 @@ interface Track {
   image: Image;
   order: number;
   allowIndividualSale: boolean;
+  description: string;
   minPrice: number; // in cents;
   metadata: { [key: string]: any };
   audio?: {

--- a/prisma/migrations/20250425043316_yarn_prisma_build/migration.sql
+++ b/prisma/migrations/20250425043316_yarn_prisma_build/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Track" ADD COLUMN     "description" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -545,6 +545,7 @@ model Track {
   trackGroup          TrackGroup          @relation(fields: [trackGroupId], references: [id])
   trackGroupId        Int
   title               String?
+  description         String?
   audio               TrackAudio?
   createdAt           DateTime            @default(now())
   updatedAt           DateTime            @updatedAt

--- a/src/routers/v1/manage/tracks/index.ts
+++ b/src/routers/v1/manage/tracks/index.ts
@@ -60,6 +60,7 @@ export default function () {
       isPreview,
       lyrics,
       isrc,
+      description,
     } = req.body;
     try {
       await doesTrackGroupBelongToUser(Number(trackGroupId), loggedInUser);
@@ -72,6 +73,7 @@ export default function () {
           metadata,
           lyrics,
           isrc,
+          description,
           trackGroup: {
             connect: {
               id: Number(trackGroupId),

--- a/src/routers/v1/manage/tracks/{trackId}/index.ts
+++ b/src/routers/v1/manage/tracks/{trackId}/index.ts
@@ -18,6 +18,7 @@ interface TrackBody {
   isrc: string;
   minPrice: number;
   allowIndividualSale: boolean;
+  description: string;
   trackArtists?: {
     artistName: string;
     id: string;
@@ -45,6 +46,7 @@ export default function () {
       allowIndividualSale,
       lyrics,
       isrc,
+      description,
     } = req.body as TrackBody;
 
     try {
@@ -60,6 +62,7 @@ export default function () {
           allowIndividualSale,
           minPrice,
           licenseId: Number(licenseId),
+          description,
         },
         include: {
           trackArtists: true,

--- a/test/routers/manage/tracks/{id}.spec.ts
+++ b/test/routers/manage/tracks/{id}.spec.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert";
+import * as dotenv from "dotenv";
+dotenv.config();
+import { describe, it, beforeEach } from "mocha";
+import { clearTables, createTrack, createTrackGroup, createUser, createArtist } from "../../../utils";
+import { requestApp } from "../../utils";
+
+describe("PUT /manage/tracks/{id}", () => {
+  beforeEach(async () => {
+    await clearTables();
+  });
+
+  it("should update the description of a track", async () => {
+    const { user, accessToken } = await createUser({
+      email: "artist@artist.com",
+    });
+    const artist = await createArtist(user.id);
+    const trackGroup = await createTrackGroup(artist.id);
+    const track = await createTrack(trackGroup.id, {
+      title: "test track",
+      description: "test description",
+    });
+
+    const response = await requestApp
+      .put(`manage/tracks/${track.id}`)
+      .send({ title: "test track", description: "Updated description" })
+      .set("Cookie", [`jwt=${accessToken}`])
+      .set("Accept", "application/json");
+
+    assert.equal(response.body.result.description, "Updated description");
+    assert.equal(response.statusCode, 200);
+  });
+});

--- a/test/routers/tracks/{id}.spec.ts
+++ b/test/routers/tracks/{id}.spec.ts
@@ -2,7 +2,13 @@ import assert from "node:assert";
 import * as dotenv from "dotenv";
 dotenv.config();
 import { describe, it } from "mocha";
-import { clearTables } from "../../utils";
+import {
+  clearTables,
+  createArtist,
+  createTrackGroup,
+  createUser,
+  createTrack
+} from "../../utils";
 
 import { requestApp } from "../utils";
 
@@ -21,6 +27,44 @@ describe("tracks/{id}", () => {
         .get("tracks/1")
         .set("Accept", "application/json");
       assert.equal(response.statusCode, 404);
+    });
+
+    it("should GET / 200 with description", async () => {
+      const { user } = await createUser({
+        email: "artist@artist.com",
+      });
+      const artist = await createArtist(user.id);
+      const trackGroup = await createTrackGroup(artist.id);
+      const track = await createTrack(trackGroup.id, {
+        title: "test track",
+        description: "This is a test description",
+      });
+
+      const response = await requestApp
+        .get("tracks/" + track.id)
+        .set("Accept", "application/json");
+
+      assert.equal(response.body.result.description, "This is a test description");
+      assert.equal(response.statusCode, 200);
+    });
+
+    it("should GET / 200 with empty description", async () => {
+      const { user } = await createUser({
+        email: "artist@artist.com",
+      });
+      const artist = await createArtist(user.id);
+      const trackGroup = await createTrackGroup(artist.id);
+      const track = await createTrack(trackGroup.id, {
+        title: "test track",
+      });
+
+      const response = await requestApp
+        .get("tracks/" + track.id)
+        .set("Accept", "application/json");
+
+        
+      assert.equal(response.body.result.description, null);
+      assert.equal(response.statusCode, 200);
     });
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -166,6 +166,7 @@ export const createTrack = async (
     data: {
       title: data?.title,
       trackGroupId,
+      description: data?.description,
       stripeProductKey: data?.stripeProductKey,
       minPrice: data?.minPrice,
       isPreview: data?.isPreview,


### PR DESCRIPTION
Closes #1093 
feat: Add support for track descriptions

- Updated schema to include `description` field
- Enhanced API endpoints to handle descriptions
- Added tests for API
- Modified track editor UI to allow adding descriptions
- Displayed track descriptions on the track page

![desc1](https://github.com/user-attachments/assets/dcc2512e-f354-49dc-b25b-b71d29c2ffca)

![desc2](https://github.com/user-attachments/assets/314c3317-a60b-470e-940a-8b533fc38258)

![desc3](https://github.com/user-attachments/assets/0c52922a-4c67-4428-8688-8b752f919fd7)
