### PR TITLE
fix(purchase): allow preorder CTA when logged out

### DIFF
--- a/client/src/components/TrackGroup/PurchaseOrDownloadAlbumModal.tsx
+++ b/client/src/components/TrackGroup/PurchaseOrDownloadAlbumModal.tsx
@@ -68,11 +68,11 @@ const PurchaseOrDownloadAlbum: React.FC<{
     );
   }
 
-  const isPublished =
+  const isVisibleRelease =
     trackGroup.published ||
-    (trackGroup.publishedAt && new Date(trackGroup.publishedAt) <= new Date());
+    Boolean(trackGroup.publishedAt && new Date(trackGroup.publishedAt).getTime());
 
-  if (!isPublished) {
+  if (!isVisibleRelease) {
     return null;
   }
 


### PR DESCRIPTION
## Summary\n- Treat scheduled releases with a valid publishedAt as visible purchase targets even when logged out\n\n## Testing\n- Not run (UI logic change)\n\nRefs #529