### PR TITLE
fix page name on Announcement description box

### DIFF
--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -855,7 +855,7 @@
     "announcement": "Write an announcement:",
     "editAnnouncement": "Edit announcement",
     "close": "Close",
-    "announcementDescription": "This announcement will appear at the top of the Artist page in a highlighted box. Leave it blank to not display anything. You can format it with Markdown syntax.",
+    "announcementDescription": "This announcement will appear at the top of the profile page in a highlighted box. Leave it blank to not display anything. You can format it with Markdown syntax.",
     "areYouSureDelete": "Are your sure you want to delete this profile page?",
     "whatLabelsisThisArtistPartOf": "What label is this artist a part of?",
     "terminationDanger": " Artist page termination ",


### PR DESCRIPTION
change "profile page" to "Artist page" because profile page would be understood as the the page where you set your properties, language etc... while Artist page is already used in public communication to talk about the public-facing Artist page on which you can see releases and merch etc...
I'd also like to make it so "markdown" gives a link to a "basic markdown rules"[ like this one](https://markdowncheatsheet.net/) page for users who don't know what Markdown is but i'm not sure how to do it.