### PR TITLE
Refactor renaming banner into background

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/css";
-import PageBanner from "components/common/ArtistBanner";
+import PageBackground from "components/common/ArtistBackground";
 import Snackbar from "components/common/Snackbar";
 import Player from "components/Player";
 import { useContext, useEffect } from "react";
@@ -72,7 +72,7 @@ function App() {
               }
             `}
           >
-            <PageBanner />
+            <PageBackground />
             <UserBanner />
           </div>
           <div

--- a/client/src/components/Artist/ArtistContainer.tsx
+++ b/client/src/components/Artist/ArtistContainer.tsx
@@ -16,7 +16,7 @@ const ArtistContainer: React.FC = () => {
     queryArtist({ artistSlug: artistId ?? "" })
   );
 
-  const artistBanner = artist?.banner?.sizes;
+  const artistBackground = artist?.background?.sizes;
 
   const isPostOrRelease = trackGroupId || postId;
 
@@ -25,7 +25,7 @@ const ArtistContainer: React.FC = () => {
       {!isPostOrRelease && (
         <>
           <ArtistPageWrapper
-            artistBanner={!!artistBanner}
+            hasBackground={!!artistBackground}
             artistBackground={artist?.properties?.colors?.background}
           >
             <ArtistHeaderSection

--- a/client/src/components/Artist/ArtistLinks.tsx
+++ b/client/src/components/Artist/ArtistLinks.tsx
@@ -37,7 +37,6 @@ const ArtistLinks: React.FC = () => {
   const isOwningArtist = artist?.userId === user?.id;
 
   return (
-    // <ArtistPageWrapper artistBanner={!!artistBanner}>
     <div
       className={css`
         background-color: ${colors?.background ??

--- a/client/src/components/Artist/ArtistSquare.tsx
+++ b/client/src/components/Artist/ArtistSquare.tsx
@@ -15,7 +15,7 @@ const ArtistSquare: React.FC<{
   artist: Artist;
 }> = ({ artist }) => {
   const standardImageSrc =
-    artist.avatar?.sizes?.[300] ?? artist.banner?.sizes?.[625];
+    artist.avatar?.sizes?.[300] ?? artist.background?.sizes?.[625];
 
   console.log(
     "ArtistSquare render",

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 import { Link, useParams } from "react-router-dom";
 import usePublicArtist from "utils/usePublicObjectById";
-import PageBanner from "components/common/ArtistBanner";
+import PageBackground from "components/common/ArtistBackground";
 import { bp } from "../../constants";
 import HeaderSearch from "./HeaderSearch";
 import Logo from "components/common/Logo";
@@ -20,7 +20,7 @@ import UserBanner from "components/common/UserBanner";
 import Menu from "components/Header/Menu";
 
 const HeaderWrapper = styled.div<{
-  artistBanner?: boolean;
+  hasBackground?: boolean;
   transparent?: boolean;
   artistId?: boolean;
   show?: string;
@@ -72,26 +72,26 @@ const HeaderWrapper = styled.div<{
     align-items: flex-start;
 
     ${(props) =>
-      props.artistBanner && !props.trackGroupId
-        ? `top: calc(var(--header-cover-sticky-height) - 25vw); 
-           aspect-ratio: 4 / 1; 
-           width: auto; 
-           min-height: auto; 
+      props.hasBackground && !props.trackGroupId
+        ? `top: calc(var(--header-cover-sticky-height) - 25vw);
+           aspect-ratio: 4 / 1;
+           width: auto;
+           min-height: auto;
            transition: top 0.4s ease-out;`
         : ""}
     ${(props) =>
-      props.artistBanner && !props.trackGroupId && props.show === "up"
-        ? `top: calc(var(--header-cover-sticky-height) - 25vw); 
-           aspect-ratio: 4 / 1; 
-           width: auto; 
+      props.hasBackground && !props.trackGroupId && props.show === "up"
+        ? `top: calc(var(--header-cover-sticky-height) - 25vw);
+           aspect-ratio: 4 / 1;
+           width: auto;
            transition: top 0.4s ease-out;`
         : ""}
     ${(props) =>
-      props.artistBanner && !props.trackGroupId && props.show === "down"
-        ? `top: calc(var(--header-cover-sticky-height) - 50vw); 
-           aspect-ratio: 4 / 1; 
-           width: auto; 
-           min-height: auto; 
+      props.hasBackground && !props.trackGroupId && props.show === "down"
+        ? `top: calc(var(--header-cover-sticky-height) - 50vw);
+           aspect-ratio: 4 / 1;
+           width: auto;
+           min-height: auto;
            transition: top 0.4s ease-out;`
         : ""}
 
@@ -151,11 +151,11 @@ const Header = () => {
   const { artistId, trackGroupId } = useParams();
 
   const { object: artist } = usePublicArtist<Artist>("artists", artistId);
-  const artistBanner = artist?.banner?.sizes;
+  const artistBackground = artist?.background?.sizes;
   const colors = artist?.properties?.colors;
 
   const show = useShow();
-  const transparent = !!artistBanner && !!artistId;
+  const transparent = !!artistBackground && !!artistId;
 
   const { data: instanceArtist } = useQuery(queryInstanceArtist());
 
@@ -178,14 +178,14 @@ const Header = () => {
   return (
     <HeaderWrapper
       transparent={transparent}
-      artistBanner={!!artistBanner}
+      hasBackground={!!artistBackground}
       show={show}
       trackGroupId={!!trackGroupId}
       artistId={!!artistId}
       colors={colors}
     >
       <div className="md:hidden!">
-        <PageBanner />
+        <PageBackground />
         <UserBanner />
       </div>
       <div className="absolute w-full h-full md:hidden!"></div>

--- a/client/src/components/ManageArtist/ManageArtistContainer.tsx
+++ b/client/src/components/ManageArtist/ManageArtistContainer.tsx
@@ -18,11 +18,11 @@ import { useAuthContext } from "state/AuthContext";
 import api from "services/api";
 import { getArtistUrl } from "utils/artist";
 
-const Container = styled.div<{ artistBanner: boolean }>`
+const Container = styled.div<{ hasBackground: boolean }>`
   width: 100%;
   padding: var(--mi-side-paddings-normal);
   ${(props) =>
-    !props.artistBanner ? "margin-top: 0px;" : "margin-top: calc(8vh);"}
+    !props.hasBackground ? "margin-top: 0px;" : "margin-top: calc(8vh);"}
   margin-top: calc(8vh - 39px);
   max-width: var(--mi-container-big);
 
@@ -34,21 +34,21 @@ const Container = styled.div<{ artistBanner: boolean }>`
     padding: var(--mi-side-paddings-xsmall);
     padding: 0rem !important;
     width: 100%;
-    ${(props) => (props.artistBanner ? "margin-top: 0px;" : "")}
-    ${(props) => (!props.artistBanner ? "margin-top: 0px;" : "")}
+    ${(props) => (props.hasBackground ? "margin-top: 0px;" : "")}
+    ${(props) => (!props.hasBackground ? "margin-top: 0px;" : "")}
   }
 `;
 
 export const ArtistPageWrapper: React.FC<{
   children: React.ReactNode;
-  artistBanner?: boolean;
+  hasBackground?: boolean;
   artistBackground?: string;
-}> = ({ children, artistBanner, artistBackground }) => {
+}> = ({ children, hasBackground, artistBackground }) => {
   return (
-    <Container artistBanner={!!artistBanner}>
+    <Container hasBackground={!!hasBackground}>
       <div
         className={css`
-          ${artistBanner
+          ${hasBackground
             ? "filter: drop-shadow(0 0 0.5rem rgba(50, 50, 50, 0.3));"
             : ""}
           background-color: ${artistBackground ?? "transparent"};
@@ -87,7 +87,7 @@ const ManageArtistContainer: React.FC<{}> = () => {
 
   const location = useLocation();
 
-  const artistBanner = artist?.banner?.sizes;
+  const artistBackground = artist?.background?.sizes;
 
   if (!artist) {
     return null;
@@ -108,7 +108,7 @@ const ManageArtistContainer: React.FC<{}> = () => {
 
   return (
     <ArtistPageWrapper
-      artistBanner={!!artistBanner}
+      hasBackground={!!artistBackground}
       artistBackground={artist?.properties?.colors?.background}
     >
       <div

--- a/client/src/components/ManageArtist/ManageArtistDetails/CustomizeLook.tsx
+++ b/client/src/components/ManageArtist/ManageArtistDetails/CustomizeLook.tsx
@@ -64,7 +64,7 @@ export type ArtistFormData = {
   name: string;
   bio: string;
   urlSlug: string;
-  banner: File[];
+  background: File[];
   avatar: File[];
   activityPub: boolean;
   defaultPlatformFee: number;
@@ -320,7 +320,7 @@ export const CustomizeLook: React.FC = () => {
                     <UploadArtistImage
                       existing={artist}
                       imageTypeDescription={t("backgroundImageDescription")}
-                      imageType="banner"
+                      imageType="background"
                       height="auto"
                       width="100%"
                       maxDimensions="2500x2500"

--- a/client/src/components/ManageArtist/UploadArtistImage.tsx
+++ b/client/src/components/ManageArtist/UploadArtistImage.tsx
@@ -17,7 +17,13 @@ import { queryArtist } from "queries";
 import { ArtistButton } from "components/Artist/ArtistButtons";
 import { useAuthContext } from "state/AuthContext";
 
-type ImageType = "banner" | "avatar" | "cover" | "image" | "profile";
+type ImageType =
+  | "background"
+  | "banner"
+  | "avatar"
+  | "cover"
+  | "image"
+  | "profile";
 
 export function isTrackgroup(entity: unknown): entity is TrackGroup {
   if (!entity) {
@@ -62,15 +68,19 @@ const getExistingImage = (
     } else if (isUser(existing) && imageType === "banner") {
       image = existing.userBanner;
     }
-  } else if (imageType === "avatar" || imageType === "banner") {
-    image = existing[imageType];
+  } else if (imageType === "avatar") {
+    image = (existing as Artist).avatar;
+  } else if (imageType === "background") {
+    image = (existing as Artist).background;
   }
 
   if (!image) {
     return undefined;
   }
   const actualImageLocation =
-    imageType === "banner" ? image?.sizes?.[625] : image?.sizes?.[600];
+    imageType === "banner" || imageType === "background"
+      ? image?.sizes?.[625]
+      : image?.sizes?.[600];
   return `${actualImageLocation}?updatedAt=${image?.updatedAt}`;
 };
 

--- a/client/src/components/ManageArtist/UploadGeneralImage.tsx
+++ b/client/src/components/ManageArtist/UploadGeneralImage.tsx
@@ -17,63 +17,6 @@ import { ArtistButton } from "components/Artist/ArtistButtons";
 import { useAuthContext } from "state/AuthContext";
 import { useFormContext } from "react-hook-form";
 
-type ImageType = "banner" | "avatar" | "cover" | "image" | "profile";
-
-export function isTrackgroup(entity: unknown): entity is TrackGroup {
-  if (!entity) {
-    return false;
-  }
-  return (entity as TrackGroup).cover !== undefined;
-}
-
-export function isUser(entity: unknown): entity is LoggedInUser {
-  if (!entity) {
-    return false;
-  }
-  return (entity as LoggedInUser).userAvatar !== undefined;
-}
-
-export function isTrack(entity: unknown): entity is Track {
-  if (!entity) {
-    return false;
-  }
-  return (entity as Track).trackGroupId !== undefined;
-}
-
-export function isMerch(entity: unknown): entity is Merch {
-  if (!entity) {
-    return false;
-  }
-  return (entity as Merch).quantityRemaining !== undefined;
-}
-
-const getExistingImage = (
-  existing: Artist | TrackGroup | Merch | LoggedInUser,
-  imageType: ImageType
-) => {
-  let image = undefined;
-  if (isTrackgroup(existing)) {
-    image = existing["cover"];
-  } else if (isMerch(existing)) {
-    image = existing.images?.[0];
-  } else if (isUser(existing)) {
-    if (isUser(existing) && imageType === "avatar") {
-      image = existing.userAvatar;
-    } else if (isUser(existing) && imageType === "banner") {
-      image = existing.userBanner;
-    }
-  } else if (imageType === "avatar") {
-    image = (existing as Artist).avatar;
-  }
-
-  if (!image) {
-    return undefined;
-  }
-  const actualImageLocation =
-    imageType === "banner" ? image?.sizes?.[625] : image?.sizes?.[600];
-  return `${actualImageLocation}?updatedAt=${image?.updatedAt}`;
-};
-
 type ExistingImage = {
   sizes: { [key: number]: string };
 };
@@ -87,7 +30,6 @@ const UploadGeneralImage: React.FC<{
   labelFor?: string;
   imageAlt?: string;
   size?: 625 | 1024 | 300 | 600 | 1200;
-  // imageType: ImageType;
   height: string;
   width: string;
   maxDimensions: string;

--- a/client/src/components/ManageArtist/UploadGeneralImage.tsx
+++ b/client/src/components/ManageArtist/UploadGeneralImage.tsx
@@ -62,8 +62,8 @@ const getExistingImage = (
     } else if (isUser(existing) && imageType === "banner") {
       image = existing.userBanner;
     }
-  } else if (imageType === "avatar" || imageType === "banner") {
-    image = existing[imageType];
+  } else if (imageType === "avatar") {
+    image = (existing as Artist).avatar;
   }
 
   if (!image) {

--- a/client/src/components/common/ArtistBackground.tsx
+++ b/client/src/components/common/ArtistBackground.tsx
@@ -29,7 +29,7 @@ export const StretchedImage = styled.img`
   }
 `;
 
-export const BannerWrapper = styled.div`
+export const BackgroundWrapper = styled.div`
   position: fixed;
   height: 100%;
   width: 100%;
@@ -44,7 +44,7 @@ export const BannerWrapper = styled.div`
   }
 `;
 
-const ArtistBanner = () => {
+const ArtistBackground = () => {
   const { pathname } = useLocation();
 
   const isManage = pathname.includes("manage");
@@ -52,30 +52,33 @@ const ArtistBanner = () => {
 
   const { data: artist } = useArtistQuery();
 
-  const artistBanner = artist?.banner;
+  const artistBackground = artist?.background;
 
-  const showBanner = !(trackGroupId || postId) || isManage;
+  const showBackground = !(trackGroupId || postId) || isManage;
 
   return (
     <>
-      {artistBanner && showBanner && (
-        <BannerWrapper>
-          {artistBanner && !artist.properties?.tileBackgroundImage && (
+      {artistBackground && showBackground && (
+        <BackgroundWrapper>
+          {artistBackground && !artist.properties?.tileBackgroundImage && (
             <StretchedImage
-              src={artistBanner?.sizes?.[2500] + `?${artistBanner?.updatedAt}`}
-              alt="Artist banner"
+              src={
+                artistBackground?.sizes?.[2500] +
+                `?${artistBackground?.updatedAt}`
+              }
+              alt="Artist background"
             />
           )}
-          {artistBanner && artist.properties?.tileBackgroundImage && (
+          {artistBackground && artist.properties?.tileBackgroundImage && (
             <TiledImage
-              url={`${artistBanner.sizes?.original}?${artistBanner?.updatedAt}`}
+              url={`${artistBackground.sizes?.original}?${artistBackground?.updatedAt}`}
             />
           )}
-        </BannerWrapper>
+        </BackgroundWrapper>
       )}
-      {(!artistBanner || !showBanner) && <NoMargin />}
+      {(!artistBackground || !showBackground) && <NoMargin />}
     </>
   );
 };
 
-export default ArtistBanner;
+export default ArtistBackground;

--- a/client/src/components/common/UserBanner.tsx
+++ b/client/src/components/common/UserBanner.tsx
@@ -1,10 +1,10 @@
 import { useLocation, useParams } from "react-router-dom";
 import {
-  BannerWrapper,
+  BackgroundWrapper,
   StretchedImage,
   TiledImage,
   NoMargin,
-} from "./ArtistBanner";
+} from "./ArtistBackground";
 import { queryLabelBySlug } from "queries";
 import { useQuery } from "@tanstack/react-query";
 
@@ -23,7 +23,7 @@ const UserBanner = () => {
   return (
     <>
       {banner && showBanner && (
-        <BannerWrapper>
+        <BackgroundWrapper>
           {banner && !label.properties?.tileBackgroundImage && (
             <StretchedImage
               src={banner?.sizes?.[2500] + `?${banner?.updatedAt}`}
@@ -35,7 +35,7 @@ const UserBanner = () => {
               url={`${banner.sizes?.original}?${banner?.updatedAt}`}
             />
           )}
-        </BannerWrapper>
+        </BackgroundWrapper>
       )}
       {(!banner || !showBanner) && <NoMargin />}
     </>

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -290,7 +290,7 @@ interface Artist {
   };
   announcementText?: string;
   user?: Partial<User>;
-  banner?: {
+  background?: {
     url: string;
     sizes?: { [key: number]: string; original: string };
     updatedAt: string;

--- a/prisma/migrations/20260415000000_rename_artist_banner_to_background/migration.sql
+++ b/prisma/migrations/20260415000000_rename_artist_banner_to_background/migration.sql
@@ -1,0 +1,2 @@
+-- Rename ArtistBanner table to ArtistBackground
+ALTER TABLE "ArtistBanner" RENAME TO "ArtistBackground";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -283,7 +283,7 @@ model Artist {
   updatedAt                          DateTime                             @default(now()) @updatedAt
   deletedAt                          DateTime?
   subscriptionTiers                  ArtistSubscriptionTier[]
-  banner                             ArtistBanner?
+  background                         ArtistBackground?
   avatar                             ArtistAvatar?
   urlSlug                            String
   /// [Properties]                              @unique
@@ -326,7 +326,7 @@ model ArtistAvatar {
   originalFilename String?
 }
 
-model ArtistBanner {
+model ArtistBackground {
   id               String    @id @default(uuid()) @db.Uuid
   url              String[]
   artist           Artist    @relation(fields: [artistId], references: [id])

--- a/src/activityPub/utils.ts
+++ b/src/activityPub/utils.ts
@@ -3,7 +3,7 @@ import { Request } from "express";
 import {
   Artist,
   ArtistAvatar,
-  ArtistBanner,
+  ArtistBackground,
   ArtistUserSubscription,
   Post,
   TrackGroup,
@@ -12,7 +12,7 @@ import { AppError } from "../utils/error";
 import crypto, { createVerify } from "crypto";
 import {
   finalArtistAvatarBucket,
-  finalArtistBannerBucket,
+  finalArtistBackgroundBucket,
 } from "../utils/minio";
 import { generateFullStaticImageUrl } from "../utils/images";
 import { isTrackGroup } from "../utils/typeguards";
@@ -113,7 +113,10 @@ export const getClient = async () => {
 };
 
 export const turnArtistIntoActor = async (
-  artist: Artist & { avatar: ArtistAvatar | null; banner: ArtistBanner | null }
+  artist: Artist & {
+    avatar: ArtistAvatar | null;
+    background: ArtistBackground | null;
+  }
 ) => {
   const client = await getClient();
   const { publicKey } = await generateKeysForSiteIfNeeded();
@@ -147,14 +150,14 @@ export const turnArtistIntoActor = async (
           },
         }
       : {}),
-    ...(artist.banner
+    ...(artist.background
       ? {
           image: {
             type: "Image",
             mediaType: "image/webp",
             url: generateFullStaticImageUrl(
-              artist.banner.url[0],
-              finalArtistBannerBucket
+              artist.background.url[0],
+              finalArtistBackgroundBucket
             ),
           },
         }

--- a/src/config/sharp.ts
+++ b/src/config/sharp.ts
@@ -75,6 +75,17 @@ export default {
         ],
       },
     },
+    background: {
+      webp: {
+        variants: [
+          { width: 2500, height: 2500 },
+          { width: 1250, height: 1250 },
+          { width: 1200, height: 630 },
+          { width: 1024, height: 1024 },
+          { width: 625, height: 625 },
+        ],
+      },
+    },
     banner: {
       webp: {
         variants: [

--- a/src/jobs/optimize-image.ts
+++ b/src/jobs/optimize-image.ts
@@ -205,8 +205,8 @@ const optimizeImage = async (job: Job) => {
         where: { id: destinationId },
         data: { url: urls },
       });
-    } else if (model === "artistBanner") {
-      await prisma.artistBanner.update({
+    } else if (model === "artistBackground") {
+      await prisma.artistBackground.update({
         where: { id: destinationId },
         data: { url: urls },
       });

--- a/src/parseIndex.ts
+++ b/src/parseIndex.ts
@@ -6,7 +6,7 @@ import { getClient } from "./activityPub/utils";
 import { generateFullStaticImageUrl } from "./utils/images";
 import {
   finalArtistAvatarBucket,
-  finalArtistBannerBucket,
+  finalArtistBackgroundBucket,
   finalCoversBucket,
   finalMerchImageBucket,
   finalPostImageBucket,
@@ -613,7 +613,7 @@ const handleDefault: RouteHandler<{}> = async ({ $, client }) => {
  */
 const resolveArtistImageUrl = (artist: {
   avatar?: { url: string[] } | null;
-  banner?: { url: string[] } | null;
+  background?: { url: string[] } | null;
   trackGroups?: Array<{ cover?: { url: string[] } | null }>;
 }): string | undefined => {
   // Try avatar first
@@ -622,10 +622,15 @@ const resolveArtistImageUrl = (artist: {
     return generateFullStaticImageUrl(avatarString, finalArtistAvatarBucket);
   }
 
-  // Fall back to banner
-  const bannerString = artist.banner?.url.find((u) => u.includes("x625"));
-  if (bannerString) {
-    return generateFullStaticImageUrl(bannerString, finalArtistBannerBucket);
+  // Fall back to background
+  const backgroundString = artist.background?.url.find((u) =>
+    u.includes("x625")
+  );
+  if (backgroundString) {
+    return generateFullStaticImageUrl(
+      backgroundString,
+      finalArtistBackgroundBucket
+    );
   }
 
   // Fall back to first album cover
@@ -748,7 +753,7 @@ export const analyzePathAndGenerateHTML = async (
       where: { urlSlug: segments[0] },
       include: {
         avatar: true,
-        banner: true,
+        background: true,
         trackGroups: {
           where: whereForPublishedTrackGroups(),
           include: { cover: true },

--- a/src/queues/processImages.ts
+++ b/src/queues/processImages.ts
@@ -6,13 +6,13 @@ import { REDIS_CONFIG } from "../config/redis";
 import {
   createBucketIfNotExists,
   finalArtistAvatarBucket,
-  finalArtistBannerBucket,
+  finalArtistBackgroundBucket,
   finalMerchImageBucket,
   finalPostImageBucket,
   finalUserAvatarBucket,
   finalUserBannerBucket,
   incomingArtistAvatarBucket,
-  incomingArtistBannerBucket,
+  incomingArtistBackgroundBucket,
   incomingMerchImageBucket,
   incomingUserBannerBucket,
   uploadWrapper,
@@ -71,7 +71,7 @@ export const uploadAndSendToImageQueue = async (
   ctx: APIContext,
   incomingBucket: string,
   model: string,
-  sharpConfigKey: "artwork" | "avatar" | "banner" | "inFormData",
+  sharpConfigKey: "artwork" | "avatar" | "background" | "banner" | "inFormData",
   createDatabaseEntry: (
     {
       filename,
@@ -80,7 +80,7 @@ export const uploadAndSendToImageQueue = async (
       filename: string;
       mimeType: string;
     },
-    details: { dimensions: "square" | "banner" }
+    details: { dimensions: "square" | "background" | "banner" }
   ) => Promise<{ id: string } | void>,
   finalBucket?: string, // If this is not supplied, we this basically just uploads to the first bucket,0
   storeWithExtension?: boolean
@@ -92,15 +92,18 @@ export const uploadAndSendToImageQueue = async (
 
   ctx.req.pipe(ctx.req.busboy);
   const fromBody: {
-    dimensions?: "square" | "banner";
+    dimensions?: "square" | "background" | "banner";
     relation?: "subscriptionTierImage";
     imageId?: string;
   } = {};
 
   const details = await new Promise((resolve, reject) => {
     ctx.req.busboy.on("field", function (fieldname, val) {
-      if (fieldname === "dimensions" && ["square", "banner"].includes(val)) {
-        fromBody["dimensions"] = val as "square" | "banner";
+      if (
+        fieldname === "dimensions" &&
+        ["square", "background", "banner"].includes(val)
+      ) {
+        fromBody["dimensions"] = val as "square" | "background" | "banner";
       }
       if (fieldname === "imageId") {
         fromBody["imageId"] = val;
@@ -137,7 +140,12 @@ export const uploadAndSendToImageQueue = async (
       if (finalBucket) {
         logger.info("Adding image to queue");
 
-        const config: "square" | "banner" | "avatar" | "artwork" =
+        const config:
+          | "square"
+          | "background"
+          | "banner"
+          | "avatar"
+          | "artwork" =
           sharpConfigKey === "inFormData"
             ? (fromBody.dimensions ?? "square")
             : sharpConfigKey;
@@ -246,15 +254,15 @@ export const processArtistAvatar = (ctx: APIContext) => {
   };
 };
 
-export const processArtistBanner = (ctx: APIContext) => {
+export const processArtistBackground = (ctx: APIContext) => {
   return async (artistId: number) => {
     return uploadAndSendToImageQueue(
       ctx,
-      incomingArtistBannerBucket,
-      "artistBanner",
-      "banner",
+      incomingArtistBackgroundBucket,
+      "artistBackground",
+      "background",
       async (fileInfo: { filename: string }) => {
-        return prisma.artistBanner.upsert({
+        return prisma.artistBackground.upsert({
           create: {
             originalFilename: fileInfo.filename,
             artistId: artistId,
@@ -268,7 +276,7 @@ export const processArtistBanner = (ctx: APIContext) => {
           },
         });
       },
-      finalArtistBannerBucket
+      finalArtistBackgroundBucket
     );
   };
 };

--- a/src/routers/v1/admin/artists/index.ts
+++ b/src/routers/v1/admin/artists/index.ts
@@ -42,7 +42,7 @@ export default function () {
         take: take ? Number(take) : undefined,
         include: {
           avatar: true,
-          banner: true,
+          background: true,
           user: true,
         },
         orderBy: {

--- a/src/routers/v1/artists/index.ts
+++ b/src/routers/v1/artists/index.ts
@@ -114,7 +114,7 @@ export default function () {
               deletedAt: null,
             },
           },
-          banner: {
+          background: {
             where: {
               deletedAt: null,
             },

--- a/src/routers/v1/labels/index.ts
+++ b/src/routers/v1/labels/index.ts
@@ -67,7 +67,7 @@ export default function () {
               deletedAt: null,
             },
           },
-          banner: {
+          background: {
             where: {
               deletedAt: null,
             },

--- a/src/routers/v1/labels/{id}/index.ts
+++ b/src/routers/v1/labels/{id}/index.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../utils/artist";
 import {
   finalArtistAvatarBucket,
-  finalArtistBannerBucket,
+  finalArtistBackgroundBucket,
   finalCoversBucket,
 } from "../../../../utils/minio";
 import { whereForPublishedTrackGroups } from "../../../../utils/trackGroup";
@@ -27,7 +27,7 @@ export default function () {
       const labelProfile = await prisma.artist.findFirst({
         where: { id: artistId, isLabelProfile: true },
         include: {
-          banner: true,
+          background: true,
           avatar: true,
         },
       });
@@ -54,7 +54,7 @@ export default function () {
                       deletedAt: null,
                     },
                   },
-                  banner: {
+                  background: {
                     where: {
                       deletedAt: null,
                     },

--- a/src/routers/v1/labels/{id}/tracks.ts
+++ b/src/routers/v1/labels/{id}/tracks.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../utils/artist";
 import {
   finalArtistAvatarBucket,
-  finalArtistBannerBucket,
+  finalArtistBackgroundBucket,
   finalCoversBucket,
   finalUserAvatarBucket,
   finalUserBannerBucket,

--- a/src/routers/v1/manage/artists/{artistId}/background.ts
+++ b/src/routers/v1/manage/artists/{artistId}/background.ts
@@ -4,10 +4,10 @@ import {
   artistBelongsToLoggedInUser,
   userAuthenticated,
 } from "../../../../../auth/passport";
-import { processArtistBanner } from "../../../../../queues/processImages";
+import { processArtistBackground } from "../../../../../queues/processImages";
 import prisma from "@mirlo/prisma";
 import { User } from "@mirlo/prisma/client";
-import { deleteArtistBanner } from "../../../../../utils/artist";
+import { deleteArtistBackground } from "../../../../../utils/artist";
 import { AppError } from "../../../../../utils/error";
 import { busboyOptions } from "../../../../../utils/images";
 
@@ -31,7 +31,7 @@ export default function () {
     const { artistId } = req.params as unknown as Params;
 
     try {
-      const { jobId, imageId } = await processArtistBanner({ req, res })(
+      const { jobId, imageId } = await processArtistBackground({ req, res })(
         Number(artistId)
       );
 
@@ -42,7 +42,7 @@ export default function () {
   }
 
   PUT.apiDoc = {
-    summary: "Updates an artist banner belonging to a user",
+    summary: "Updates an artist background belonging to a user",
     parameters: [
       {
         in: "path",
@@ -55,7 +55,7 @@ export default function () {
         name: "file",
         type: "file",
         required: true,
-        description: "The banner to upload",
+        description: "The background image to upload",
       },
     ],
     responses: {
@@ -89,7 +89,7 @@ export default function () {
         throw new AppError({ description: "Artist not found", httpCode: 404 });
       }
 
-      await deleteArtistBanner(artist.id);
+      await deleteArtistBackground(artist.id);
 
       res.json({ message: "Success" });
     } catch (error) {
@@ -98,7 +98,7 @@ export default function () {
   }
 
   DELETE.apiDoc = {
-    summary: "Deletes an artist banner belonging to a user",
+    summary: "Deletes an artist background belonging to a user",
     parameters: [
       {
         in: "path",

--- a/src/routers/v1/manage/artists/{artistId}/images/index.ts
+++ b/src/routers/v1/manage/artists/{artistId}/images/index.ts
@@ -43,7 +43,7 @@ export default function () {
         async (
           fileInfo: { filename: string },
           details: {
-            dimensions: "square" | "banner";
+            dimensions: "square" | "background" | "banner";
             imageId?: string;
             relation?: string;
             tierId?: number;

--- a/src/routers/v1/users/{userId}/banner.ts
+++ b/src/routers/v1/users/{userId}/banner.ts
@@ -4,13 +4,10 @@ import {
   artistBelongsToLoggedInUser,
   userAuthenticated,
 } from "../../../../auth/passport";
-import {
-  processArtistBanner,
-  processUserBanner,
-} from "../../../../queues/processImages";
+import { processUserBanner } from "../../../../queues/processImages";
 import prisma from "@mirlo/prisma";
 import { User } from "@mirlo/prisma/client";
-import { deleteArtistBanner } from "../../../../utils/artist";
+import { deleteArtistBackground } from "../../../../utils/artist";
 import { AppError } from "../../../../utils/error";
 import { busboyOptions } from "../../../../utils/images";
 
@@ -87,7 +84,7 @@ export default function () {
         throw new AppError({ description: "Artist not found", httpCode: 404 });
       }
 
-      await deleteArtistBanner(artist.id);
+      await deleteArtistBackground(artist.id);
 
       res.json({ message: "Success" });
     } catch (error) {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -93,7 +93,7 @@ const routes = [
   "manage/artists/{artistId}/labels/{labelUserId}",
   "manage/artists/{artistId}/codes",
   "manage/artists/{artistId}/subscribers",
-  "manage/artists/{artistId}/banner",
+  "manage/artists/{artistId}/background",
   "manage/artists/{artistId}/avatar",
   "manage/artists/{artistId}/drafts",
   "manage/artists/{artistId}/trackGroupOrder",

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -3,7 +3,7 @@ import {
   ArtistSubscriptionTier,
   Artist,
   Post,
-  ArtistBanner,
+  ArtistBackground,
   ArtistAvatar,
   TrackGroup,
   TrackGroupCover,
@@ -24,7 +24,7 @@ import postProcessor from "./post";
 import { convertURLArrayToSizes } from "./images";
 import {
   finalArtistAvatarBucket,
-  finalArtistBannerBucket,
+  finalArtistBackgroundBucket,
   finalCoversBucket,
   finalImageBucket,
   finalUserAvatarBucket,
@@ -382,22 +382,22 @@ export const deleteUserAvatar = async (userId: number) => {
   }
 };
 
-export const deleteArtistBanner = async (artistId: number) => {
-  const banner = await prisma.artistBanner.findFirst({
+export const deleteArtistBackground = async (artistId: number) => {
+  const background = await prisma.artistBackground.findFirst({
     where: {
       artistId,
     },
   });
 
-  if (banner) {
-    await prisma.artistBanner.delete({
+  if (background) {
+    await prisma.artistBackground.delete({
       where: {
         artistId,
       },
     });
 
     try {
-      removeObjectsFromBucket(finalArtistBannerBucket, banner.id);
+      removeObjectsFromBucket(finalArtistBackgroundBucket, background.id);
     } catch (e) {
       console.error("Found no files, that's okay");
     }
@@ -473,7 +473,7 @@ export const singleInclude = (queryOptions?: {
       },
     },
     tourDates: true,
-    banner: {
+    background: {
       where: {
         deletedAt: null,
       },
@@ -580,7 +580,7 @@ export const singleInclude = (queryOptions?: {
 
 interface LocalArtist extends Artist {
   posts?: Post[];
-  banner?: ArtistBanner | null;
+  background?: ArtistBackground | null;
   avatar?: ArtistAvatar | null;
   trackGroups?: (TrackGroup & {
     cover?: TrackGroupCover | null;
@@ -616,7 +616,10 @@ export const processSingleArtist = (
       postProcessor.single(p, isUserSubscriber || artist.userId === userId)
     ),
     merch: artist?.merch?.map(processSingleMerch),
-    banner: addSizesToImage(finalArtistBannerBucket, artist?.banner),
+    background: addSizesToImage(
+      finalArtistBackgroundBucket,
+      artist?.background
+    ),
     avatar: addSizesToImage(finalArtistAvatarBucket, artist?.avatar),
     trackGroups: artist?.trackGroups?.map((tg) =>
       processSingleTrackGroup(tg, {

--- a/src/utils/minio.ts
+++ b/src/utils/minio.ts
@@ -20,9 +20,9 @@ import { Readable } from "stream";
 
 const s3UniquePrefix = "";
 
-export const incomingArtistBannerBucket =
+export const incomingArtistBackgroundBucket =
   s3UniquePrefix + "incoming-artist-banners";
-export const finalArtistBannerBucket = s3UniquePrefix + "artist-banners";
+export const finalArtistBackgroundBucket = s3UniquePrefix + "artist-banners";
 
 export const incomingArtistAvatarBucket =
   s3UniquePrefix + "incoming-artist-avatars";

--- a/test/routers/manage/artists/{id}.background.spec.ts
+++ b/test/routers/manage/artists/{id}.background.spec.ts
@@ -7,12 +7,12 @@ import { clearTables, createArtist, createUser } from "../../../utils";
 import prisma from "@mirlo/prisma";
 import {
   createBucketIfNotExists,
-  finalArtistBannerBucket,
+  finalArtistBackgroundBucket,
 } from "../../../../src/utils/minio";
 
 import { requestApp } from "../../utils";
 
-describe("manage/artists/{artistId}/banner", () => {
+describe("manage/artists/{artistId}/background", () => {
   beforeEach(async () => {
     try {
       await clearTables();
@@ -25,20 +25,20 @@ describe("manage/artists/{artistId}/banner", () => {
     it("should DELETE with one artist", async () => {
       const { user, accessToken } = await createUser({ email: "test@testcom" });
       const artist = await createArtist(user.id);
-      await createBucketIfNotExists(finalArtistBannerBucket);
+      await createBucketIfNotExists(finalArtistBackgroundBucket);
 
-      await prisma.artistBanner.create({
+      await prisma.artistBackground.create({
         data: {
           artistId: artist.id,
         },
       });
 
       const response = await requestApp
-        .delete(`manage/artists/${artist.id}/banner`)
+        .delete(`manage/artists/${artist.id}/background`)
         .set("Cookie", [`jwt=${accessToken}`])
         .set("Accept", "application/json");
 
-      const foundOld = await prisma.artistBanner.findFirst({
+      const foundOld = await prisma.artistBackground.findFirst({
         where: { artistId: artist.id },
       });
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -34,7 +34,7 @@ export const clearTables = async () => {
   await prisma.$executeRaw`DELETE FROM "TrackGroupDownloadableContent";`;
   await prisma.$executeRaw`DELETE FROM "TrackGroupDownloadCodes";`;
   await prisma.$executeRaw`DELETE FROM "TrackGroup";`;
-  await prisma.$executeRaw`DELETE FROM "ArtistBanner";`;
+  await prisma.$executeRaw`DELETE FROM "ArtistBackground";`;
   await prisma.$executeRaw`DELETE FROM "UserArtistTip";`;
   await prisma.$executeRaw`DELETE FROM "ArtistAvatar";`;
   await prisma.$executeRaw`DELETE FROM "ArtistUserSubscriptionConfirmation";`;


### PR DESCRIPTION
With the all the recent talks of needing to offer more styling options and allow the page to feel more like a proper website, it felt extremely important to rename background correctly because its naming was currently misleading in the database. Only the minIO/S3 "bucket names" ("incoming-artist-banners" and "artist-banners") are left with the incorrect naming because they'll eventually be abandonned for another system anyway.