### PR TITLE
trackPlays endpoint: Remove Requirement to be Logged in

### DIFF
--- a/src/routers/v1/tracks/{id}/trackPlay.ts
+++ b/src/routers/v1/tracks/{id}/trackPlay.ts
@@ -21,7 +21,7 @@ import { AppError } from "../../../../utils/error";
 
 export default function () {
   const operations = {
-    GET: [userLoggedInWithoutRedirect, GET],
+    GET,
   };
 
   async function GET(req: Request, res: Response, next: NextFunction) {


### PR DESCRIPTION
It look's like `{ ip: req.ip }` from `...(user ? { userId: user.id } : { ip: req.ip }),` can't be reached since a user is required to be logged in?

Was trying to register trackPlays as a logged out user but kept getting an error that the api call was failing. Thinking this might've been the issue