### PR TITLE
Fix failing tests in CI

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -51,7 +51,7 @@ jobs:
           cp .env.example .env
 
       - name: Build docker image
-        run: docker compose build test
+        run: docker compose --profile test build test
 
       - name: Run tests
         run: docker compose run test


### PR DESCRIPTION
Fixing failures on tests running in GitHub Actions due to updated ubuntu 24.04 runner.

[Failing builds](https://github.com/funmusicplace/mirlo/actions/runs/15586673755/job/43895607254?pr=1237)

[Related Issue on runner-images repo](https://github.com/actions/runner-images/issues/12289)