### PR TITLE
Update PostHeader.tsx

### DIFF
--- a/client/src/components/Post/PostHeader.tsx
+++ b/client/src/components/Post/PostHeader.tsx
@@ -25,12 +25,12 @@ const PostHeader: React.FC<{ post: Post }> = ({ post }) => {
   return (
     <div
       className={css`
-        height: ${featuredImage ? "50vh" : "20vh"};
+        height: ${featuredImage ? "50vh" : "30vh"};
         overflow: none;
         position: relative;
 
         @media (max-width: ${bp.medium}px) {
-          height: ${featuredImage ? "70vh" : "30vh"};
+          height: ${featuredImage ? "70vh" : "20vh"};
         }
       `}
     >


### PR DESCRIPTION
On posts with no images, on mobile and desktop, the height for the h1 container divs was reversed. 

It should be height: 20vh on mobile and height: 30vh on desktop.

I've added those changes here.