### PR TITLE
Bug: Track appears unsaved

### DIFF
--- a/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/EditTrackRow.tsx
+++ b/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/EditTrackRow.tsx
@@ -130,7 +130,7 @@ const EditTrackRow: React.FC<{
           packet
         );
 
-        if (formData.trackFile.length > 0) {
+        if (!!formData.trackFile && formData.trackFile.length > 0) {
           const jobInfo = await api.uploadFile(
             `manage/tracks/${trackId}/audio`,
             [formData.trackFile[0]]


### PR DESCRIPTION
Running into `formData.trackFile` undefined, track appears to not save due to lack of toast.

After I named this branch, I noticed it happens even if release isn't published.