### PR TITLE
Bug: download Opus

### DIFF
--- a/client/src/components/common/DownloadAlbumButton.tsx
+++ b/client/src/components/common/DownloadAlbumButton.tsx
@@ -17,7 +17,7 @@ const formatsDisplay: { [format: string]: string } = {
   "": "",
   flac: "FLAC",
   wav: "WAV",
-  "128.opus": "OPUS",
+  "128.opus": "OPUS 128kbps",
   "320.mp3": "MP3 320kbps",
   "256.mp3": "MP3 256kbps",
   "128.mp3": "MP3 128kbps",


### PR DESCRIPTION
Fix #1227.

ffmpeg needs a bitrate for Opus. I picked 128kbps based on the [Opus Recommended Settings](https://wiki.xiph.org/Opus_Recommended_Settings#Recommended_Bitrates).