### PR TITLE
Bug: Arial bold, emoji not found locally

### DIFF
--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -7,11 +7,6 @@
 }
 body {
   margin: 0;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
-    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  -webkit-font-smoothing: auto;
-  -moz-osx-font-smoothing: auto;
 }
 
 #root {
@@ -33,9 +28,7 @@ html {
   --header-cover-sticky-height: 55px;
 
   --mi-font-family-stack:
-    "Arial", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+    system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
   --mi-font-size-normal: 1rem;
   --mi-font-size-small: 0.875rem;
@@ -66,7 +59,6 @@ body {
   background-color: var(--mi-normal-background-color);
   color: var(--mi-normal-foreground-color);
   font-family: var(--mi-font-family-stack);
-  font-smoothing: antialiased;
 }
 body,
 root {


### PR DESCRIPTION
Close #1283.

Any and all eyes on this would be appreciated. I replaced Arial and several others with `system-ui` ([95% on caniuse](https://caniuse.com/?search=system-ui)). Fallback of `sans-serif` as before. Pulled from here: https://github.com/system-fonts/modern-font-stacks. 

Looks good here on macOS which uses San Francisco. Raspberry Pi OS (variant of Debian) uses PibotoLt, which is similar to Android's Roboto.

<img width="1332" alt="Screenshot 2025-07-10 at 00 33 24" src="https://github.com/user-attachments/assets/bfdfbccf-fbb9-41b0-8091-3f6bcfc4bbe5" />
