### PR TITLE
feat: slugify with rules of user language

### DIFF
--- a/client/src/components/common/SlugInput.tsx
+++ b/client/src/components/common/SlugInput.tsx
@@ -17,7 +17,9 @@ const SlugInput: React.FC<{
   currentName?: string;
 }> = ({ currentArtistId, isDisabled, type, currentName }) => {
   const { colors } = useGetArtistColors();
-  const { t } = useTranslation("translation", { keyPrefix: "manageArtist" });
+  const { i18n, t } = useTranslation("translation", {
+    keyPrefix: "manageArtist",
+  });
   const {
     register,
     watch,
@@ -50,7 +52,11 @@ const SlugInput: React.FC<{
 
   const useCurrentNameAsSlug = React.useCallback(() => {
     if (currentName) {
-      const slug = slugify(currentName, { lower: true, strict: true });
+      const slug = slugify(currentName, {
+        locale: i18n.language,
+        lower: true,
+        strict: true,
+      });
       setValue("urlSlug", slug);
     }
     return "";
@@ -85,6 +91,7 @@ const SlugInput: React.FC<{
         >
           {t("useUrlSlug", {
             suggestedUrlSlug: slugify(currentName.toLowerCase(), {
+              locale: i18n.language,
               strict: true,
             }),
           })}

--- a/src/auth/passport.ts
+++ b/src/auth/passport.ts
@@ -57,6 +57,7 @@ passport.use(
         isAdmin: foundUser?.isAdmin,
         isLabelAccount: foundUser?.isLabelAccount,
         canCreateArtists: foundUser?.canCreateArtists,
+        language: foundUser?.language,
       });
     }
   )

--- a/src/routers/v1/manage/artists/index.ts
+++ b/src/routers/v1/manage/artists/index.ts
@@ -99,8 +99,14 @@ export default function () {
       }
 
       const slug = slugify(
-        urlSlug?.toLowerCase() ?? slugify(name, { lower: true, strict: true }),
+        urlSlug?.toLowerCase() ??
+          slugify(name, {
+            locale: user.language ?? undefined,
+            lower: true,
+            strict: true,
+          }),
         {
+          locale: user.language ?? undefined,
           strict: true,
         }
       );

--- a/src/routers/v1/manage/artists/{artistId}/index.ts
+++ b/src/routers/v1/manage/artists/{artistId}/index.ts
@@ -42,6 +42,7 @@ export default function () {
       shortDescription,
       maxFreePlays,
     } = req.body;
+    const user = req.user as User;
 
     try {
       // FIXME: check type of properties object.
@@ -61,7 +62,13 @@ export default function () {
           shortDescription,
           maxFreePlays,
           ...(urlSlug
-            ? { urlSlug: slugify(urlSlug, { strict: true, lower: true }) }
+            ? {
+                urlSlug: slugify(urlSlug, {
+                  locale: user.language ?? undefined,
+                  strict: true,
+                  lower: true,
+                }),
+              }
             : {}),
           properties,
         },

--- a/src/routers/v1/manage/merch/{merchId}/index.ts
+++ b/src/routers/v1/manage/merch/{merchId}/index.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../../../auth/passport";
 
 import prisma from "@mirlo/prisma";
+import { User } from "@mirlo/prisma/client";
 import { AppError } from "../../../../../utils/error";
 import { deleteMerch, processSingleMerch } from "../../../../../utils/merch";
 import slugify from "slugify";
@@ -98,12 +99,14 @@ export default function () {
         }
       }
 
+      const user = req.user as User;
       await prisma.merch.updateMany({
         where: { id: merchId },
         data: {
           ...newValues,
           urlSlug: !merch?.urlSlug // only update slug if it was not set before
             ? slugify(newValues.title ?? merch?.title, {
+                locale: user.language ?? undefined,
                 strict: true,
                 lower: true,
               })

--- a/src/routers/v1/manage/posts/{postId}/index.ts
+++ b/src/routers/v1/manage/posts/{postId}/index.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { userAuthenticated } from "../../../../../auth/passport";
 import prisma from "@mirlo/prisma";
+import { User } from "@mirlo/prisma/client";
 import { doesPostBelongToUser } from "../../../../../utils/post";
 import { AppError } from "../../../../../utils/error";
 import slugify from "slugify";
@@ -25,6 +26,7 @@ export default function () {
         shouldSendEmail,
         urlSlug,
       } = req.body;
+      const user = req.user as User;
 
       if (minimumSubscriptionTierId !== undefined) {
         const validTier = await prisma.artistSubscriptionTier.findFirst({
@@ -60,6 +62,7 @@ export default function () {
           shouldSendEmail,
           urlSlug: !post?.urlSlug
             ? slugify(urlSlug ?? title ?? post?.title, {
+                locale: user.language ?? undefined,
                 strict: true,
                 lower: true,
               })

--- a/src/routers/v1/manage/trackGroups/{trackGroupId}/index.ts
+++ b/src/routers/v1/manage/trackGroups/{trackGroupId}/index.ts
@@ -118,7 +118,12 @@ export default function () {
       });
 
       if (trackGroup?.title && trackGroup.urlSlug.includes("mi-temp-slug")) {
-        let slug = slugify(newValues.title, { strict: true, lower: true });
+        const loggedInUser = req.user as User;
+        let slug = slugify(newValues.title, {
+          locale: loggedInUser.language ?? undefined,
+          strict: true,
+          lower: true,
+        });
 
         if (slug === "") {
           slug = "blank";

--- a/src/routers/v1/users/{userId}/index.ts
+++ b/src/routers/v1/users/{userId}/index.ts
@@ -164,6 +164,7 @@ export default function () {
               urlSlug:
                 updatedUser.urlSlug ??
                 slugify(updatedUser.name ?? updatedUser.email, {
+                  locale: updatedUser.language ?? undefined,
                   lower: true,
                   strict: true,
                 }),


### PR DESCRIPTION
I like that Mirlo creates URL slugs using transliteration, this is an improvement over Bandcamp which, from what I remember, made `/--123` URLs for Cyrillic titles and rejected my support requests. However, during local testing of translations (#1530, #1545) I notice that Mirlo transliterates Ukrainian titles using Russian rules. For example `и` should become `y` but instead becomes `i`, e.g. for a blog post called `Мій допис` I want `mii-dopys` but have `mij-dopis`.

I read the documentation of `slugify`, the library used by Mirlo for transliteration, and notice that it offers a `locale` configuration parameter that turns on different rule presets depending on the language. I see a `language` field in the `User` entity on the Mirlo back end, and a `language` field in the `i18n` field returned by `useTranslation` on the front end, which, as far as I can see, can be passed to the `locale` of `slugify` as is, at least while the locales are named like `uk` and not `uk_UA`.

So, I patched my local back end to use this and I now get the `miy-dopys` transliteration for my language. `miy` still doesn't match the modern Ukrainian rules but a ruleset from 2000s is better than a ruleset of another language. I'm sharing this patch as a suggestion, but I have to note it was tested manually, I haven't figured out how to write a unit test for this project to guard against regressions.