### PR TITLE
feat: add Ukrainian to finishedLanguages

### DIFF
--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -25,6 +25,7 @@ export const finishedLanguages = [
   { short: "en", name: "English" },
   { short: "fr", name: "Français" },
   { short: "es", name: "Español" },
+  { short: "uk", name: "Українська" },
 ];
 
 const defaultLanguage = finishedLanguages.find((lang) =>


### PR DESCRIPTION
Hi, all remaining 55 untranslated strings on Transifex don't seem to be present anywhere on the Mirlo website, so I think it's safe to turn on Ukrainian for the public, as it's reasonably complete.