### PR TITLE
fix: remade the button "add to collection" strings had been broken

### DIFF
--- a/client/src/components/TrackGroup/PurchaseAlbumModal.tsx
+++ b/client/src/components/TrackGroup/PurchaseAlbumModal.tsx
@@ -44,7 +44,7 @@ const PurchaseAlbumModal: React.FC<{
 
   const preOrderOrBuyText =
     trackGroup.minPrice === null
-      ? "saveAlbum"
+      ? "addToCollection"
       : trackGroup.fundraiser?.isAllOrNothing
         ? "backThisProject"
         : isBeforeReleaseDate

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -236,7 +236,7 @@
     "youWillBeChargedWhenItsFullyFunded": "You are backing this project. You will be charged when it's fully funded.",
     "consentToStoreData": "I understand that my payment method will be stored to process when the project reaches its fundraising goal.",
     "backThisProject": "Back this project",
-    "addToCollection": "Save",
+    "addToCollection": "Add to collection",
     "changePledge": "Change pledge",
     "updatePledge": "Update pledge",
     "pledgeDeletedSuccessfully": "Pledge deleted successfully!",


### PR DESCRIPTION
Not too sure what the new "save" naming convention was supposed to imply, but upon testing locally I couldn't find any reason beyond shortening the word for visual concision but I think the loss of meaning is too big.