### PR TITLE
Add help text for tiling background image option

### DIFF
--- a/client/src/components/ManageArtist/ManageArtistDetails/CustomizeLook.tsx
+++ b/client/src/components/ManageArtist/ManageArtistDetails/CustomizeLook.tsx
@@ -312,6 +312,7 @@ export const CustomizeLook: React.FC = () => {
                       type="checkbox"
                       {...methods.register("properties.tileBackgroundImage")}
                     />
+                    <small>{t("tileImageDescription")}</small>
                   </FormComponent>
                 </div>
               </div>

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -821,6 +821,7 @@
     "uploading": "Uploading...",
     "replace": "Replace",
     "tileImage": "Tile background image?",
+    "tileImageDescription": "The image will be duplicated to cover the whole background area.",
     "updatedArtist": "Updated artist",
     "dimensionsTip": "For the best effect, upload a {{maxDimensions}} size image. File size is limited to {{ maxSize }}.",
     "yourAlbums": "Your albums",


### PR DESCRIPTION
Changes:
- Added helper text below the tile background image checkbox to clarify how tiling affects the artist banner display.
- Added a corresponding translation string explaining that the background image will repeat to fill the entire area.

Why?
- Closes #1377