### PR TITLE
Fetch favicons for custom artist links

### DIFF
--- a/client/src/components/ManageArtist/ArtistFormLinks.tsx
+++ b/client/src/components/ManageArtist/ArtistFormLinks.tsx
@@ -32,9 +32,21 @@ interface ArtistFormLinksProps {
   onSubmit: (data: Pick<Artist, "linksJson">) => Promise<void>;
 }
 
+const normalizeStoredLink = (link: Link): Link => ({
+  ...link,
+  inHeader: link.inHeader ?? true,
+  linkLabel: link.linkLabel ?? "",
+  linkType: link.linkType ?? "",
+  iconUrl: link.iconUrl ?? undefined,
+});
+
 export function transformFromLinks(
   artist: Pick<Artist, "links" | "linksJson">
 ): FormData {
+  const normalizedJsonLinks = (artist.linksJson ?? []).map((link) =>
+    normalizeStoredLink(link)
+  );
+
   return {
     linkArray: [
       ...(artist.links?.map((l) => ({
@@ -44,13 +56,7 @@ export function transformFromLinks(
         inHeader: true,
         iconUrl: undefined,
       })) ?? []),
-      ...((artist.linksJson ?? []).map((link) => ({
-        ...link,
-        inHeader: link.inHeader ?? true,
-        linkLabel: link.linkLabel ?? "",
-        linkType: link.linkType ?? "",
-        iconUrl: link.iconUrl ?? undefined,
-      })) as Link[]),
+      ...normalizedJsonLinks,
     ],
   };
 }

--- a/client/src/components/ManageArtist/ArtistFormLinks.tsx
+++ b/client/src/components/ManageArtist/ArtistFormLinks.tsx
@@ -7,6 +7,7 @@ import { FaPen, FaPlus, FaSave, FaTimes, FaTrash } from "react-icons/fa";
 import React from "react";
 import {
   findOutsideSite,
+  isEmailLink,
   linkUrlHref,
   outsideLinks,
 } from "components/common/LinkIconDisplay";
@@ -41,15 +42,97 @@ export function transformFromLinks(
         linkType: "",
         linkLabel: "",
         inHeader: true,
+        iconUrl: undefined,
       })) ?? []),
-      ...(artist.linksJson ?? []),
+      ...((artist.linksJson ?? []).map((link) => ({
+        ...link,
+        inHeader: link.inHeader ?? true,
+        linkLabel: link.linkLabel ?? "",
+        linkType: link.linkType ?? "",
+        iconUrl: link.iconUrl ?? undefined,
+      })) as Link[]),
     ],
   };
 }
 
 function transformToLinks(data: FormData): Pick<Artist, "linksJson" | "links"> {
-  return { linksJson: data.linkArray, links: [] };
+  return {
+    linksJson: data.linkArray.map((link) => {
+      const trimmedLinkType = link.linkType?.trim();
+      const matchingSite = trimmedLinkType
+        ? outsideLinks.find((site) => site.name === trimmedLinkType)
+        : undefined;
+      const allowsCustomIcon =
+        !matchingSite || matchingSite.matches === "";
+
+      const sanitizedIconUrl = link.iconUrl?.trim();
+
+      const sanitizedLink: Link = {
+        ...link,
+        linkType: trimmedLinkType ?? "",
+      };
+
+      if (allowsCustomIcon && sanitizedIconUrl) {
+        sanitizedLink.iconUrl = sanitizedIconUrl;
+      } else {
+        delete sanitizedLink.iconUrl;
+      }
+
+      return sanitizedLink;
+    }),
+    links: [],
+  };
 }
