### PR TITLE
fix: allow label releases to be linked to merch items

### DIFF
--- a/emails/catalogue-purchase-artist-notification/html.pug
+++ b/emails/catalogue-purchase-artist-notification/html.pug
@@ -12,7 +12,7 @@ block content
     
   p The final money will be available via your Stripe dashboard
   p Learn more about
-    a(href="https://docs.mirlo.space") how payouts work on Mirlo
+    a(href="https://docs.mirlo.space/payouts") how payouts work on Mirlo
     | .
   p If you have any questions please reach out to hi@mirlo.space
 

--- a/src/auth/passport.ts
+++ b/src/auth/passport.ts
@@ -5,7 +5,10 @@ import { TokenExpiredError } from "jsonwebtoken";
 import passport from "passport";
 import passportJWT, { JwtFromRequestFunction } from "passport-jwt";
 import prisma from "@mirlo/prisma";
-import { findArtistIdForURLSlug } from "../utils/artist";
+import {
+  findArtistIdForURLSlug,
+  whereForAllArtistsThisLabelCanEdit,
+} from "../utils/artist";
 import logger from "../logger";
 import { AppError } from "../utils/error";
 import {
@@ -188,19 +191,7 @@ export const artistBelongsToLoggedInUser = async (
 
       const artist = await prisma.artist.findFirst({
         where: {
-          OR: [
-            {
-              userId: loggedInUser.id,
-            },
-            {
-              artistLabels: {
-                some: {
-                  labelUserId: loggedInUser.id,
-                  canLabelManageArtist: true,
-                },
-              },
-            },
-          ],
+          ...whereForAllArtistsThisLabelCanEdit(loggedInUser.id),
           id: Number(castArtistId),
         },
       });

--- a/src/routers/v1/manage/merch/{merchId}/index.ts
+++ b/src/routers/v1/manage/merch/{merchId}/index.ts
@@ -81,12 +81,17 @@ export default function () {
 
       if (newValues.includePurchaseTrackGroupId) {
         // check that the artist who owns this merch also
-        // owns this trackgroup
-
+        // owns this trackgroup, or that the logged-in user
+        // is the label owner of the trackgroup
+        const user = req.user as User;
         const trackGroup = await prisma.trackGroup.findFirst({
           where: {
-            artistId: merch?.artistId,
             id: Number(newValues.includePurchaseTrackGroupId),
+            OR: [
+              { artistId: merch?.artistId },
+              { paymentToUserId: user.id },
+              { artist: { userId: user.id } },
+            ],
           },
         });
 
@@ -99,7 +104,6 @@ export default function () {
         }
       }
 
-      const user = req.user as User;
       await prisma.merch.updateMany({
         where: { id: merchId },
         data: {

--- a/src/routers/v1/manage/merch/{merchId}/index.ts
+++ b/src/routers/v1/manage/merch/{merchId}/index.ts
@@ -10,6 +10,7 @@ import { User } from "@mirlo/prisma/client";
 import { AppError } from "../../../../../utils/error";
 import { deleteMerch, processSingleMerch } from "../../../../../utils/merch";
 import generateSlug from "../../../../../utils/generateSlug";
+import { whereForAllArtistsThisLabelCanEdit } from "../../../../../utils/artist";
 
 type Params = {
   merchId: string;
@@ -90,7 +91,7 @@ export default function () {
             OR: [
               { artistId: merch?.artistId },
               { paymentToUserId: user.id },
-              { artist: { userId: user.id } },
+              { artist: whereForAllArtistsThisLabelCanEdit(user.id) },
             ],
           },
         });

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  namespace Express {
+    interface User extends import("@mirlo/prisma/client").User {}
+  }
+}
+
+export {};

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -131,6 +131,22 @@ export const getPlatformFeeForArtist = async (
   return artist?.defaultPlatformFee ?? settings.platformPercent;
 };
 
+export const whereForAllArtistsThisLabelCanEdit = (
+  userId: number
+): Prisma.ArtistWhereInput => ({
+  OR: [
+    { userId },
+    {
+      artistLabels: {
+        some: {
+          labelUserId: userId,
+          canLabelManageArtist: true,
+        },
+      },
+    },
+  ],
+});
+
 export const findArtistIdForURLSlug = async (id: string) => {
   if (Number.isNaN(Number(id))) {
     const artist = await prisma.artist.findFirst({

--- a/test/routers/manage/merch/{id}.index.spec.ts
+++ b/test/routers/manage/merch/{id}.index.spec.ts
@@ -39,4 +39,76 @@ describe("manage/merch/{merchId}", () => {
       assert.equal(response.status, 200);
     });
   });
+
+  describe("PUT", () => {
+    it("should allow linking a track group that belongs to the merch's artist", async () => {
+      const { user, accessToken } = await createUser({ email: "test@testcom" });
+      const artist = await createArtist(user.id);
+      const trackGroup = await createTrackGroup(artist.id);
+      const merch = await createMerch(artist.id, {});
+
+      const response = await requestApp
+        .put(`manage/merch/${merch.id}`)
+        .send({ includePurchaseTrackGroupId: trackGroup.id })
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.status, 200);
+      assert.equal(
+        response.body.result.includePurchaseTrackGroup.id,
+        trackGroup.id
+      );
+    });
+
+    it("should allow linking a label release (paymentToUserId matches logged-in user)", async () => {
+      const { user, accessToken } = await createUser({ email: "test@testcom" });
+      const labelArtist = await createArtist(user.id);
+
+      // A roster artist owned by a different user
+      const { user: rosterUser } = await createUser({
+        email: "roster@testcom",
+      });
+      const rosterArtist = await createArtist(rosterUser.id);
+
+      // Label release: belongs to the roster artist but payment goes to the label user
+      const labelRelease = await createTrackGroup(rosterArtist.id, {
+        paymentToUserId: user.id,
+      });
+
+      const merch = await createMerch(labelArtist.id, {});
+
+      const response = await requestApp
+        .put(`manage/merch/${merch.id}`)
+        .send({ includePurchaseTrackGroupId: labelRelease.id })
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.status, 200);
+      assert.equal(
+        response.body.result.includePurchaseTrackGroup.id,
+        labelRelease.id
+      );
+    });
+
+    it("should reject linking a track group that does not belong to the user", async () => {
+      const { user, accessToken } = await createUser({ email: "test@testcom" });
+      const artist = await createArtist(user.id);
+      const merch = await createMerch(artist.id, {});
+
+      // A track group owned by a completely different user
+      const { user: otherUser } = await createUser({
+        email: "other@testcom",
+      });
+      const otherArtist = await createArtist(otherUser.id);
+      const unrelatedTrackGroup = await createTrackGroup(otherArtist.id);
+
+      const response = await requestApp
+        .put(`manage/merch/${merch.id}`)
+        .send({ includePurchaseTrackGroupId: unrelatedTrackGroup.id })
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.status, 400);
+    });
+  });
 });


### PR DESCRIPTION
The API validation was rejecting label releases because it only checked artistId

Now also accepts track groups where the logged-in user is the label owner

Closes #1859