### PR TITLE
Limit loading state to active promo code button

### DIFF
--- a/client/src/components/ManageArtist/AlbumTools/AlbumCodesRow.tsx
+++ b/client/src/components/ManageArtist/AlbumTools/AlbumCodesRow.tsx
@@ -21,9 +21,10 @@ const OverflowTD = styled.td`
 
 const AlbumCodesRow: React.FC<{
   r: Reduced;
-  downloadCodes: (group: string) => Promise<void>;
+  downloadCodes: (group: string, trackGroupId: number) => Promise<void>;
   albumCodes: AlbumCode[];
-}> = ({ r, downloadCodes, albumCodes }) => {
+  isDownloading: boolean;
+}> = ({ r, downloadCodes, albumCodes, isDownloading }) => {
   const snackbar = useSnackbar();
   const { t } = useTranslation("translation", {
     keyPrefix: "manageArtistTools",
@@ -45,8 +46,9 @@ const AlbumCodesRow: React.FC<{
         <ArtistButton
           size="compact"
           startIcon={<FaFileCsv />}
-          onClick={() => downloadCodes(r.group)}
+          onClick={() => downloadCodes(r.group, r.trackGroupId)}
           variant="dashed"
+          isLoading={isDownloading}
         />
         <ArtistButton
           size="compact"


### PR DESCRIPTION
Changes:
- Tracked the active promo-code download target (all codes vs. a specific group) and reset it after each request so only the relevant control shows its loading spinner.
- Passed a per-row `isDownloading` flag into `AlbumCodesRow` and bound the CSV button’s `isLoading` prop to that flag, ensuring only the clicked row animates during its download.

Why?
- Closes #1480