### PR TITLE
fix: delete confirmation popup showing raw variable name

### DIFF
--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -680,6 +680,7 @@
   },
   "artistForm": {
     "deleteArtist": "Permanently delete artist page",
+    "areYouSureDelete": "Are your sure you want to delete this artist page?",
     "whatLabelsisThisArtistPartOf": "What label is this artist a part of?",
     "terminationDanger": " Artist page termination ",
     "backgroundImageLabel": "Background image",


### PR DESCRIPTION
i did a thing ! i saw this happening from the artist page and thought this might be quite easy to fix so i dipped my toes. i hope it's fixed ?
<img width="489" height="173" alt="image" src="https://github.com/user-attachments/assets/ea830afa-91de-4c49-9ac6-84f17a5c7fcb" />
