### PR TITLE
chore: rewrite how post notifications work to not use a cron job

### DIFF
--- a/src/auth/cors.ts
+++ b/src/auth/cors.ts
@@ -77,7 +77,9 @@ export const corsCheck = async (...args: [Request, Response, NextFunction]) => {
             key: apiHeader,
           },
         });
-        log.info(`Found ${clients.length} clients with that API key`);
+        log.info(
+          `Found ${clients.length} clients with that API key: ${clients.map((c) => c.allowedCorsOrigins.join(", ")).join(", ")}`
+        );
       }
     }
 
@@ -98,8 +100,6 @@ export const corsCheck = async (...args: [Request, Response, NextFunction]) => {
     if (process.env.NODE_ENV === "development") {
       origin.push("http://localhost:8080"); // Just... for ease of coding
     }
-
-    log.info(`CORS origins: ${origin.join(", ")}`);
 
     return cors({
       origin,

--- a/src/jobs/queue-worker.ts
+++ b/src/jobs/queue-worker.ts
@@ -11,10 +11,12 @@ import verifyAudioJob from "./verify-audio";
 import generateAlbumJob from "./generate-album";
 import optimizeImage from "./optimize-image";
 import cleanUpOldFilesJob from "./clean-up-old-files";
+import sendPostNotification from "./send-post-notification";
 
 import sendMail from "./send-mail";
 
 import "../queues/send-mail-queue";
+import "../queues/send-post-notification-queue";
 
 import { REDIS_CONFIG } from "../config/redis";
 import { moveFilesToBackblazeJob } from "../queues/moving-files-to-backblaze";
@@ -49,6 +51,7 @@ yargs // eslint-disable-line
     imageQueue();
     generateAlbumQueueWorker();
     sendMailQueue();
+    sendPostNotificationQueue();
     cleanUpFilesQueue();
   })
   .help().argv;
@@ -86,6 +89,25 @@ async function sendMailQueue() {
 
   worker.on("error", (err: any) => {
     logger.error("error:send-mail", err);
+  });
+}
+
+async function sendPostNotificationQueue() {
+  const worker = new Worker("send-post-notification", sendPostNotification, {
+    ...workerOptions,
+  });
+  logger.info("Send post notification worker started");
+
+  worker.on("completed", (job: Job) => {
+    logger.info("completed:send-post-notification");
+  });
+
+  worker.on("failed", (job?: Job, err?: any) => {
+    logger.error("failed:send-post-notification", err);
+  });
+
+  worker.on("error", (err: any) => {
+    logger.error("error:send-post-notification", err);
   });
 }
 

--- a/src/jobs/send-notification-email.ts
+++ b/src/jobs/send-notification-email.ts
@@ -1,8 +1,7 @@
 import prisma from "@mirlo/prisma";
-import { Artist, Notification, Post } from "@mirlo/prisma/client";
+import { Artist, Notification } from "@mirlo/prisma/client";
 import logger from "../logger";
 import { sendMailQueue, sendMailQueueEvents } from "../queues/send-mail-queue";
-import { processSinglePost } from "../utils/post";
 
 export const parseOutIframes = async (content: string) => {
   // Replace <iframe src="https://mirlo.space/widget/trackGroup/:id"> or <iframe src="https://mirlo.space/widget/track/:id">
@@ -145,75 +144,6 @@ export const parseOutIframes = async (content: string) => {
   return htmlContent;
 };
 
-const sendPostNotifications = async (
-  notification: { id: string; notificationType: string } & {
-    post: Partial<Post> | null;
-  } & {
-    user: { email: string };
-  }
-) => {
-  if (!notification.post) {
-    return;
-  }
-  const post = processSinglePost(notification.post);
-
-  if (!post.shouldSendEmail) {
-    logger.info(
-      `sendNotificationEmail: post asked not to be emailed: ${post.title} to ${notification.user.email}`
-    );
-    await prisma.notification.update({
-      where: {
-        id: notification.id,
-      },
-      data: {
-        isRead: true,
-      },
-    });
-    logger.info(`sendNotificationEmail: updated notification`);
-  } else if (!!post.content) {
-    // If the post doesn't have content we shouldn't send it.
-    // It's likely an error
-    logger.info(
-      `sendNotificationEmail: sending to queue notification for: ${post.title} to ${notification.user.email}`
-    );
-    const htmlContent = await parseOutIframes(post.content);
-
-    try {
-      await sendMailQueue.add("send-mail", {
-        template: "announce-post-published",
-        message: {
-          to: notification.user.email,
-        },
-        locals: {
-          artist: post.artist,
-          post: {
-            ...post,
-            htmlContent,
-          },
-          email: encodeURIComponent(notification.user.email),
-          host: process.env.API_DOMAIN,
-          client: process.env.REACT_APP_CLIENT_DOMAIN,
-        },
-      });
-
-      await prisma.notification.update({
-        where: {
-          id: notification.id,
-        },
-        data: {
-          isRead: true,
-        },
-      });
-      logger.info(`sendNotificationEmail: updated notification`);
-    } catch (e) {
-      logger.error(
-        `sendNotificationEmail: failed to send to queue notification ${notification.id} to ${notification.user.email}`
-      );
-      logger.error(e);
-    }
-  }
-};
-
 const sendLabelInviteNotification = async (
   notification: Notification & { artist: Partial<Artist> | null } & {
     user: { email: string } | null;
@@ -282,78 +212,6 @@ const sendLabelInviteNotification = async (
 
 const sendNotificationEmail = async () => {
   logger.info(`sendNotificationEmail: sending notifications`);
-
-  const postNotifciations = await prisma.notification.findMany({
-    where: {
-      isRead: false,
-      createdAt: {
-        lte: new Date(),
-      },
-      notificationType: {
-        in: ["NEW_ARTIST_POST", "SYSTEM_MESSAGE"],
-      },
-      deliveryMethod: {
-        in: ["EMAIL", "BOTH"],
-      },
-    },
-    select: {
-      id: true,
-      notificationType: true,
-      post: {
-        select: {
-          id: true,
-          title: true,
-          urlSlug: true,
-          featuredImageId: true,
-          content: true,
-          artist: {
-            select: {
-              id: true,
-              name: true,
-              urlSlug: true,
-              avatar: {
-                select: {
-                  url: true,
-                },
-              },
-              user: {
-                select: { email: true },
-              },
-            },
-          },
-          shouldSendEmail: true,
-          featuredImage: true,
-        },
-      },
-      user: {
-        select: { email: true },
-      },
-    },
-  });
-
-  logger.info(
-    `sendNotificationEmail: found ${postNotifciations.length} post notifications`
-  );
-
-  try {
-    for await (const notification of postNotifciations) {
-      logger.info(
-        `sendNotificationEmail: checking for post notification ${notification.id}`
-      );
-      if (
-        notification.post &&
-        notification.notificationType === "NEW_ARTIST_POST" &&
-        notification.post.artist
-      ) {
-        sendPostNotifications(notification);
-      }
-    }
-  } catch (e) {
-    logger.error(
-      `sendNotificationEmail: failed to send out all post notifications`
-    );
-    logger.error(e);
-  }
 
   const labelNotifications = await prisma.notification.findMany({
     where: {

--- a/src/jobs/send-post-notification.ts
+++ b/src/jobs/send-post-notification.ts
@@ -1,0 +1,156 @@
+import prisma from "@mirlo/prisma";
+import logger from "../logger";
+import { sendMailQueue } from "../queues/send-mail-queue";
+import { parseOutIframes } from "./send-notification-email";
+import { processSinglePost } from "../utils/post";
+import { flatten, uniqBy } from "lodash";
+
+/**
+ * Job processor: Sends notification emails when a post is published
+ * Handles the complete flow: creates notifications + queues emails
+ * Idempotent: safe to retry on failure without creating duplicates
+ */
+export default async function sendPostNotification(job: {
+  data: { postId: number };
+}) {
+  const { postId } = job.data;
+  logger.info(`sendPostNotification: processing post ${postId}`);
+
+  try {
+    const post = await prisma.post.findUnique({
+      where: { id: postId },
+      include: {
+        artist: {
+          include: {
+            subscriptionTiers: {
+              where: { deletedAt: null },
+              include: {
+                userSubscriptions: {
+                  where: { deletedAt: null },
+                  include: {
+                    user: {
+                      select: {
+                        id: true,
+                        email: true,
+                        deletedAt: true,
+                        emailConfirmationToken: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!post) {
+      logger.warn(`sendPostNotification: post ${postId} not found`);
+      return;
+    }
+
+    // Only process published, non-draft posts that should send email
+    const hasContent = post.content && post.content.trim().length > 0;
+    if (
+      post.isDraft ||
+      !post.shouldSendEmail ||
+      !hasContent ||
+      post.hasAnnounceEmailBeenSent
+    ) {
+      logger.info(
+        `sendPostNotification: skipping post ${postId} (draft=${post.isDraft}, shouldSendEmail=${post.shouldSendEmail}, hasContent=${hasContent}, alreadySent=${post.hasAnnounceEmailBeenSent})`
+      );
+      return;
+    }
+
+    // Collect all unique subscribers (filtering out deleted/unconfirmed users)
+    const flatSubscriptions = flatten(
+      (post.artist?.subscriptionTiers ?? []).map((st) =>
+        st.userSubscriptions
+          .map((us) => us.user)
+          .filter(
+            (u) => u.deletedAt === null && u.emailConfirmationToken === null
+          )
+      )
+    );
+    const uniqueSubscribers = uniqBy(flatSubscriptions, "id");
+
+    logger.info(
+      `sendPostNotification: found ${uniqueSubscribers.length} subscribers for post ${postId}`
+    );
+
+    // Create notifications and queue emails in a transaction
+    // This ensures atomicity - if it fails halfway, the transaction rolls back
+    await prisma.$transaction(async (tx) => {
+      // Create notifications (skipDuplicates prevents duplicate emails)
+      const createdNotifications = await tx.notification.createMany({
+        data: uniqueSubscribers.map((subscriber) => ({
+          postId,
+          userId: subscriber.id,
+          notificationType: "NEW_ARTIST_POST" as const,
+          deliveryMethod: post.artist?.activityPub
+            ? ("BOTH" as const)
+            : ("EMAIL" as const),
+        })),
+        skipDuplicates: true,
+      });
+
+      logger.info(
+        `sendPostNotification: created ${createdNotifications.count} new notifications for post ${postId}`
+      );
+
+      // Find ALL notifications for this post (both newly created and existing)
+      // to queue emails for them
+      const notificationsToEmail = await tx.notification.findMany({
+        where: {
+          postId,
+          deliveryMethod: { in: ["EMAIL", "BOTH"] },
+        },
+        include: {
+          user: { select: { email: true } },
+        },
+      });
+
+      logger.info(
+        `sendPostNotification: queueing ${notificationsToEmail.length} email(s) for post ${postId}`
+      );
+
+      // Queue emails for all notifications
+      for (const notification of notificationsToEmail) {
+        const htmlContent = await parseOutIframes(post.content || "");
+
+        await sendMailQueue.add("send-mail", {
+          template: "announce-post-published",
+          message: {
+            to: notification.user?.email,
+          },
+          locals: {
+            artist: post.artist,
+            post: {
+              ...processSinglePost(post),
+              htmlContent,
+            },
+            email: encodeURIComponent(notification.user?.email || ""),
+            host: process.env.API_DOMAIN,
+            client: process.env.REACT_APP_CLIENT_DOMAIN,
+          },
+        });
+      }
+
+      // Mark post as having email announcement sent
+      // This prevents re-processing on job retry
+      await tx.post.update({
+        where: { id: postId },
+        data: { hasAnnounceEmailBeenSent: true },
+      });
+    });
+
+    logger.info(`sendPostNotification: completed for post ${postId}`);
+  } catch (error) {
+    logger.error(`sendPostNotification: error processing post ${postId}`);
+    logger.error(error);
+    // Re-throw to let BullMQ handle retry logic
+    throw error;
+  }
+}

--- a/src/queues/send-post-notification-queue.ts
+++ b/src/queues/send-post-notification-queue.ts
@@ -1,0 +1,44 @@
+import { Queue, QueueEvents } from "bullmq";
+import { REDIS_CONFIG } from "../config/redis";
+import { logger } from "../logger";
+
+const queueOptions = {
+  prefix: "mirlo",
+  connection: REDIS_CONFIG,
+};
+
+export const sendPostNotificationQueue = new Queue(
+  "send-post-notification",
+  queueOptions
+);
+
+export const sendPostNotificationQueueEvents = new QueueEvents(
+  "send-post-notification",
+  queueOptions
+);
+
+sendPostNotificationQueueEvents.on(
+  "completed",
+  async (result: { jobId: string; returnvalue?: any }) => {
+    logger.info(
+      `Job with id ${JSON.stringify(
+        result.jobId
+      )} has been completed, ${JSON.stringify(result.returnvalue)}`
+    );
+  }
+);
+
+sendPostNotificationQueueEvents.on(
+  "stalled",
+  async (result: { jobId: string }) => {
+    logger.info(`jobId ${result.jobId} stalled`);
+  }
+);
+
+sendPostNotificationQueueEvents.on("failed", async (result: any) => {
+  logger.error(`jobId ${result.jobId} failed:`, result.failedReason);
+});
+
+sendPostNotificationQueueEvents.on("error", async (error) => {
+  logger.error(`send-post-notification queue error:`, error);
+});

--- a/src/routers/v1/manage/posts/{postId}/publish.ts
+++ b/src/routers/v1/manage/posts/{postId}/publish.ts
@@ -2,6 +2,8 @@ import { Request, Response } from "express";
 import prisma from "@mirlo/prisma";
 import { userAuthenticated } from "../../../../../auth/passport";
 import { doesPostBelongToUser } from "../../../../../utils/post";
+import { sendPostNotificationQueue } from "../../../../../queues/send-post-notification-queue";
+import logger from "../../../../../logger";
 
 export default function () {
   const operations = {
@@ -19,6 +21,53 @@ export default function () {
         where: { id: Number(postId) || undefined },
         data: { isDraft: !existingPost?.isDraft },
       });
+
+      // If post is being published (isDraft transitioning from true to false),
+      // queue the notification job with a 10-minute delay. This gives users
+      // a grace period to revert the post if needed. The job is idempotent
+      // and can be safely retried by BullMQ.
+      if (existingPost?.isDraft === true && updatedPost.isDraft === false) {
+        // Only queue if shouldSendEmail is true and content is not blank.
+        const hasContent =
+          updatedPost.content && updatedPost.content.trim().length > 0;
+        if (updatedPost.shouldSendEmail && hasContent) {
+          logger.info(
+            `publish: queueing post notification job for post ${postId} with 10 minute delay`
+          );
+          await sendPostNotificationQueue.add(
+            "send-post-notification",
+            { postId: updatedPost.id },
+            { delay: 10 * 60 * 1000 } // 10 minutes in milliseconds
+          );
+        } else {
+          logger.info(
+            `publish: skipping notification queue for post ${postId} (shouldSendEmail=${updatedPost.shouldSendEmail}, hasContent=${hasContent})`
+          );
+        }
+      }
+
+      // If post is being reverted to draft (isDraft transitioning from false to true),
+      // remove any pending notification jobs to prevent emails from being sent
+      if (existingPost?.isDraft === false && updatedPost.isDraft === true) {
+        logger.info(
+          `publish: removing pending notification job for post ${postId}`
+        );
+        // Find all jobs for this post and remove pending ones
+        const jobs = await sendPostNotificationQueue.getJobs([
+          "delayed",
+          "waiting",
+          "active",
+        ]);
+        for (const job of jobs) {
+          if (job.data.postId === Number(postId)) {
+            await job.remove();
+            logger.info(
+              `publish: removed pending job ${job.id} for post ${postId}`
+            );
+          }
+        }
+      }
+
       res.json({ result: updatedPost });
     } catch (error) {
       res.json({

--- a/test/jobs/send-notification-email.spec.ts
+++ b/test/jobs/send-notification-email.spec.ts
@@ -40,236 +40,34 @@ describe("send-notification-email", () => {
     await sendMailQueueEvents.close();
   });
 
-  describe("NEW_ARTIST_POST", () => {
-    it("should send email based on NEW_ARTIST_POST notification", async () => {
-      // const stub = sinon.stub(sendMail, "default");
-      const stub = sinon.stub(sendMailQueue, "add");
-
+  describe("parseOutIframes", () => {
+    it("should replace iframe with trackGroup", async () => {
       const { user: artistUser } = await createUser({
         email: "artist@artist.com",
       });
 
-      const followerEmail = "follower+subscription@follower.com";
+      const artist = await createArtist(artistUser.id);
+      const trackGroup = await createTrackGroup(artist.id);
 
-      const { user: followerUser } = await createUser({
-        email: followerEmail,
-        emailConfirmationToken: null,
-      });
-
-      const artist = await prisma.artist.create({
-        data: {
-          name: "Test artist",
-          urlSlug: "test-artist",
-          userId: artistUser.id,
-          enabled: true,
-        },
-      });
-
-      const post = await createPost(artist.id, {
-        title: "Our Custom Title",
-        content: `<h2 id="hi">HI</h2>`,
-      });
-
-      await prisma.notification.create({
-        data: {
-          userId: followerUser.id,
-          postId: post.id,
-          isRead: false,
-          notificationType: "NEW_ARTIST_POST",
-        },
-      });
-
-      await sendNotificationEmail();
-
-      assert.equal(stub.calledOnce, true);
-      const args = stub.getCall(0).args;
-      assert.equal(args[0], "send-mail");
-      const data = args[1];
-      assert.equal(data.template, "announce-post-published");
-      assert.equal(data.message.to, followerEmail);
-      assert.equal(data.locals.post.id, post.id);
-      assert.equal(data.locals.post.title, post.title);
-      assert.equal(data.locals.post.htmlContent.trim(), '<h2 id="hi">HI</h2>');
-      assert.equal(data.locals.artist.urlSlug, artist.urlSlug);
-      assert.equal(data.locals.post.urlSlug, post.urlSlug);
-      assert.equal(data.locals.artist.id, artist.id);
-      assert.equal(data.locals.artist.name, artist.name);
-      assert.equal(data.featuredImageId, null);
-      assert.equal(data.featuredImage, null);
-      assert.equal(data.locals.email, encodeURIComponent(followerEmail));
+      const content = `<iframe src="https://mirlo.space/widget/trackGroup/${trackGroup.id}"></iframe>`;
+      const result = await parseOutIframes(content);
+      assert(
+        result.includes(
+          `<div data-type="trackGroup" data-id="${trackGroup.id}"`
+        )
+      );
     });
 
-    it("should not send email if post is marked as not shouldSendEmail", async () => {
-      const stub = sinon.stub(sendMailQueue, "add");
-
-      const { user: artistUser } = await createUser({
-        email: "artist@artist.com",
-      });
-
-      const { user: followerUser } = await createUser({
-        email: "follower@follower.com",
-        emailConfirmationToken: null,
-      });
-
-      const artist = await prisma.artist.create({
-        data: {
-          name: "Test artist",
-          urlSlug: "test-artist",
-          userId: artistUser.id,
-          enabled: true,
-        },
-      });
-
-      const post = await createPost(artist.id, {
-        title: "Our Custom Title",
-        content: "# HI",
-        shouldSendEmail: false,
-      });
-
-      await prisma.notification.create({
-        data: {
-          userId: followerUser.id,
-          postId: post.id,
-          isRead: false,
-          notificationType: "NEW_ARTIST_POST",
-        },
-      });
-
-      await sendNotificationEmail();
-
-      assert.equal(stub.called, false);
+    it("should replace iframe with track", async () => {
+      const content = `<iframe src="https://mirlo.space/widget/track/67890"></iframe>`;
+      const result = await parseOutIframes(content);
+      assert(result.includes('<div data-type="track" data-id="67890">'));
     });
 
-    it("should send email with post that has a featured image", async () => {
-      const stub = sinon.stub(sendMailQueue, "add");
-
-      const { user: artistUser } = await createUser({
-        email: "artist@artist.com",
-      });
-
-      const { user: followerUser } = await createUser({
-        email: "follower@follower.com",
-        emailConfirmationToken: null,
-      });
-
-      const artist = await prisma.artist.create({
-        data: {
-          name: "Test artist",
-          urlSlug: "test-artist",
-          userId: artistUser.id,
-          enabled: true,
-        },
-      });
-
-      const post = await createPost(artist.id, {
-        title: "Our Custom Title",
-        content: "# HI",
-      });
-
-      const image = await prisma.postImage.create({
-        data: {
-          postId: post.id,
-          extension: "jpg",
-          mimeType: "image/jpeg",
-        },
-      });
-
-      await prisma.post.update({
-        where: {
-          id: post.id,
-        },
-        data: {
-          featuredImageId: image.id,
-        },
-      });
-
-      await prisma.notification.create({
-        data: {
-          userId: followerUser.id,
-          postId: post.id,
-          isRead: false,
-          notificationType: "NEW_ARTIST_POST",
-        },
-      });
-
-      await sendNotificationEmail();
-
-      assert.equal(stub.called, true);
-      const args = stub.getCall(0).args;
-      const src: string = args[1].locals.post.featuredImage.src;
-      assert(src.endsWith(`/post-images/${image.id}.${image.extension}`));
-    });
-
-    it("should not send email if post content is blank", async () => {
-      const stub = sinon.stub(sendMailQueue, "add");
-
-      const { user: artistUser } = await createUser({
-        email: "artist@artist.com",
-      });
-
-      const { user: followerUser } = await createUser({
-        email: "follower@follower.com",
-        emailConfirmationToken: null,
-      });
-
-      const artist = await prisma.artist.create({
-        data: {
-          name: "Test artist",
-          urlSlug: "test-artist",
-          userId: artistUser.id,
-          enabled: true,
-        },
-      });
-
-      const post = await createPost(artist.id, {
-        title: "Our Custom Title",
-        content: "",
-        shouldSendEmail: false,
-      });
-
-      await prisma.notification.create({
-        data: {
-          userId: followerUser.id,
-          postId: post.id,
-          isRead: false,
-          notificationType: "NEW_ARTIST_POST",
-        },
-      });
-
-      await sendNotificationEmail();
-
-      assert.equal(stub.called, false);
-    });
-
-    describe("parseOutIframes", () => {
-      it("should replace iframe with trackGroup", async () => {
-        const { user: artistUser } = await createUser({
-          email: "artist@artist.com",
-        });
-
-        const artist = await createArtist(artistUser.id);
-        const trackGroup = await createTrackGroup(artist.id);
-
-        const content = `<iframe src="https://mirlo.space/widget/trackGroup/${trackGroup.id}"></iframe>`;
-        const result = await parseOutIframes(content);
-        assert(
-          result.includes(
-            `<div data-type="trackGroup" data-id="${trackGroup.id}"`
-          )
-        );
-      });
-
-      it("should replace iframe with track", async () => {
-        const content = `<iframe src="https://mirlo.space/widget/track/67890"></iframe>`;
-        const result = await parseOutIframes(content);
-        assert(result.includes('<div data-type="track" data-id="67890">'));
-      });
-
-      it("should not modify content without iframes", async () => {
-        const content = `<p>No iframes here!</p>`;
-        const result = await parseOutIframes(content);
-        assert.equal(result, content);
-      });
+    it("should not modify content without iframes", async () => {
+      const content = `<p>No iframes here!</p>`;
+      const result = await parseOutIframes(content);
+      assert.equal(result, content);
     });
   });
 

--- a/test/jobs/send-onboarding-email.spec.ts
+++ b/test/jobs/send-onboarding-email.spec.ts
@@ -2,7 +2,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 import { describe, it } from "mocha";
 
-import { clearTables, createPost, createUser } from "../utils";
+import { clearTables, createUser } from "../utils";
 
 import prisma from "@mirlo/prisma";
 import assert from "assert";

--- a/test/routers/manage/posts/{id}.publish.spec.ts
+++ b/test/routers/manage/posts/{id}.publish.spec.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert";
 import * as dotenv from "dotenv";
 dotenv.config();
-import { describe, it } from "mocha";
+import { describe, it, afterEach } from "mocha";
+import sinon from "sinon";
 import {
   clearTables,
   createArtist,
@@ -11,6 +12,10 @@ import {
 
 import { requestApp } from "../../utils";
 import prisma from "@mirlo/prisma";
+import {
+  sendPostNotificationQueue,
+  sendPostNotificationQueueEvents,
+} from "../../../../src/queues/send-post-notification-queue";
 
 describe("manage/posts/{id}/publish", () => {
   beforeEach(async () => {
@@ -19,6 +24,25 @@ describe("manage/posts/{id}/publish", () => {
     } catch (e) {
       console.error(e);
     }
+
+    // Clear any existing jobs before the test
+    const jobsBefore = await sendPostNotificationQueue.getJobs([
+      "delayed",
+      "waiting",
+    ]);
+    for (const job of jobsBefore) {
+      await job.remove();
+    }
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  after(async () => {
+    // Gotta make sure to close the queues and queue events
+    await sendPostNotificationQueue.close();
+    await sendPostNotificationQueueEvents.close();
   });
 
   describe("/", () => {
@@ -40,6 +64,157 @@ describe("manage/posts/{id}/publish", () => {
         where: { id: post.id },
       });
       assert.equal(updatedPost?.isDraft, false);
+    });
+
+    it("should queue exactly one send-post-notification job when publishing a post", async () => {
+      const { user, accessToken } = await createUser({
+        email: "artist@artist.com",
+      });
+      const artist = await createArtist(user.id);
+      const post = await createPost(artist.id);
+      assert.equal(post.isDraft, true);
+
+      await requestApp
+        .put(`manage/posts/${post.id}/publish`)
+        .set("Cookie", [`jwt=${accessToken}`])
+        .send({})
+        .set("Accept", "application/json");
+
+      // Give the queue a moment to process the job addition
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify exactly one job was queued with the correct parameters
+      const queuedJobs = await sendPostNotificationQueue.getJobs([
+        "delayed",
+        "waiting",
+      ]);
+      assert.equal(queuedJobs.length, 1, "exactly one job should be queued");
+
+      const job = queuedJobs[0];
+      assert.equal(
+        job.name,
+        "send-post-notification",
+        "job name should be send-post-notification"
+      );
+      assert.deepEqual(
+        job.data,
+        { postId: post.id },
+        "job data should contain postId"
+      );
+      // Verify 10-minute delay is set (accounting for when the job was created)
+      assert.ok(
+        job.delay && job.delay >= 10 * 60 * 1000,
+        "job should have at least 10 minute delay"
+      );
+    });
+
+    it("should remove pending notification job when reverting a post to draft", async () => {
+      const { user, accessToken } = await createUser({
+        email: "artist@artist.com",
+      });
+      const artist = await createArtist(user.id);
+      // Create post as published
+      const post = await createPost(artist.id, { isDraft: false });
+      assert.equal(post.isDraft, false);
+
+      // Manually add a pending notification job to the queue (simulating a previously published post)
+      const addedJob = await sendPostNotificationQueue.add(
+        "send-post-notification",
+        { postId: post.id },
+        { delay: 10 * 60 * 1000 }
+      );
+      assert.ok(addedJob, "job should be added to queue");
+
+      // Verify the job exists before reverting
+      let jobsBefore = await sendPostNotificationQueue.getJobs([
+        "delayed",
+        "waiting",
+      ]);
+      const jobForPostBefore = jobsBefore.find(
+        (j) => j.data.postId === post.id
+      );
+      assert.ok(
+        jobForPostBefore,
+        "job should exist for this post before reverting"
+      );
+
+      // Revert post back to draft
+      await requestApp
+        .put(`manage/posts/${post.id}/publish`)
+        .set("Cookie", [`jwt=${accessToken}`])
+        .send({})
+        .set("Accept", "application/json");
+
+      // Give the queue a moment to process the job removal
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify the job was removed
+      const jobsAfter = await sendPostNotificationQueue.getJobs([
+        "delayed",
+        "waiting",
+      ]);
+      const jobForPostAfter = jobsAfter.find((j) => j.data.postId === post.id);
+      assert.ok(
+        !jobForPostAfter,
+        "job should be removed after reverting to draft"
+      );
+    });
+
+    it("should NOT queue a job when publishing a post with shouldSendEmail set to false", async () => {
+      const { user, accessToken } = await createUser({
+        email: "artist@artist.com",
+      });
+      const artist = await createArtist(user.id);
+      const post = await createPost(artist.id, { shouldSendEmail: false });
+      assert.equal(post.isDraft, true);
+      assert.equal(post.shouldSendEmail, false);
+
+      await requestApp
+        .put(`manage/posts/${post.id}/publish`)
+        .set("Cookie", [`jwt=${accessToken}`])
+        .send({})
+        .set("Accept", "application/json");
+
+      // Give the queue a moment (if it were to process)
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify NO jobs were queued for this post
+      const queuedJobs = await sendPostNotificationQueue.getJobs([
+        "delayed",
+        "waiting",
+      ]);
+      const jobForPost = queuedJobs.find((j) => j.data.postId === post.id);
+      assert.ok(
+        !jobForPost,
+        "no job should be queued when shouldSendEmail is false"
+      );
+    });
+
+    it("should NOT queue a job when publishing a post with blank content", async () => {
+      const { user, accessToken } = await createUser({
+        email: "artist@artist.com",
+      });
+      const artist = await createArtist(user.id);
+      const post = await createPost(artist.id, { content: "" });
+      assert.equal(post.isDraft, true);
+      assert.equal(post.content, "");
+
+      await requestApp
+        .put(`manage/posts/${post.id}/publish`)
+        .set("Cookie", [`jwt=${accessToken}`])
+        .send({})
+        .set("Accept", "application/json");
+
+      // Give the queue a moment (if it were to process)
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify NO jobs were queued for this post
+      const queuedJobs = await sendPostNotificationQueue.getJobs([
+        "delayed",
+        "waiting",
+      ]);
+      const jobForPost = queuedJobs.find((j) => j.data.postId === post.id);
+      assert.ok(!jobForPost, "no job should be queued when content is blank");
     });
   });
 });


### PR DESCRIPTION
Using a cron job instead of a one time push to a queue was causing our re-curring e-mail send issue that broke things every time we did it. So this removes that. 