### PR TITLE
fix: don't show artist releases if we're looking at a label page

### DIFF
--- a/client/src/components/Artist/ArtistAlbums.tsx
+++ b/client/src/components/Artist/ArtistAlbums.tsx
@@ -71,7 +71,7 @@ const ArtistAlbums: React.FC = () => {
         <div />
         {artist.userId === user?.id && <NewAlbumButton artist={artist} />}
       </SpaceBetweenDiv>
-      <SortableArtistAlbums />
+      {!artist.isLabelProfile && <SortableArtistAlbums />}
       {artist.isLabelProfile && (
         <>
           <TrackgroupGrid

--- a/client/src/components/Releases.tsx
+++ b/client/src/components/Releases.tsx
@@ -19,7 +19,6 @@ import Select from "./common/Select";
 import React from "react";
 
 const pageSize = 40;
-const futureReleasesPageSize = 6;
 
 const Releases: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
   const location = useLocation();


### PR DESCRIPTION
Got an e-mail

> Actually, I do have another question regarding the label profile. I’ve
> just noticed that it duplicates releases when I publish them through the
> label profile. This is a problem because I’m publishing one through a
> band profile, and it still shows at the top as the “latest” one, I
> assume, the duplicated one I made of Holy:
> 
> https://mirlo.space/ediciones-subterranias/releases
> 
> I have the impression that this happens because the label profile is
> probably running two queries in the releases section: one for the
> label’s own releases, and another for releases published by label
> artists + the label. If that’s the case, I suppose the solution could be
> as simple as removing the first query when it’s a label profile, since
> in this case all releases (both label releases and label artists’
> releases) should be grouped together and ordered by publication date.
> 
> Could this be reviewed? I’m sure it’s not a very big change :))
> 
> Thank you very much!!

And this seemed like the simplest fix. 