### PR TITLE
Adjust single-track hover labels

### DIFF
--- a/client/src/components/Artist/ArtistItemLink.tsx
+++ b/client/src/components/Artist/ArtistItemLink.tsx
@@ -46,10 +46,15 @@ const ArtistItemLink: React.FC<{
 
   const url = determineItemLink(artist, item);
 
+  const labelKey =
+    isTrack(item) || (isTrackgroup(item) && item.tracks?.length === 1)
+      ? "goToTrack"
+      : "goToAlbum";
+
   return (
     <Link
       to={url}
-      aria-label={`${t("goToAlbum")}: ${item.title || t("untitled")}`}
+      aria-label={`${t(labelKey)}: ${item.title || t("untitled")}`}
       className={
         item.title?.length
           ? css`

--- a/client/src/components/common/ClickToPlay.tsx
+++ b/client/src/components/common/ClickToPlay.tsx
@@ -271,12 +271,18 @@ const ClickToPlay: React.FC<
     }
   }, [dispatch, localTrackIds, detectTracksPlayable]);
 
+  const isSingleTrackGroup = !track && trackGroup.tracks.length === 1;
+
+  const linkTarget = track ?? (isSingleTrackGroup ? trackGroup.tracks[0] : trackGroup);
+
+  const linkLabelKey = track || isSingleTrackGroup ? "goToTrack" : "goToAlbum";
+
   const currentlyPlaying =
     playing &&
     currentlyPlayingIndex !== undefined &&
     localTrackIds.includes(playerQueueIds[currentlyPlayingIndex]);
 
-  const url = determineItemLink(trackGroup.artist, track ?? trackGroup);
+  const url = determineItemLink(trackGroup.artist, linkTarget);
   return (
     <ClickToPlayWrapper>
       <Wrapper className={className}>
@@ -322,7 +328,7 @@ const ClickToPlay: React.FC<
           {/*
            * Likewise, this "Go to album" text SHOULD also be used to describe the album link (through aria-label).
            */}
-          <p aria-hidden>{t(track ? "goToTrack" : "goToAlbum")}</p>
+          <p aria-hidden>{t(linkLabelKey)}</p>
         </PlayWrapper>
 
         {currentlyPlaying && (


### PR DESCRIPTION
Changes:
- Treated single-track releases as tracks when determining the ClickToPlay overlay label and destination, ensuring hover text says “Go to track” for one-track albums.
- Adjusted ArtistItemLink aria-label generation so track destinations use the “Go to track” phrasing for both tracks and single-track releases.

Why?
- Closes #1277