### PR TITLE
Localize SmallTileDetails labels

### DIFF
--- a/client/src/components/common/SmallTileDetails.tsx
+++ b/client/src/components/common/SmallTileDetails.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/css";
 import { bp } from "../../constants";
 import React from "react";
 import styled from "@emotion/styled";
+import { Trans } from "react-i18next";
 
 const WidgetSection = styled.div`
   overflow: hidden;
@@ -28,6 +29,10 @@ export const SmallTileDetails: React.FC<{
   footer,
   textColor = "var(--mi-normal-foreground-color)",
 }) => {
+  const SubtitleComponent = () => <span>{subtitle}</span>;
+
+  const FooterComponent = () => <>{footer}</>;
+
   return (
     <>
       <div
@@ -83,8 +88,14 @@ export const SmallTileDetails: React.FC<{
               }
             `}
           >
-            <span>from </span>
-            <span>{subtitle}</span>
+            <Trans
+              ns="translation"
+              i18nKey="smallTileDetails.subtitle"
+              components={{
+                label: <span />,
+                subtitle: <SubtitleComponent />,
+              }}
+            />
           </WidgetSection>
         )}
         {footer && (
@@ -109,7 +120,14 @@ export const SmallTileDetails: React.FC<{
               }
             `}
           >
-            {"by"} {footer}
+            <Trans
+              ns="translation"
+              i18nKey="smallTileDetails.footer"
+              components={{
+                label: <span />,
+                footer: <FooterComponent />,
+              }}
+            />
           </WidgetSection>
         )}
       </div>

--- a/client/src/components/common/SmallTileDetails.tsx
+++ b/client/src/components/common/SmallTileDetails.tsx
@@ -29,10 +29,6 @@ export const SmallTileDetails: React.FC<{
   footer,
   textColor = "var(--mi-normal-foreground-color)",
 }) => {
-  const SubtitleComponent = () => <span>{subtitle}</span>;
-
-  const FooterComponent = () => <>{footer}</>;
-
   return (
     <>
       <div
@@ -93,7 +89,7 @@ export const SmallTileDetails: React.FC<{
               i18nKey="smallTileDetails.subtitle"
               components={{
                 label: <span />,
-                subtitle: <SubtitleComponent />,
+                subtitle: <>{subtitle}</>,
               }}
             />
           </WidgetSection>
@@ -125,7 +121,7 @@ export const SmallTileDetails: React.FC<{
               i18nKey="smallTileDetails.footer"
               components={{
                 label: <span />,
-                footer: <FooterComponent />,
+                footer: <>{footer}</>,
               }}
             />
           </WidgetSection>

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -1057,6 +1057,10 @@
     "viewCodes": "Overview of your codes",
     "codesForGroup": "Codes for {{ group }}"
   },
+  "smallTileDetails": {
+    "subtitle": "<label>from</label> <subtitle/>",
+    "footer": "<label>by</label> <footer/>"
+  },
   "artists": {
     "artists": "All artists",
     "sortBy": "Sort by",


### PR DESCRIPTION
Changes:
- Localized the SmallTileDetails subtitle and footer using `Trans`, so translators can control the full “from/by” phrases shown with release metadata.
- Added English translation templates for the SmallTileDetails subtitle and footer strings to support localization work.