### PR TITLE
Handle cancelled Stripe checkout redirects

### DIFF
--- a/client/src/components/Checkout/CheckoutError.tsx
+++ b/client/src/components/Checkout/CheckoutError.tsx
@@ -1,0 +1,77 @@
+import { css } from "@emotion/css";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+
+import { WidthWrapper } from "components/common/WidthContainer";
+
+type MessageKey =
+  | "generic"
+  | "userCanceled"
+  | "abandoned"
+  | "paymentFailed"
+  | "expired";
+
+const REASON_TRANSLATION_MAP: Record<string, MessageKey> = {
+  user_canceled: "userCanceled",
+  abandoned: "abandoned",
+  expired: "expired",
+  failed: "paymentFailed",
+  failed_invoice: "paymentFailed",
+  void_invoice: "paymentFailed",
+  declined: "paymentFailed",
+  duplicate: "paymentFailed",
+  fraudulent: "paymentFailed",
+  expired_card: "paymentFailed",
+  lost_card: "paymentFailed",
+  stolen_card: "paymentFailed",
+  testmode_payment_canceled: "paymentFailed",
+};
+
+const DEFAULT_MESSAGE_KEY: MessageKey = "generic";
+
+type RouteParams = {
+  artistId?: string;
+};
+
+function CheckoutError() {
+  const { t } = useTranslation("translation", { keyPrefix: "checkoutError" });
+  const [searchParams] = useSearchParams();
+  const { artistId } = useParams<RouteParams>();
+
+  const reason = (searchParams.get("reason") ?? "").toLowerCase();
+  const messageKey = REASON_TRANSLATION_MAP[reason] ?? DEFAULT_MESSAGE_KEY;
+  const homePath = useMemo(
+    () => (artistId ? `/${encodeURIComponent(artistId)}` : "/"),
+    [artistId]
+  );
+
+  return (
+    <WidthWrapper
+      variant="small"
+      className={css`
+        margin-top: 4rem !important;
+        text-align: center;
+
+        h1 {
+          margin-bottom: 1.5rem;
+        }
+
+        p {
+          margin-bottom: 2rem;
+        }
+
+        a {
+          color: var(--color-primary);
+          font-weight: 600;
+        }
+      `}
+    >
+      <h1>{t("title")}</h1>
+      <p>{t(messageKey)}</p>
+      <Link to={homePath}>{t("returnHome")}</Link>
+    </WidthWrapper>
+  );
+}
+
+export default CheckoutError;

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -115,6 +115,17 @@ const routes: RouteObject[] = [
         },
       },
       {
+        path: "checkout-error",
+        async lazy() {
+          const { default: Component } = await import(
+            "components/Checkout/CheckoutError"
+          );
+          return {
+            Component: () => <Component />,
+          };
+        },
+      },
+      {
         path: "password-reset",
         async lazy() {
           const { default: Component } = await import(
@@ -715,6 +726,17 @@ const routes: RouteObject[] = [
                 async lazy() {
                   const { default: Component } = await import(
                     "components/Artist/CheckoutComplete"
+                  );
+                  return {
+                    Component: () => <Component />,
+                  };
+                },
+              },
+              {
+                path: "checkout-error",
+                async lazy() {
+                  const { default: Component } = await import(
+                    "components/Checkout/CheckoutError"
                   );
                   return {
                     Component: () => <Component />,

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -460,6 +460,15 @@
     "isSubscribed": "Subscribed",
     "moreLinks": "More links"
   },
+  "checkoutError": {
+    "title": "Checkout not completed",
+    "generic": "We couldn't finish your checkout. Please try again or contact support if the issue keeps happening.",
+    "userCanceled": "It looks like you left the checkout before finishing your purchase.",
+    "abandoned": "The checkout closed before Stripe confirmed your payment. Please start over to try again.",
+    "paymentFailed": "Stripe couldn't process your payment method. Please try another card or contact support if this continues.",
+    "expired": "This checkout session expired before the payment was completed. Please restart the checkout to continue.",
+    "returnHome": "Return to Mirlo"
+  },
   "clickToPlay": {
     "untitled": "Untitled",
     "goToAlbum": "Go to album",

--- a/src/routers/v1/checkout/index.ts
+++ b/src/routers/v1/checkout/index.ts
@@ -128,8 +128,6 @@ export default function () {
           const artist = await prisma.artist.findUnique({
             where: { id: +artistId },
           });
-          const client = await clientPromise;
-          const artist = await artistPromise;
 
           const searchParams = new URLSearchParams();
           searchParams.set("purchaseType", purchaseType ?? "");

--- a/src/routers/v1/checkout/index.ts
+++ b/src/routers/v1/checkout/index.ts
@@ -66,14 +66,12 @@ export default function () {
         const clientId = parseNumericQueryParam(req.query.clientId);
         const artistId = parseNumericQueryParam(req.query.artistId);
 
-        const clientPromise = clientId
-          ? prisma.client.findUnique({ where: { id: clientId } })
-          : Promise.resolve(null);
-        const artistPromise = artistId
-          ? prisma.artist.findUnique({ where: { id: artistId } })
-          : Promise.resolve(null);
-        const client = await clientPromise;
-        const artist = await artistPromise;
+        const client = clientId
+          ? await prisma.client.findUnique({ where: { id: clientId } })
+          : null;
+        const artist = artistId
+          ? await prisma.artist.findUnique({ where: { id: artistId } })
+          : null;
 
         const checkoutPath = artist?.urlSlug
           ? `${artist.urlSlug}/checkout-error`
@@ -124,10 +122,10 @@ export default function () {
           tipId: string | null;
         };
         if (clientId && artistId) {
-          const clientPromise = prisma.client.findUnique({
+          const client = await prisma.client.findUnique({
             where: { id: +clientId },
           });
-          const artistPromise = prisma.artist.findUnique({
+          const artist = await prisma.artist.findUnique({
             where: { id: +artistId },
           });
           const client = await clientPromise;

--- a/src/routers/v1/checkout/index.ts
+++ b/src/routers/v1/checkout/index.ts
@@ -3,14 +3,100 @@ import prisma from "@mirlo/prisma";
 
 import stripe from "../../../utils/stripe";
 
+const DEFAULT_CLIENT_BASE_URL =
+  process.env.REACT_APP_CLIENT_DOMAIN ?? "https://mirlo.space";
+
+const ensureTrailingSlash = (value: string) =>
+  value.endsWith("/") ? value : `${value}/`;
+
+const normaliseBaseUrl = (candidate?: string | null) => {
+  const fallback = ensureTrailingSlash(DEFAULT_CLIENT_BASE_URL);
+  if (!candidate) {
+    return fallback;
+  }
+
+  try {
+    const trimmed = candidate.trim();
+    if (!trimmed) {
+      return fallback;
+    }
+
+    const parsed = new URL(trimmed);
+    return ensureTrailingSlash(parsed.toString());
+  } catch (error) {
+    console.warn(
+      "Invalid client application URL provided, falling back to default domain",
+      error
+    );
+    return fallback;
+  }
+};
+
+const parseNumericQueryParam = (value: unknown) => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const buildCheckoutRedirectUrl = (
+  baseUrl: string | null | undefined,
+  path: string,
+  params: URLSearchParams
+) => {
+  const target = new URL(path.replace(/^\/+/, ""), normaliseBaseUrl(baseUrl));
+  params.forEach((value, key) => {
+    target.searchParams.set(key, value);
+  });
+
+  return target.toString();
+};
+
 export default function () {
   const operations = {
     GET: [GET],
   };
 
   async function GET(req: Request, res: Response, next: NextFunction) {
-    const { success, session_id, stripeAccountId } = req.query;
+    const { success, canceled, session_id, stripeAccountId } = req.query;
     try {
+      if (canceled) {
+        const clientId = parseNumericQueryParam(req.query.clientId);
+        const artistId = parseNumericQueryParam(req.query.artistId);
+
+        const clientPromise = clientId
+          ? prisma.client.findUnique({ where: { id: clientId } })
+          : Promise.resolve(null);
+        const artistPromise = artistId
+          ? prisma.artist.findUnique({ where: { id: artistId } })
+          : Promise.resolve(null);
+        const client = await clientPromise;
+        const artist = await artistPromise;
+
+        const checkoutPath = artist?.urlSlug
+          ? `${artist.urlSlug}/checkout-error`
+          : "checkout-error";
+
+        const reasonParam =
+          typeof req.query.reason === "string" && req.query.reason
+            ? req.query.reason
+            : "user_canceled";
+
+        const searchParams = new URLSearchParams();
+        searchParams.set("reason", reasonParam);
+
+        res.redirect(
+          buildCheckoutRedirectUrl(
+            client?.applicationUrl ?? null,
+            checkoutPath,
+            searchParams
+          )
+        );
+        return;
+      }
+
       if (
         typeof session_id === "string" &&
         typeof stripeAccountId === "string"
@@ -38,15 +124,14 @@ export default function () {
           tipId: string | null;
         };
         if (clientId && artistId) {
-          const client = await prisma.client.findFirst({
-            where: {
-              id: +clientId,
-            },
+          const clientPromise = prisma.client.findUnique({
+            where: { id: +clientId },
           });
-
-          const artist = await prisma.artist.findFirst({
+          const artistPromise = prisma.artist.findUnique({
             where: { id: +artistId },
           });
+          const client = await clientPromise;
+          const artist = await artistPromise;
 
           const searchParams = new URLSearchParams();
           searchParams.set("purchaseType", purchaseType ?? "");
@@ -57,14 +142,19 @@ export default function () {
           merchId && searchParams.set("merchId", merchId);
           tipId && searchParams.set("tipId", tipId);
 
-          res.redirect(
-            client?.applicationUrl +
-              `/${artist?.urlSlug}/checkout-complete?${searchParams.toString()}`
-          );
+          if (artist?.urlSlug) {
+            res.redirect(
+              buildCheckoutRedirectUrl(
+                client?.applicationUrl ?? null,
+                `${artist.urlSlug}/checkout-complete`,
+                searchParams
+              )
+            );
+          } else {
+            res.redirect(normaliseBaseUrl(client?.applicationUrl ?? null));
+          }
         } else {
-          res.redirect(
-            process.env.REACT_APP_CLIENT_DOMAIN ?? "https://mirlo.space"
-          );
+          res.redirect(normaliseBaseUrl());
         }
       } else {
         res


### PR DESCRIPTION
Changes:
- Redirected cancelled Stripe checkout requests to a frontend error page, using client and artist lookups to choose the appropriate destination and providing a reason code for display.
- Added client and artist identifiers to Stripe cancel URLs for catalogue purchases, tips, and subscriptions so the API can generate accurate redirects after a cancellation.
- Created a checkout error view with routing and translations to explain cancelled purchases to users on both artist-specific and global pages.

Why?
- Fixes #907