### PR TITLE
add more metadata to track and trackGroup descriptions

### DIFF
--- a/src/parseIndex.ts
+++ b/src/parseIndex.ts
@@ -300,6 +300,7 @@ const parseIndex = async (pathname: string) => {
         include: {
           artist: true,
           cover: true,
+          tracks: true,
         },
       });
       if (tg && route[4] === "tracks") {


### PR DESCRIPTION
Adding more metadata to track and trackGroup descriptions so that more info appears in `[og:description]` meta tag. This helps other projects such as [freq](https://freq.social/about) process relevant metadata when displaying albums from Mirlo. It also will help anyone who attempts to build a script to [seed MusicBrainz entires](https://musicbrainz.org/doc/Development/Seeding) from Mirlo URLs.

Other metadata might also be helpful here, but this is a barebones pull request intended to facilitate Mirlo embeds on Freq.