### PR TITLE
fix: confirmation token expired

### DIFF
--- a/client/src/components/EmailConfirmation.tsx
+++ b/client/src/components/EmailConfirmation.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import api from "../services/api";
+import { useSnackbar } from "state/SnackbarContext";
+import { useTranslation } from "react-i18next";
+import Box from "./common/Box";
+import Button from "./common/Button";
+
+function EmailConfirmation() {
+  const navigate = useNavigate();
+  const { t } = useTranslation("translation", {
+    keyPrefix: "emailConfirmation",
+  });
+  const [search] = useSearchParams();
+
+  const { token, userId, client, accountType, email, error } = React.useMemo(
+    () => ({
+      token: search.get("token"),
+      userId: search.get("id"),
+      client: search.get("client"),
+      accountType: search.get("accountType") as "artist" | "listener" | null,
+      email: search.get("email"),
+      error: search.get("error"),
+    }),
+    [search]
+  );
+
+  const snackbar = useSnackbar();
+  const [isConfirming, setIsConfirming] = React.useState(false);
+  const [confirmationError, setConfirmationError] = React.useState<
+    string | null
+  >(error);
+  const [isConfirmed, setIsConfirmed] = React.useState(false);
+  const [isTokenExpired, setIsTokenExpired] = React.useState(false);
+  const [isResending, setIsResending] = React.useState(false);
+  const [resendCountdown, setResendCountdown] = React.useState(30);
+
+  const onConfirmEmail = React.useCallback(async () => {
+    if (!token || !userId || !client) {
+      setConfirmationError(t("invalidLink"));
+      return;
+    }
+
+    setIsConfirming(true);
+    try {
+      await api.post("confirm-email-token", {
+        token,
+        userId: Number(userId),
+        client: Number(client),
+        accountType,
+      });
+      snackbar(t("confirmed"), { type: "success" });
+      setIsConfirmed(true);
+      setTimeout(() => {
+        navigate(accountType === "artist" ? "/manage/" : "/profile/collection");
+      }, 3000);
+    } catch (e: unknown) {
+      const errorMessage = (e as Error).message || t("confirmationFailed");
+      setConfirmationError(errorMessage);
+      // Check if it's a token expired error
+      if (errorMessage.includes("Token expired")) {
+        setIsTokenExpired(true);
+      }
+      snackbar(errorMessage, { type: "warning" });
+      console.error(e);
+    } finally {
+      setIsConfirming(false);
+    }
+  }, [token, userId, client, accountType]);
+
+  const onResendEmail = React.useCallback(async () => {
+    if (!email) {
+      snackbar(t("invalidLink"), { type: "warning" });
+      return;
+    }
+
+    setIsResending(true);
+    setResendCountdown(30);
+    try {
+      await api.post("resend-verification-email", {
+        email,
+        client: window.location.origin,
+        accountType,
+      });
+      snackbar(t("emailResent"), { type: "success" });
+      setConfirmationError(null);
+      setIsTokenExpired(false);
+    } catch (e: unknown) {
+      const errorMessage = (e as Error).message || t("resendFailed");
+      snackbar(errorMessage, { type: "warning" });
+      console.error(e);
+    } finally {
+      setIsResending(false);
+    }
+  }, [email, client, accountType, snackbar, t]);
+
+  // Countdown timer for resend button
+  React.useEffect(() => {
+    if (!isTokenExpired || isResending) return;
+
+    if (resendCountdown > 0) {
+      const timer = setTimeout(() => {
+        setResendCountdown(resendCountdown - 1);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [isTokenExpired, isResending, resendCountdown]);
+
+  React.useEffect(() => {
+    console.log({ token, userId, client, error });
+    if (token && userId && client && !error) {
+      onConfirmEmail();
+    }
+  }, [token, userId, client, error, onConfirmEmail]); // excluding onConfirmEmail but not sure why it's getting re-created. FIXME.
+
+  return (
+    <div className="flex flex-col max-w-sm mx-auto my-12 text-center">
+      <h2>{t("title")}</h2>
+
+      {confirmationError && (
+        <Box variant="warning" className="mt-4">
+          {confirmationError}
+        </Box>
+      )}
+
+      {isConfirmed && (
+        <Box variant="info" className="mt-4">
+          {t("redirecting")}
+        </Box>
+      )}
+
+      {isConfirming && !confirmationError && (
+        <div className="mt-4">
+          <p>{t("confirming")}</p>
+          <div className="inline-block w-[30px] h-[30px] border-4 border-[var(--mi-disable-background-color)] border-t-[var(--mi-foreground-color)] rounded-full animate-spin mx-auto my-4" />
+        </div>
+      )}
+
+      {!isConfirming && confirmationError && !isTokenExpired && (
+        <Button onClick={onConfirmEmail} className="mt-4">
+          {t("tryAgain")}
+        </Button>
+      )}
+
+      {isTokenExpired && (
+        <div className="mt-4 flex flex-col items-center">
+          <Button
+            onClick={onResendEmail}
+            disabled={isResending || resendCountdown > 0}
+            className="mt-4"
+          >
+            {resendCountdown > 0
+              ? `${t("resendEmail")} (${resendCountdown}s)`
+              : t("resendEmail")}
+          </Button>
+        </div>
+      )}
+
+      <img
+        alt="a blackbird"
+        src="/static/images/blackbird.png"
+        className="w-1/2 py-8 mx-auto my-12"
+      />
+    </div>
+  );
+}
+
+export default EmailConfirmation;

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -141,6 +141,15 @@ const routes: RouteObject[] = [
         },
       },
       {
+        path: "email-confirmation",
+        async lazy() {
+          const { default: Component } = await import(
+            "components/EmailConfirmation"
+          );
+          return { Component };
+        },
+      },
+      {
         path: "profile",
         async lazy() {
           const { default: ProfileContainer } = await import(

--- a/client/src/services/APIInstance.ts
+++ b/client/src/services/APIInstance.ts
@@ -23,6 +23,7 @@ const APIInstance = (apiRoot: string, mirloApiKey: string) => {
     "verify-email",
     "verify-password",
     "signup",
+    "confirm-email-token",
     "resend-verification-email",
     "password-reset/initiate",
     "password-reset/set-password",

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -105,6 +105,18 @@
     "confirmNewPassword": "Set password",
     "accountIncomplete": "Set a password to finish claiming this account"
   },
+  "emailConfirmation": {
+    "title": "Verify your email",
+    "confirmed": "Email verified! Redirecting...",
+    "confirming": "Verifying your email...",
+    "confirmationFailed": "Email verification failed",
+    "invalidLink": "Invalid verification link",
+    "tryAgain": "Try again",
+    "redirecting": "Redirecting to your account...",
+    "resendEmail": "Resend verification email",
+    "emailResent": "Verification email sent! Check your inbox.",
+    "resendFailed": "Failed to resend verification email"
+  },
   "headerMenu": {
     "logOutSuccess": "Logged out!",
     "collection": "Collection",

--- a/emails/new-user/html.pug
+++ b/emails/new-user/html.pug
@@ -5,5 +5,5 @@ block content
   p Someone signed up to mirlo using this email address
   p #{user.email}
   p 
-    a(href!=`${host}/auth/confirmation/${user.emailConfirmationToken}?user=${user.id}&client=${client}&accountType=${accountType}`) Click here to confirm
+    a(href!=`${clientDomain}/email-confirmation?token=${user.emailConfirmationToken}&id=${user.id}&client=${client}&accountType=${accountType}&email=${encodeURIComponent(user.email)}`) Click here to confirm
   p If this was not you, you can safely ignore this email.

--- a/src/routers/auth/confirmEmailToken.ts
+++ b/src/routers/auth/confirmEmailToken.ts
@@ -1,0 +1,107 @@
+import { NextFunction, Request, Response } from "express";
+import prisma from "@mirlo/prisma";
+import { setTokens } from "./utils";
+import { AppError } from "../../utils/error";
+import logger from "../../logger";
+
+const confirmEmailToken = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const {
+      token,
+      userId,
+      client: clientID,
+      accountType,
+    } = req.body as {
+      token: string;
+      userId: number;
+      client: number;
+      accountType: "artist" | "listener";
+    };
+
+    logger.info(`auth/confirmEmailToken: confirming email for user ${userId}`);
+
+    if (!token || !userId || !clientID) {
+      return next(
+        new AppError({
+          httpCode: 400,
+          description: "Token, userId, and client are required",
+        })
+      );
+    }
+
+    const user = await prisma.user.findFirst({
+      where: {
+        id: userId,
+        emailConfirmationToken: token,
+      },
+    });
+
+    if (!user) {
+      return next(
+        new AppError({
+          httpCode: 404,
+          description: "This user does not exist",
+        })
+      );
+    }
+
+    const client = await prisma.client.findFirst({
+      where: {
+        id: clientID,
+      },
+    });
+
+    if (!client) {
+      return next(
+        new AppError({
+          httpCode: 404,
+          description: "This client does not exist",
+        })
+      );
+    }
+
+    if (
+      user.emailConfirmationExpiration &&
+      user.emailConfirmationExpiration < new Date()
+    ) {
+      return next(
+        new AppError({
+          httpCode: 400,
+          description: "Token expired",
+        })
+      );
+    }
+
+    const updatedUser = await prisma.user.update({
+      data: {
+        emailConfirmationToken: null,
+        emailConfirmationExpiration: null,
+      },
+      where: {
+        id: user.id,
+      },
+      select: {
+        email: true,
+        id: true,
+      },
+    });
+
+    setTokens(res, updatedUser);
+
+    res.json({
+      message: "Email confirmed successfully",
+      userId: updatedUser.id,
+      email: updatedUser.email,
+      accountType,
+    });
+  } catch (e) {
+    logger.error(`Error confirming email token: ${e}`);
+    next(e);
+  }
+};
+
+export default confirmEmailToken;

--- a/src/routers/auth/index.ts
+++ b/src/routers/auth/index.ts
@@ -8,6 +8,7 @@ import refresh from "./refresh";
 import login from "./login";
 import verifyEmail from "./verifyEmail";
 import resendVerificationEmail from "./resendVerificationEmail";
+import confirmEmailToken from "./confirmEmailToken";
 import {
   passwordResetConfirmation,
   passwordResetInitiate,
@@ -21,72 +22,9 @@ router.post(`/signup`, signup);
 
 router.post(`/verify-email`, verifyEmail);
 
+router.post(`/confirm-email-token`, confirmEmailToken);
+
 router.post(`/resend-verification-email`, resendVerificationEmail);
-
-router.get(`/confirmation/:emailConfirmationToken`, async (req, res, next) => {
-  try {
-    let { emailConfirmationToken } = req.params;
-
-    // FIXME: should the client be changed from a URL to an id. Probably
-    // And then check that the client exists in the DB.
-    let {
-      client: clientID,
-      user: userId,
-      accountType,
-    } = req.query as {
-      client: string;
-      accountType: "artist" | "listener";
-      user: string;
-    };
-
-    const user = await prisma.user.findFirst({
-      where: {
-        id: Number(userId),
-        emailConfirmationToken,
-      },
-    });
-
-    const client = await prisma.client.findFirst({
-      where: {
-        id: Number(clientID),
-      },
-    });
-
-    if (!client) {
-      return res.status(404).json({ error: "This client does not exist" });
-    }
-    if (!user) {
-      return res.status(404).json({ error: "This user does not exist" });
-    } else if (
-      user.emailConfirmationExpiration &&
-      user.emailConfirmationExpiration < new Date()
-    ) {
-      return res.status(404).json({ error: "Token expired" });
-    } else {
-      const updatedUser = await prisma.user.update({
-        data: {
-          emailConfirmationToken: null,
-          emailConfirmationExpiration: null,
-        },
-        where: {
-          id: user.id,
-        },
-        select: {
-          email: true,
-          id: true,
-        },
-      });
-      setTokens(res, updatedUser);
-      if (accountType === "artist") {
-        return res.redirect(`${client.applicationUrl}/manage/welcome`);
-      }
-      return res.redirect(`${client.applicationUrl}/profile/collection`);
-    }
-  } catch (e) {
-    console.error(e);
-    res.status(500);
-  }
-});
 
 router.get("/password-reset/confirmation/:token", passwordResetConfirmation);
 

--- a/src/routers/auth/passwordReset.ts
+++ b/src/routers/auth/passwordReset.ts
@@ -85,7 +85,7 @@ export const passwordResetInitiate = async (
       return res.status(404).json({ error: "This user does not exist" });
     } else {
       const expirationDate = new Date();
-      expirationDate.setMinutes(new Date().getMinutes() + 30);
+      expirationDate.setMinutes(new Date().getMinutes() + 60);
       const token = randomUUID();
       const result = await prisma.user.update({
         where: {
@@ -110,6 +110,7 @@ export const passwordResetInitiate = async (
           locals: {
             user: result,
             host: process.env.API_DOMAIN,
+            clientDomain: process.env.REACT_APP_CLIENT_DOMAIN,
             redirectClient,
             accountIncomplete,
             token,

--- a/src/routers/auth/resendVerificationEmail.ts
+++ b/src/routers/auth/resendVerificationEmail.ts
@@ -8,7 +8,7 @@ import {
   sendVerificationEmail,
 } from "./sendVerificationEmail";
 
-const RESEND_EXPIRATION_MINUTES = 20;
+const RESEND_EXPIRATION_MINUTES = 60;
 
 const resendVerificationEmail = async (
   req: Request,
@@ -91,13 +91,11 @@ const resendVerificationEmail = async (
       accountType: accountTypeValue,
     });
 
-    return res
-      .status(200)
-      .json({
-        message: "Success! Verification email sent.",
-        emailConfirmationExpiresAt:
-          updatedUser.emailConfirmationExpiration?.toISOString() ?? null,
-      });
+    return res.status(200).json({
+      message: "Success! Verification email sent.",
+      emailConfirmationExpiresAt:
+        updatedUser.emailConfirmationExpiration?.toISOString() ?? null,
+    });
   } catch (error) {
     next(error);
   }

--- a/src/routers/auth/sendVerificationEmail.ts
+++ b/src/routers/auth/sendVerificationEmail.ts
@@ -38,6 +38,7 @@ export const sendVerificationEmail = async <UserType extends { email: string }>(
         user,
         host: process.env.API_DOMAIN,
         client: clientId,
+        clientDomain: process.env.REACT_APP_CLIENT_DOMAIN,
       },
     },
   } as Job);


### PR DESCRIPTION
Instead of handling the token expiration as a link to the api from the e-mail, this creates a front-end page that provides better UX, the ability to resend emails, etc.

Also bump our window to 1 hour. 

to do with #647