+
+const websiteSite = outsideLinks.find((site) => site.matches === "");
+const DEFAULT_WEBSITE_NAME = websiteSite?.name ?? "Website";
+
+const normalizeUrlInput = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  return linkUrlHref(trimmed);
+};
+
+const allowsCustomIconForLinkType = (linkType?: string) => {
+  if (!linkType) {
+    return true;
+  }
+  const matchingSite = outsideLinks.find((site) => site.name === linkType);
+  return !matchingSite || matchingSite.matches === "";
+};
+
+const resolveFaviconUrl = async (url: string): Promise<string | undefined> => {
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) {
+    return undefined;
+  }
+
+  if (
+    typeof window === "undefined" ||
+    typeof Image === "undefined" ||
+    isEmailLink(trimmedUrl)
+  ) {
+    return undefined;
+  }
+
+  try {
+    const parsedUrl = new URL(trimmedUrl);
+    const faviconUrl = `https://icons.duckduckgo.com/ip3/${parsedUrl.hostname}.ico`;
+
+    const isValid = await new Promise<boolean>((resolve) => {
+      const image = new Image();
+      image.onload = () => resolve(true);
+      image.onerror = () => resolve(false);
+      image.src = faviconUrl;
+    });
+
+    return isValid ? faviconUrl : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
   artist,
@@ -62,7 +145,8 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
   const methods = useForm<FormData>({
     values: transformFromLinks(artist),
   });
-  const { register, control, watch, handleSubmit, reset, setValue } = methods;
+  const { register, control, watch, handleSubmit, reset, setValue, getValues } =
+    methods;
   const { fields, append, remove } = useFieldArray({
     control,
     name: "linkArray",
@@ -81,11 +165,42 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
   );
 
   const handleInputElBlur = React.useCallback(
-    (val: string, index: number) => {
-      const newVal = findOutsideSite({ url: val, linkType: "" }).name;
+    async (val: string, index: number) => {
+      const normalizedUrl = normalizeUrlInput(val);
+
+      if (!normalizedUrl) {
+        setValue(`linkArray.${index}.url`, "");
+        setValue(`linkArray.${index}.linkType`, "");
+        setValue(`linkArray.${index}.iconUrl`, undefined);
+        return;
+      }
+
+      setValue(`linkArray.${index}.url`, normalizedUrl);
+
+      const newVal = findOutsideSite({ url: normalizedUrl, linkType: "" }).name;
       setValue(`linkArray.${index}.linkType`, newVal);
+
+      if (!allowsCustomIconForLinkType(newVal)) {
+        setValue(`linkArray.${index}.iconUrl`, undefined);
+        return;
+      }
+
+      setValue(`linkArray.${index}.iconUrl`, undefined);
+      const iconUrl = await resolveFaviconUrl(normalizedUrl);
+
+      if (getValues(`linkArray.${index}.url`) !== normalizedUrl) {
+        return;
+      }
+
+      if (!allowsCustomIconForLinkType(getValues(`linkArray.${index}.linkType`))) {
+        return;
+      }
+
+      if (iconUrl) {
+        setValue(`linkArray.${index}.iconUrl`, iconUrl);
+      }
     },
-    [setValue]
+    [getValues, setValue]
   );
 
   return (
@@ -111,6 +226,10 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
               > svg {
                 margin-right: 0.5rem;
               }
+
+              > img {
+                margin-right: 0.5rem;
+              }
             }
 
             a:last-child {
@@ -119,6 +238,7 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
           `}
         >
           {links
+            .slice()
             .sort((l) => (findOutsideSite(l).showFull ? 1 : -1))
             .map((l) => {
               const site = findOutsideSite(l);
@@ -166,7 +286,8 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
       <Modal open={isOpen} size="small" onClose={() => setIsOpen(false)}>
         <FormProvider {...methods}>
           {fields.map((field, index) => {
-            const linkType = watch(`linkArray.${index}.linkType`);
+            const linkValue = watch(`linkArray.${index}`) as Link | undefined;
+            const site = linkValue ? findOutsideSite(linkValue) : undefined;
             return (
               <div
                 key={index}
@@ -177,6 +298,11 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
                   margin-left: 0.5rem;
 
                   > svg {
+                    margin-right: 0.5rem;
+                    min-width: 1rem;
+                  }
+
+                  > img {
                     margin-right: 0.5rem;
                     min-width: 1rem;
                   }
@@ -222,6 +348,7 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
                   <div id={`linkIcon${index}`}>
                     <SelectEl {...register(`linkArray.${index}.linkType`)}>
                       {outsideLinks
+                        .slice()
                         .sort((a, b) => {
                           if (a.name > b.name) {
                             return 1;
@@ -237,7 +364,7 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
                           </option>
                         ))}
                     </SelectEl>
-                    &nbsp;{outsideLinks.find((l) => l.name === linkType)?.icon}
+                    &nbsp;{site?.icon}
                   </div>
                   <label
                     className={css`
@@ -272,8 +399,10 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
                     `}
                     id={`linkUrl${index}`}
                     {...register(`linkArray.${index}.url`, {
-                      setValueAs: linkUrlHref,
-                      onBlur: (e) => handleInputElBlur(e.target.value, index),
+                      setValueAs: normalizeUrlInput,
+                      onBlur: (e) => {
+                        void handleInputElBlur(e.target.value, index);
+                      },
                     })}
                     placeholder={t("linkPlaceholder") ?? ""}
                     key={field.id}
@@ -314,6 +443,7 @@ const ArtistFormLinks: React.FC<ArtistFormLinksProps> = ({
                 append({
                   url: "",
                   linkType: "",
+                  iconUrl: undefined,
                 })
               }
               startIcon={<FaPlus />}

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -193,6 +193,7 @@ interface Link {
   linkType?: string;
   linkLabel?: string;
   inHeader?: boolean;
+  iconUrl?: string;
 }
 
 interface ArtistLabel {


### PR DESCRIPTION
Changes:
- Enhanced the Manage Artist links form to normalize saved data, fetch DuckDuckGo favicons for custom website entries, and surface the icon previews throughout the editor and link list views.
- Updated the link icon resolver to render stored favicon images and added an optional `iconUrl` property to the shared `Link` type.

Why?
- Closes #930