### PR TITLE
feat: replace REACT_APP_CLIENT_DOMAIN with getClient().applicationUrl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ COPY prisma/package.json ./prisma/package.json
 COPY client/package.json ./client/package.json
 RUN --mount=type=cache,target=/root/.yarn,sharing=locked YARN_CACHE_FOLDER=/root/.yarn yarn install --immutable
 
-COPY . .
+COPY prisma ./prisma
 RUN yarn prisma:build
+
+COPY . .
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,8 @@ COPY prisma/package.json ./prisma/package.json
 COPY client/package.json ./client/package.json
 RUN --mount=type=cache,target=/root/.yarn,sharing=locked YARN_CACHE_FOLDER=/root/.yarn yarn install --immutable
 
-COPY prisma ./prisma
-RUN yarn prisma:build
-
 COPY . .
+RUN yarn prisma:build
 
 EXPOSE 3000
 

--- a/src/jobs/send-notification-email.ts
+++ b/src/jobs/send-notification-email.ts
@@ -2,6 +2,7 @@ import prisma from "@mirlo/prisma";
 import { Artist, Notification } from "@mirlo/prisma/client";
 import logger from "../logger";
 import { sendMailQueue, sendMailQueueEvents } from "../queues/send-mail-queue";
+import { getClient } from "../activityPub/utils";
 
 export const parseOutIframes = async (content: string) => {
   // Replace <iframe src="https://mirlo.space/widget/trackGroup/:id"> or <iframe src="https://mirlo.space/widget/track/:id">
@@ -54,6 +55,7 @@ export const parseOutIframes = async (content: string) => {
     const trackMap = Object.fromEntries(tracks.map((t) => [t.id, t]));
 
     // Replace iframes with divs containing info
+    const { applicationUrl } = await getClient();
     htmlContent = htmlContent.replace(
       iframeRegex,
       (_match, _before, type, id, _after) => {
@@ -66,7 +68,7 @@ export const parseOutIframes = async (content: string) => {
           const foreground = tg.artist.properties?.colors?.foreground || "#111";
           return `<div data-type="trackGroup" data-id="${id}" style="display:flex;flex-direction:row;gap:8px;background-color:${background};border-radius:8px;padding:16px;">
                     <div>
-                      <a href="${process.env.REACT_APP_CLIENT_DOMAIN}/${tg.artist.urlSlug}/release/${tg.urlSlug}" style="
+                      <a href="${applicationUrl}/${tg.artist.urlSlug}/release/${tg.urlSlug}" style="
                       display:inline-block;
                       text-decoration:none;
                       background:${primary};
@@ -86,7 +88,7 @@ export const parseOutIframes = async (content: string) => {
                     </div>
                     <div>
                       <strong>${tg.title}</strong><br/>
-                      <a href="${process.env.REACT_APP_CLIENT_DOMAIN}/${tg.artist.urlSlug}" style="color:${primary};text-decoration:none;">
+                      <a href="${applicationUrl}/${tg.artist.urlSlug}" style="color:${primary};text-decoration:none;">
                         ${tg.artist?.name || "Unknown"}
                       </a><br/>
                       <ol>
@@ -106,7 +108,7 @@ export const parseOutIframes = async (content: string) => {
             t.trackGroup.artist.properties?.colors?.foreground || "#111";
           return `<div data-type="track" data-id="${id}" style="display:flex;flex-direction:column;gap:8px;background-color:${background};border-radius:8px;padding:16px;">
                   <div>
-                    <a href="${process.env.REACT_APP_CLIENT_DOMAIN}/${t.trackGroup.artist.urlSlug}/release/${t.trackGroup.urlSlug}/track/${t.urlSlug}" style="display:inline-block;
+                    <a href="${applicationUrl}/${t.trackGroup.artist.urlSlug}/release/${t.trackGroup.urlSlug}/track/${t.urlSlug}" style="display:inline-block;
                       text-decoration:none;
                       background:${primary};
                       color:${foreground};
@@ -125,7 +127,7 @@ export const parseOutIframes = async (content: string) => {
                   </div>
                   <div>
                     <strong>${t.title}</strong><br/>
-                    <a href="${process.env.REACT_APP_CLIENT_DOMAIN}/${t.trackGroup.artist.urlSlug}" style="color:${foreground}; text-decoration:none;">
+                    <a href="${applicationUrl}/${t.trackGroup.artist.urlSlug}" style="color:${foreground}; text-decoration:none;">
                       ${t.trackGroup.artist?.name || "Unknown"}
                     </a>
                   </div>
@@ -177,6 +179,7 @@ const sendLabelInviteNotification = async (
       isLabelProfile: true,
     },
   });
+  const { applicationUrl } = await getClient();
 
   try {
     await sendMailQueue.add("send-mail", {
@@ -189,7 +192,7 @@ const sendLabelInviteNotification = async (
         email: encodeURIComponent(notification.user.email),
         host: process.env.API_DOMAIN,
         label: labelProfile,
-        client: process.env.REACT_APP_CLIENT_DOMAIN,
+        client: applicationUrl,
       },
     });
 

--- a/src/jobs/send-onboarding-email.ts
+++ b/src/jobs/send-onboarding-email.ts
@@ -3,6 +3,7 @@ import prisma from "@mirlo/prisma";
 import logger from "../logger";
 
 import { sendMailQueue } from "../queues/send-mail-queue";
+import { getClient } from "../activityPub/utils";
 
 const sendOnboardingEmail = async () => {
   const date = new Date();
@@ -64,7 +65,7 @@ const sendOnboardingEmail = async () => {
                 <p>If you have any questions or need assistance, feel free to reach out to us at hi@mirlo.space.</p>`,
 
                 host: process.env.API_DOMAIN,
-                client: process.env.REACT_APP_CLIENT_DOMAIN,
+                client: (await getClient()).applicationUrl,
               },
             });
             await prisma.user.update({

--- a/src/jobs/send-out-monthly-receipts.ts
+++ b/src/jobs/send-out-monthly-receipts.ts
@@ -2,6 +2,7 @@ import prisma from "@mirlo/prisma";
 import sendMail from "./send-mail";
 
 import logger from "../logger";
+import { getClient } from "../activityPub/utils";
 import { groupBy } from "lodash";
 import { Job } from "bullmq";
 
@@ -64,7 +65,7 @@ const sendOutMonthlyReceipts = async () => {
                 userSubscriptions,
                 user: userSubscriptions[0].user,
                 host: process.env.API_DOMAIN,
-                client: process.env.REACT_APP_CLIENT_DOMAIN,
+                client: (await getClient()).applicationUrl,
               } as AnnounceMonthlyReceiptsEmailType,
             },
           } as Job);

--- a/src/jobs/send-out-monthy-income-report.ts
+++ b/src/jobs/send-out-monthy-income-report.ts
@@ -1,6 +1,7 @@
 import prisma from "@mirlo/prisma";
 
 import logger from "../logger";
+import { getClient } from "../activityPub/utils";
 import { findSales } from "../routers/v1/artists/{id}/supporters";
 import { groupBy, keyBy } from "lodash";
 import sendMail from "./send-mail";
@@ -70,7 +71,7 @@ const sendOutMonthlyIncomeReport = async () => {
               userSales,
               totalIncome,
               host: process.env.API_DOMAIN,
-              client: process.env.REACT_APP_CLIENT_DOMAIN,
+              client: (await getClient()).applicationUrl,
             },
           },
         } as Job);

--- a/src/jobs/send-post-notification.ts
+++ b/src/jobs/send-post-notification.ts
@@ -4,6 +4,7 @@ import { sendMailQueue } from "../queues/send-mail-queue";
 import { parseOutIframes } from "./send-notification-email";
 import { processSinglePost } from "../utils/post";
 import { flatten, uniqBy } from "lodash";
+import { getClient } from "../activityPub/utils";
 
 /**
  * Job processor: Sends notification emails when a post is published
@@ -133,7 +134,7 @@ export default async function sendPostNotification(job: {
             },
             email: encodeURIComponent(notification.user?.email || ""),
             host: process.env.API_DOMAIN,
-            client: process.env.REACT_APP_CLIENT_DOMAIN,
+            client: (await getClient()).applicationUrl,
           },
         });
       }

--- a/src/jobs/send-subscription-renewal-reminders.ts
+++ b/src/jobs/send-subscription-renewal-reminders.ts
@@ -2,6 +2,7 @@ import prisma from "@mirlo/prisma";
 import logger from "../logger";
 import { Artist } from "@mirlo/prisma/client";
 import { sendMailQueue } from "../queues/send-mail-queue";
+import { getClient } from "../activityPub/utils";
 
 export type SubscriptionRenewalReminderEmailType = {
   interval: "MONTH" | "YEAR";
@@ -111,7 +112,7 @@ const sendSubscriptionRenewalReminders = async () => {
                 updatedAt: subscription.updatedAt,
               },
               host: process.env.API_DOMAIN,
-              client: process.env.REACT_APP_CLIENT_DOMAIN,
+              client: (await getClient()).applicationUrl,
               renewalDate,
             } as SubscriptionRenewalReminderEmailType,
           });

--- a/src/queues/auto-purchase-new-albums-queue.ts
+++ b/src/queues/auto-purchase-new-albums-queue.ts
@@ -4,6 +4,7 @@ import { logger } from "../logger";
 import prisma from "@mirlo/prisma";
 import { sendMailQueue } from "./send-mail-queue";
 import { registerPurchase } from "../utils/trackGroup";
+import { getClient } from "../activityPub/utils";
 
 export type AutomaticallyReceivedAlbumEmailType = {
   trackGroup: {
@@ -148,7 +149,7 @@ export async function autoPurchaseNewAlbumsProcessor(job: {
         trackGroup: album,
         artist: subscription.artistSubscriptionTier.artist,
         host: process.env.API_DOMAIN,
-        client: process.env.REACT_APP_CLIENT_DOMAIN,
+        client: (await getClient()).applicationUrl,
       } as AutomaticallyReceivedAlbumEmailType,
     });
 

--- a/src/routers/auth/passwordReset.ts
+++ b/src/routers/auth/passwordReset.ts
@@ -4,6 +4,7 @@ import { hashPassword, setTokens } from "./utils";
 import { sendMail } from "../../jobs/send-mail";
 import { Job } from "bullmq";
 import logger from "../../logger";
+import { getClient } from "../../activityPub/utils";
 
 import { randomUUID } from "crypto";
 
@@ -110,7 +111,7 @@ export const passwordResetInitiate = async (
           locals: {
             user: result,
             host: process.env.API_DOMAIN,
-            clientDomain: process.env.REACT_APP_CLIENT_DOMAIN,
+            clientDomain: (await getClient()).applicationUrl,
             redirectClient,
             accountIncomplete,
             token,

--- a/src/routers/v1/admin/invites/index.ts
+++ b/src/routers/v1/admin/invites/index.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../auth/passport";
 import { uniqBy } from "lodash";
 import { sendMailQueue } from "../../../../queues/send-mail-queue";
+import { getClient } from "../../../../activityPub/utils";
 
 export default function () {
   const operations = {
@@ -65,7 +66,7 @@ export default function () {
             ...newUser,
             email: encodeURIComponent(newUser.email),
             host: process.env.API_DOMAIN,
-            client: process.env.REACT_APP_CLIENT_DOMAIN,
+            client: (await getClient()).applicationUrl,
           },
         });
       });

--- a/src/routers/v1/artists/{id}/confirmFollow.ts
+++ b/src/routers/v1/artists/{id}/confirmFollow.ts
@@ -7,6 +7,7 @@ import {
   subscribeUserToArtist,
 } from "../../../../utils/artist";
 import { getSiteSettings } from "../../../../utils/settings";
+import { getClient } from "../../../../activityPub/utils";
 
 type Params = {
   id: string;
@@ -26,6 +27,7 @@ export default function () {
     };
 
     try {
+      const { applicationUrl } = await getClient();
       const artist = await prisma.artist.findFirst({
         where: {
           id: Number(artistId),
@@ -48,7 +50,7 @@ export default function () {
 
       if (!confirmation) {
         res.redirect(
-          process.env.REACT_APP_CLIENT_DOMAIN + `/?message=Something went wrong`
+          applicationUrl + `/?message=Something went wrong`
         );
       }
 
@@ -96,7 +98,7 @@ export default function () {
           });
 
           res.redirect(
-            process.env.REACT_APP_CLIENT_DOMAIN +
+            applicationUrl +
               `/${artist.urlSlug}/checkout-complete?purchaseType=follow`
           );
         }

--- a/src/routers/v1/flag.ts
+++ b/src/routers/v1/flag.ts
@@ -4,6 +4,7 @@ import sendMail from "../../jobs/send-mail";
 import { Job } from "bullmq";
 import prisma from "@mirlo/prisma";
 import { checkCloudFlareTurnstile } from "../../utils/cloudflare";
+import { getClient } from "../../activityPub/utils";
 
 export default function () {
   const operations = {
@@ -48,7 +49,7 @@ export default function () {
             to: "hi@mirlo.space",
           },
           locals: {
-            client: process.env.REACT_APP_CLIENT_DOMAIN,
+            client: (await getClient()).applicationUrl,
             email,
             reason,
             description,

--- a/src/routers/v1/manage/artists/{artistId}/codes.ts
+++ b/src/routers/v1/manage/artists/{artistId}/codes.ts
@@ -7,6 +7,7 @@ import {
 
 import prisma from "@mirlo/prisma";
 import { downloadCSVFile } from "../../../../../utils/download";
+import { getClient } from "../../../../../activityPub/utils";
 
 type Params = {
   artistId: string;
@@ -53,6 +54,7 @@ export default function () {
     const { group } = req.query as unknown as { group: string };
 
     try {
+      const { applicationUrl } = await getClient();
       const where: Prisma.TrackGroupDownloadCodesWhereInput = {
         trackGroup: {
           artistId: Number(artistId),
@@ -82,7 +84,7 @@ export default function () {
           csvColumns,
           artistCodes.map((c) => ({
             ...c,
-            url: `${process.env.REACT_APP_CLIENT_DOMAIN}/${c.trackGroup.artist.urlSlug}/release/${c.trackGroup.urlSlug}/redeem?code=${c.downloadCode}`,
+            url: `${applicationUrl}/${c.trackGroup.artist.urlSlug}/release/${c.trackGroup.urlSlug}/redeem?code=${c.downloadCode}`,
           }))
         );
       }
@@ -90,7 +92,7 @@ export default function () {
       res.json({
         results: artistCodes.map((c) => ({
           ...c,
-          url: `${process.env.REACT_APP_CLIENT_DOMAIN}/${c.trackGroup.artist.urlSlug}/release/${c.trackGroup.urlSlug}/redeem?code=${c.downloadCode}`,
+          url: `${applicationUrl}/${c.trackGroup.artist.urlSlug}/release/${c.trackGroup.urlSlug}/redeem?code=${c.downloadCode}`,
         })),
       });
     } catch (error) {

--- a/src/routers/v1/manage/artists/{artistId}/labels/index.ts
+++ b/src/routers/v1/manage/artists/{artistId}/labels/index.ts
@@ -37,7 +37,7 @@ const sendArtistNotificationOfLabel = async (
             has invited you to join their roster.
           </p>
           <p>To accept their invitation, 
-            <a href="${client}/manage/artists/${artist.id}/customize#labels">
+            <a href="${client.applicationUrl}/manage/artists/${artist.id}/customize#labels">
             manage your artist account on Mirlo</a>.
           </p>
           <p>
@@ -75,7 +75,7 @@ const sendArtistNotificationOfLabel = async (
           email: encodeURIComponent(artistUser.email),
           host: process.env.API_DOMAIN,
           label: labelProfile,
-          client: process.env.REACT_APP_CLIENT_DOMAIN,
+          client: client.applicationUrl,
         },
       });
     }

--- a/src/routers/v1/manage/purchases/{purchaseId}/contactArtist.ts
+++ b/src/routers/v1/manage/purchases/{purchaseId}/contactArtist.ts
@@ -4,6 +4,7 @@ import prisma from "@mirlo/prisma";
 import { User } from "@mirlo/prisma/client";
 import sendMail from "../../../../../jobs/send-mail";
 import { Job } from "bullmq";
+import { getClient } from "../../../../../activityPub/utils";
 
 export default function () {
   const operations = {
@@ -55,7 +56,7 @@ export default function () {
               artist,
               message,
               host: process.env.API_DOMAIN,
-              client: process.env.REACT_APP_CLIENT_DOMAIN,
+              client: (await getClient()).applicationUrl,
             },
           },
         } as Job);

--- a/src/routers/v1/trackGroups/{id}/emailDownload.ts
+++ b/src/routers/v1/trackGroups/{id}/emailDownload.ts
@@ -8,6 +8,7 @@ import prisma from "@mirlo/prisma";
 
 import sendMail from "../../../../jobs/send-mail";
 import { randomUUID } from "crypto";
+import { getClient } from "../../../../activityPub/utils";
 import { Job } from "bullmq";
 
 export default function () {
@@ -84,7 +85,7 @@ export default function () {
               trackGroup,
               email,
               host: process.env.API_DOMAIN,
-              client: process.env.REACT_APP_CLIENT_DOMAIN,
+              client: (await getClient()).applicationUrl,
               token: purchase.singleDownloadToken,
             },
           },

--- a/src/routers/v1/trackGroups/{id}/emailPurchaseLink.ts
+++ b/src/routers/v1/trackGroups/{id}/emailPurchaseLink.ts
@@ -4,6 +4,7 @@ import prisma from "@mirlo/prisma";
 
 import sendMail from "../../../../jobs/send-mail";
 import { Job } from "bullmq";
+import { getClient } from "../../../../activityPub/utils";
 
 export default function () {
   const operations = {
@@ -36,7 +37,7 @@ export default function () {
           },
           locals: {
             trackGroup,
-            client: process.env.REACT_APP_CLIENT_DOMAIN,
+            client: (await getClient()).applicationUrl,
           },
         },
       } as Job);

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -42,6 +42,7 @@ import { Job } from "bullmq";
 import { deleteMerch, processSingleMerch } from "./merch";
 import { getSiteSettings } from "./settings";
 import subscriptionTiers from "../routers/v1/manage/artists/{artistId}/subscriptionTiers";
+import { getClient } from "../activityPub/utils";
 
 type Params = {
   id: string;
@@ -171,7 +172,7 @@ export const createSubscriptionConfirmation = async (
           email,
           token: subscriptionConfirmation.token,
           host: process.env.API_DOMAIN,
-          client: process.env.REACT_APP_CLIENT_DOMAIN,
+          client: (await getClient()).applicationUrl,
         },
       },
     } as Job);

--- a/src/utils/handleFinishedTransactions.ts
+++ b/src/utils/handleFinishedTransactions.ts
@@ -1188,6 +1188,7 @@ export const handleFundraiserPledgePaymentFailure = async (
   transactionId: string,
   urlParams: string
 ) => {
+  const { applicationUrl } = await getClient();
   const transaction = await prisma.userTransaction.findFirst({
     where: {
       id: transactionId,

--- a/src/utils/handleFinishedTransactions.ts
+++ b/src/utils/handleFinishedTransactions.ts
@@ -11,6 +11,7 @@ import {
 
 import { logger } from "../logger";
 import sendMail from "../jobs/send-mail";
+import { getClient } from "../activityPub/utils";
 import { registerPurchase, registerTrackPurchase } from "./trackGroup";
 import { registerSubscription } from "./subscriptionTier";
 import { Job } from "bullmq";
@@ -176,6 +177,7 @@ export const handleTrackGroupPurchase = async (
   newUser?: boolean
 ) => {
   try {
+    const { applicationUrl } = await getClient();
     const { applicationFee, paymentProcessorFee } =
       await getApplicationFee(session);
     const amount = session?.amount_total ?? 0;
@@ -247,7 +249,7 @@ export const handleTrackGroupPurchase = async (
             isBeforeReleaseDate,
             token: purchase.singleDownloadToken,
             email: user.email,
-            client: process.env.REACT_APP_CLIENT_DOMAIN,
+            client: applicationUrl,
             host: process.env.API_DOMAIN,
           },
         },
@@ -300,7 +302,7 @@ export const handleTrackGroupPurchase = async (
             currency: transactions[0]?.currency ?? "USD",
             message: session?.metadata?.message,
             email: user.email,
-            client: process.env.REACT_APP_CLIENT_DOMAIN,
+            client: applicationUrl,
           } as ArtistPurchaseNotificationEmailType,
         },
       } as Job);
@@ -322,6 +324,7 @@ export const handleCataloguePurchase = async (
   session?: Stripe.Checkout.Session
 ) => {
   try {
+    const { applicationUrl } = await getClient();
     const artist = await prisma.artist.findFirst({
       where: {
         id: artistId,
@@ -405,7 +408,7 @@ export const handleCataloguePurchase = async (
             artist,
             trackGroups: artistTrackGroups,
             email: user.email,
-            client: process.env.REACT_APP_CLIENT_DOMAIN,
+            client: applicationUrl,
             host: process.env.API_DOMAIN,
           },
         },
@@ -559,6 +562,7 @@ const sendSaleEmails = async (
   message?: string
 ) => {
   try {
+    const { applicationUrl } = await getClient();
     const transactions = await prisma.userTransaction.findMany({
       where: {
         id: {
@@ -656,7 +660,7 @@ const sendSaleEmails = async (
           artist,
           transactions,
           email: purchaser.email,
-          client: process.env.REACT_APP_CLIENT_DOMAIN,
+          client: applicationUrl,
           host: process.env.API_DOMAIN,
         } as PurchaseReceiptEmailType,
       },
@@ -680,7 +684,7 @@ const sendSaleEmails = async (
           currency: transactions[0]?.currency ?? "USD",
           message: message ?? null,
           email: purchaser.email,
-          client: process.env.REACT_APP_CLIENT_DOMAIN,
+          client: applicationUrl,
           host: process.env.API_DOMAIN,
         } as ArtistPurchaseNotificationEmailType,
       },
@@ -1067,6 +1071,7 @@ export const handleFundraiserPledge = async (
 export const handleFundraiserPledgePaymentSuccess = async (
   transactionId: string
 ) => {
+  const { applicationUrl } = await getClient();
   const transaction = await prisma.userTransaction.findFirst({
     where: {
       id: transactionId,
@@ -1174,7 +1179,7 @@ export const handleFundraiserPledgePaymentSuccess = async (
       currency: pledge.fundraiser.trackGroups[0].currency,
       pledgedAmountFormatted: pledge.amount / 100,
       fundraisingGoalFormatted: (pledge.fundraiser.goalAmount ?? 0) / 100,
-      client: process.env.REACT_APP_CLIENT_DOMAIN,
+      client: applicationUrl,
     },
   });
 };
@@ -1234,7 +1239,7 @@ export const handleFundraiserPledgePaymentFailure = async (
       cardChargeContext: `your pledge to "${transaction.associatedPledge.fundraiser.trackGroups[0].artist.name}'s ${transaction.associatedPledge.fundraiser.trackGroups[0].title}" fundraiser`,
       currency: transaction.associatedPledge.fundraiser.trackGroups[0].currency,
       pledgedAmountFormatted: transaction.associatedPledge.amount / 100,
-      client: process.env.REACT_APP_CLIENT_DOMAIN,
+      client: applicationUrl,
       urlParams,
     },
   });

--- a/test/routers/artists/{id}.confirmFollow.spec.ts
+++ b/test/routers/artists/{id}.confirmFollow.spec.ts
@@ -68,8 +68,7 @@ describe("artists/{id}/confirmFollow", () => {
 
       assert.equal(response.status, 302);
       const redirectTo =
-        process.env.REACT_APP_CLIENT_DOMAIN +
-        `/${artist.urlSlug}/checkout-complete?purchaseType=follow`;
+        `http://localhost:8080/${artist.urlSlug}/checkout-complete?purchaseType=follow`;
 
       assert.equal(response.header["location"], redirectTo);
       const subscription =
@@ -126,8 +125,7 @@ describe("artists/{id}/confirmFollow", () => {
 
       assert.equal(response.status, 302);
       const redirectTo =
-        process.env.REACT_APP_CLIENT_DOMAIN +
-        `/${artist.urlSlug}/checkout-complete?purchaseType=follow`;
+        `http://localhost:8080/${artist.urlSlug}/checkout-complete?purchaseType=follow`;
 
       assert.equal(response.header["location"], redirectTo);
       const subscription =

--- a/test/routers/manage/artists/{id}.codes.spec.ts
+++ b/test/routers/manage/artists/{id}.codes.spec.ts
@@ -93,7 +93,7 @@ describe("manage/artists/{artistId}/codes", () => {
       assert.equal(rows[1].split(",")[0], codes[0].trackGroupId);
       assert.equal(
         rows[1].split(",")[6].replaceAll('"', ""),
-        `${process.env.REACT_APP_CLIENT_DOMAIN}/${artist.urlSlug}/release/${trackGroup.urlSlug}/redeem?code=${codes[0].downloadCode}`
+        `http://localhost:8080/${artist.urlSlug}/release/${trackGroup.urlSlug}/redeem?code=${codes[0].downloadCode}`
       );
     });
   });


### PR DESCRIPTION
Converts all async-context usages of the env var to the DB-backed value so self-hosted instances use the correct client URL automatically. Also fixes a pre-existing bug in labels/index.ts where ${client} (object) was used in a template literal instead of ${client.applicationUrl}.

Two module-level sync usages in activityPub/utils.ts and checkout/index.ts remain and require broader refactoring to address. Do we want to do that in this MR or a subsequent?

Closes #1854 