### PR TITLE
feat: Add TikTok to link list and remove unneeded function

### DIFF
--- a/client/src/components/ManageArtist/ArtistFormLinks.tsx
+++ b/client/src/components/ManageArtist/ArtistFormLinks.tsx
@@ -7,7 +7,6 @@ import { FaPen, FaPlus, FaSave, FaTimes, FaTrash } from "react-icons/fa";
 import React from "react";
 import {
   findOutsideSite,
-  linkUrlDisplay,
   linkUrlHref,
   outsideLinks,
 } from "components/common/LinkIconDisplay";
@@ -134,7 +133,6 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
                   align-items: center;
                 `}
               >
-                {linkUrlDisplay(l)}
               </ArtistButtonAnchor>
             );
           })}

--- a/client/src/components/common/LinkIconDisplay.tsx
+++ b/client/src/components/common/LinkIconDisplay.tsx
@@ -11,6 +11,7 @@ import {
   FaBluesky,
   FaYoutube,
   FaPatreon,
+  FaTiktok,
   FaXTwitter,
   FaTwitch,
   FaVideo,
@@ -103,6 +104,7 @@ export const outsideLinks = [
   { matches: "youtube.com", icon: <FaYoutube />, name: "YouTube" },
   { matches: "patreon.com", icon: <FaPatreon />, name: "Patreon" },
   { matches: "twitch.tv", icon: <FaTwitch />, name: "Twitch" },
+  { matches: "tiktok.com", icon: <FaTiktok />, name: "TikTok" },
   { matches: "@", icon: <FiMail />, name: "Email" },
   { matches: "", icon: <FaGlobe />, name: "Website" },
 ];


### PR DESCRIPTION
**Description:**

This PR addresses issue #1406 by adding TikTok as a new social media link option to the list of available links. It also includes the removal of the `linkUrlDisplay` function from `ArtistFormLinks`, which is no longer needed.

**Changes:**

- Adds a new `tiktok` option to the list of available links.
- Deletes the `linkUrlDisplay` function to clean up the codebase.

**Related Issue:**

Closes #1406 