### PR TITLE
Show login modal when favoriting while logged out

### DIFF
--- a/client/src/components/TrackGroup/Favorite.tsx
+++ b/client/src/components/TrackGroup/Favorite.tsx
@@ -1,46 +1,117 @@
-import Button, { ButtonLink } from "components/common/Button";
+import Button from "components/common/Button";
+import LogInForm from "components/common/LogInForm";
+import Modal from "components/common/Modal";
 import React from "react";
-import api from "services/api";
-import { useAuthContext } from "state/AuthContext";
 import { useTranslation } from "react-i18next";
 import { ImStarEmpty, ImStarFull } from "react-icons/im";
+import api from "services/api";
+import useErrorHandler from "services/useErrorHandler";
+import { useAuthContext } from "state/AuthContext";
 
 const FavoriteTrack: React.FC<{
   track: { id: number };
   collapse?: boolean;
 }> = ({ track, collapse }) => {
-  const { user } = useAuthContext();
-  const { t } = useTranslation("translation", { keyPrefix: "wishlist" });
+  const { user, refreshLoggedInUser } = useAuthContext();
+  const errorHandler = useErrorHandler();
+  const { t: tWishlist } = useTranslation("translation", {
+    keyPrefix: "wishlist",
+  });
+  const { t: tLogIn } = useTranslation("translation", { keyPrefix: "logIn" });
 
   const [isInFavorites, setIsInFavorites] = React.useState(
     !!user?.trackFavorites?.find((w) => w.trackId === track.id)
   );
+  const [isLogInModalOpen, setIsLogInModalOpen] = React.useState(false);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (user === undefined) {
+      return;
+    }
+
+    if (!user) {
+      setIsInFavorites(false);
+      return;
+    }
+
+    setIsInFavorites(
+      !!user.trackFavorites?.find((favorite) => favorite.trackId === track.id)
+    );
+  }, [track.id, user]);
+
+  const openLoginModal = React.useCallback(() => {
+    setIsLogInModalOpen(true);
+  }, []);
+
+  const closeLoginModal = React.useCallback(() => {
+    setIsLogInModalOpen(false);
+  }, []);
 
   const onClick = React.useCallback(async () => {
-    await api.post(`tracks/${track.id}/favorite`, {
-      favorite: !isInFavorites,
-    });
-    setIsInFavorites((val) => !val);
-  }, [isInFavorites, track.id]);
+    if (user === undefined || isSubmitting) {
+      return;
+    }
 
-  if (!user) {
-    return null;
-  }
+    if (!user) {
+      openLoginModal();
+      return;
+    }
 
-  const buttonLabel = `${isInFavorites ? t("removeFromFavorites") : t("addToFavorites")}`;
+    const nextFavoriteState = !isInFavorites;
+
+    try {
+      setIsSubmitting(true);
+      await api.post(`tracks/${track.id}/favorite`, {
+        favorite: nextFavoriteState,
+      });
+      setIsInFavorites(nextFavoriteState);
+      refreshLoggedInUser();
+    } catch (error) {
+      errorHandler(error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    errorHandler,
+    isInFavorites,
+    isSubmitting,
+    openLoginModal,
+    refreshLoggedInUser,
+    track.id,
+    user,
+  ]);
+
+  const buttonLabel = `${
+    isInFavorites ? tWishlist("removeFromFavorites") : tWishlist("addToFavorites")
+  }`;
 
   return (
-    <Button
-      size="compact"
-      variant="transparent"
-      onClick={onClick}
-      aria-label={buttonLabel}
-      className="favorite"
-      title={buttonLabel}
-      startIcon={isInFavorites ? <ImStarFull /> : <ImStarEmpty />}
-    >
-      {!collapse && buttonLabel}
-    </Button>
+    <>
+      <Button
+        size="compact"
+        variant="transparent"
+        onClick={onClick}
+        aria-label={buttonLabel}
+        className="favorite"
+        title={buttonLabel}
+        startIcon={isInFavorites ? <ImStarFull /> : <ImStarEmpty />}
+        disabled={user === undefined || isSubmitting}
+      >
+        {!collapse && buttonLabel}
+      </Button>
+
+      {!user && (
+        <Modal
+          open={isLogInModalOpen}
+          onClose={closeLoginModal}
+          size="small"
+          title={tLogIn("logIn") ?? ""}
+        >
+          <LogInForm afterLogIn={closeLoginModal} />
+        </Modal>
+      )}
+    </>
   );
 };
 

--- a/client/src/components/common/ClickToPlay.tsx
+++ b/client/src/components/common/ClickToPlay.tsx
@@ -317,7 +317,7 @@ const ClickToPlay: React.FC<
                 <Wishlist trackGroup={trackGroup} />
               </div>
             )}
-            {user && showTrackFavorite && trackGroup.tracks && (
+            {showTrackFavorite && trackGroup.tracks && (
               <div>
                 <FavoriteTrack track={trackGroup.tracks[0]} collapse />
               </div>


### PR DESCRIPTION
Changes:
- Display the track favorite control for logged-out visitors, synchronise its state with auth updates, and launch the shared login modal when they attempt to favorite a track.
- Allow the “Click to play” widget to render the favorite button regardless of authentication so the login prompt can appear when needed.

Why?
- Closes #392