### PR TITLE
Subscription page

### DIFF
--- a/client/src/components/Artist/ArtistFallbackComposite.tsx
+++ b/client/src/components/Artist/ArtistFallbackComposite.tsx
@@ -73,7 +73,6 @@ export const ArtistFallbackComposite: React.FC<{
       />
     );
   }
-  console.log("showing covers", covers);
 
   return (
     <CompositeContainer coverCount={covers.length}>

--- a/client/src/components/Artist/ArtistSquare.tsx
+++ b/client/src/components/Artist/ArtistSquare.tsx
@@ -17,13 +17,6 @@ const ArtistSquare: React.FC<{
   const standardImageSrc =
     artist.avatar?.sizes?.[300] ?? artist.banner?.sizes?.[625];
 
-  console.log(
-    "ArtistSquare render",
-    artist.name,
-    "standardImageSrc:",
-    standardImageSrc
-  );
-
   return (
     <TrackGroupWrapper>
       <div>

--- a/client/src/components/Artist/ArtistSupportBox.tsx
+++ b/client/src/components/Artist/ArtistSupportBox.tsx
@@ -11,9 +11,14 @@ import { useAuthContext } from "state/AuthContext";
 import { queryArtist } from "queries";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
-import { ArtistButton, useGetArtistColors } from "./ArtistButtons";
+import {
+  ArtistButton,
+  ArtistButtonLink,
+  useGetArtistColors,
+} from "./ArtistButtons";
 import useErrorHandler from "services/useErrorHandler";
 import IncludedReleases from "./IncludedReleases";
+import { getArtistManageTiersUrl } from "utils/artist";
 
 const ArtistSupportBox: React.FC<{
   subscriptionTier: ArtistSubscriptionTier;
@@ -111,6 +116,23 @@ const ArtistSupportBox: React.FC<{
         </div>
       )}
       <div>
+        <div className="absolute top-2 right-2 flex items-center justify-center gap-2">
+          <PlatformPercent
+            percent={subscriptionTier.platformPercent}
+            chosenPrice={
+              subscriptionTier?.minAmount ? subscriptionTier.minAmount / 100 : 0
+            }
+            artistName={artist?.name}
+            currency={subscriptionTier.currency}
+          />
+          <ArtistButtonLink
+            to={getArtistManageTiersUrl(subscriptionTier.artistId)}
+            size="compact"
+            variant="dashed"
+          >
+            Edit
+          </ArtistButtonLink>
+        </div>
         {subscriptionTier.images?.[0]?.image.sizes?.[625] && (
           <img
             src={
@@ -147,21 +169,7 @@ const ArtistSupportBox: React.FC<{
         }
       >
         {!isSubscribedToTier && !isSubscribedToArtist && (
-          <div className="flex gap-3 flex-col">
-            <div className="flex items-center content-center">
-              <ArtistVariableSupport tier={subscriptionTier} />
-            </div>
-            <PlatformPercent
-              percent={subscriptionTier.platformPercent}
-              chosenPrice={
-                subscriptionTier?.minAmount
-                  ? subscriptionTier.minAmount / 100
-                  : 0
-              }
-              artistName={artist?.name}
-              currency={subscriptionTier.currency}
-            />
-          </div>
+          <ArtistVariableSupport tier={subscriptionTier} />
         )}
         {(isSubscribedToTier || isSubscribedToArtist) && (
           <div className="flex items-center justify-center gap-3 flex-col">

--- a/client/src/components/Artist/ArtistSupportBox.tsx
+++ b/client/src/components/Artist/ArtistSupportBox.tsx
@@ -73,6 +73,10 @@ const ArtistSupportBox: React.FC<{
     return <LoadingBlocks rows={2} />;
   }
 
+  if (!subscriptionTier.minAmount || subscriptionTier.minAmount === 0) {
+    return null;
+  }
+
   const isSubscribedToTier = !!user?.artistUserSubscriptions?.find(
     (sub) => sub.artistSubscriptionTier.id === subscriptionTier.id
   );
@@ -116,7 +120,20 @@ const ArtistSupportBox: React.FC<{
         </div>
       )}
       <div>
-        <div className="absolute top-2 right-2 flex items-center justify-center gap-2">
+        <div className="absolute top-2 right-2 flex items-center justify-center gap-2 z-21 ">
+          {user && user.id === artist.userId && (
+            <ArtistButtonLink
+              to={
+                getArtistManageTiersUrl(subscriptionTier.artistId) +
+                "/" +
+                subscriptionTier.id
+              }
+              size="compact"
+              variant="dashed"
+            >
+              {t("editTier")}
+            </ArtistButtonLink>
+          )}
           <PlatformPercent
             percent={subscriptionTier.platformPercent}
             chosenPrice={
@@ -124,14 +141,8 @@ const ArtistSupportBox: React.FC<{
             }
             artistName={artist?.name}
             currency={subscriptionTier.currency}
+            alignRight
           />
-          <ArtistButtonLink
-            to={getArtistManageTiersUrl(subscriptionTier.artistId)}
-            size="compact"
-            variant="dashed"
-          >
-            Edit
-          </ArtistButtonLink>
         </div>
         {subscriptionTier.images?.[0]?.image.sizes?.[625] && (
           <img
@@ -196,9 +207,11 @@ const ArtistSupportBox: React.FC<{
           </div>
         )}
       </div>
-      <div className="text-base px-5">
-        <MarkdownContent content={subscriptionTier.description} />
-      </div>
+      {subscriptionTier.description && (
+        <div className="text-base px-5">
+          <MarkdownContent content={subscriptionTier.description} />
+        </div>
+      )}
       {hasRewards && (
         <>
           <hr className="border-(--tier-inner-border-color)" />

--- a/client/src/components/ManageArtist/ManageArtistSubscriptionTiers.tsx
+++ b/client/src/components/ManageArtist/ManageArtistSubscriptionTiers.tsx
@@ -1,94 +1,135 @@
 import { css } from "@emotion/css";
 import React from "react";
 import ManageSubscriptionTierBox from "./ManageSubscriptionTierBox";
-import SubscriptionForm from "./SubscriptionForm";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
 import { ManageSectionWrapper } from "./ManageSectionWrapper";
-import Modal from "components/common/Modal";
 import { useTranslation } from "react-i18next";
 import Button, { ButtonLink } from "components/common/Button";
 import { FaPlus, FaWrench } from "react-icons/fa";
 import {
   queryManagedArtist,
   queryManagedArtistSubscriptionTiers,
+  useCreateSubscriptionTierMutation,
 } from "queries";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import useErrorHandler from "services/useErrorHandler";
+import { useSnackbar } from "state/SnackbarContext";
+import { ArtistButton } from "components/Artist/ArtistButtons";
 
 const ManageArtistSubscriptionTiers: React.FC<{}> = () => {
-  const [addingNewTier, setAddingNewTier] = React.useState(false);
   const { t } = useTranslation("translation", {
     keyPrefix: "subscriptionForm",
   });
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const errorHandler = useErrorHandler();
+  const snackbar = useSnackbar();
 
   const { artistId } = useParams();
 
   const { data: artist } = useQuery(queryManagedArtist(Number(artistId)));
 
-  const { data: tiers, refetch: refetchTiers } = useQuery({
+  const { data: tiers } = useQuery({
     ...queryManagedArtistSubscriptionTiers({
       artistId: Number(artistId),
     }),
     enabled: Boolean(artistId),
   });
 
+  const { mutate, isPending } = useCreateSubscriptionTierMutation();
+
+  const handleAddNewTier = () => {
+    if (!artistId) return;
+    mutate(
+      {
+        artistId: Number(artistId),
+        name: t("untitledTier"),
+      },
+      {
+        onSuccess: (result) => {
+          snackbar(t("tierCreated"), { type: "success" });
+          navigate(`/manage/artists/${artistId}/tiers/${result.result.id}`);
+        },
+        onError: (error) => {
+          errorHandler(error);
+        },
+      }
+    );
+  };
+
+  const handleTierReload = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: queryManagedArtistSubscriptionTiers({
+        artistId: Number(artistId),
+      }).queryKey,
+    });
+  };
+
   if (!artist) {
     return null;
   }
 
   return (
-    <>
-      <ManageSectionWrapper>
-        <SpaceBetweenDiv>
-          <div />
-          <div
+    <ManageSectionWrapper>
+      <SpaceBetweenDiv>
+        <div />
+        <div
+          className={css`
+            display: flex;
+          `}
+        >
+          <ButtonLink
+            to="supporters"
             className={css`
-              display: flex;
+              margin-right: 0.25rem;
             `}
+            variant="dashed"
+            size="compact"
+            collapsible
+            startIcon={<FaWrench />}
           >
-            <ButtonLink
-              to="supporters"
-              className={css`
-                margin-right: 0.25rem;
-              `}
-              variant="dashed"
-              size="compact"
-              collapsible
-              startIcon={<FaWrench />}
-            >
-              {t("supporters")}
-            </ButtonLink>
-            <Button
-              onClick={() => {
-                setAddingNewTier(true);
-              }}
-              startIcon={<FaPlus />}
-              size="compact"
-              variant="dashed"
-            >
-              {t("addNewTier")}
-            </Button>
-          </div>
-        </SpaceBetweenDiv>
-        <div className="grid md:grid-cols-3 gap-1">
-          {tiers?.results.map((tier) => (
+            {t("supporters")}
+          </ButtonLink>
+          <Button
+            onClick={handleAddNewTier}
+            startIcon={<FaPlus />}
+            size="compact"
+            variant="dashed"
+            isLoading={isPending}
+            disabled={isPending}
+          >
+            {t("addNewTier")}
+          </Button>
+        </div>
+      </SpaceBetweenDiv>
+      <div className="grid md:grid-cols-3 gap-2">
+        {tiers?.results
+          .sort((a, b) => (a.minAmount ?? 0) - (b.minAmount ?? 0))
+          .map((tier) => (
             <ManageSubscriptionTierBox
               tier={tier}
               key={tier.id}
-              reload={refetchTiers}
+              reload={handleTierReload}
               artist={artist}
             />
           ))}
-        </div>
-        <Modal
-          open={addingNewTier}
-          onClose={() => setAddingNewTier(false)}
-          title={t("newSubscriptionTierFor", { artistName: artist.name }) ?? ""}
+        <ArtistButton
+          variant="dashed"
+          className={css`
+            .children {
+              display: flex;
+              align-items: center;
+              justify-content: center;
+            }
+          `}
+          startIcon={<FaPlus />}
+          onClick={handleAddNewTier}
         >
-          <SubscriptionForm artist={artist} reload={refetchTiers} />
-        </Modal>
-      </ManageSectionWrapper>
-    </>
+          {t("addNewTier")}
+        </ArtistButton>
+      </div>
+    </ManageSectionWrapper>
   );
 };
 

--- a/client/src/components/ManageArtist/ManageSubscriptionTierBox.tsx
+++ b/client/src/components/ManageArtist/ManageSubscriptionTierBox.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/css";
 import Box from "components/common/Box";
-import Button from "components/common/Button";
+import Button, { ButtonLink } from "components/common/Button";
 import Modal from "components/common/Modal";
 import { Money } from "components/common/Money";
 import React from "react";
@@ -9,11 +9,11 @@ import { useParams } from "react-router-dom";
 import api from "services/api";
 import { useSnackbar } from "state/SnackbarContext";
 import SubscriptionForm from "./SubscriptionForm";
-import ManageSubscriptionTierReleases from "./ManageSubscriptionTierReleases";
 import MarkdownContent from "components/common/MarkdownContent";
 import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
 import { useAuthContext } from "state/AuthContext";
 import { useTranslation } from "react-i18next";
+import { getArtistManageTiersUrl } from "utils/artist";
 
 const ManageSubscriptionTierBox: React.FC<{
   tier: ArtistSubscriptionTier;
@@ -50,7 +50,6 @@ const ManageSubscriptionTierBox: React.FC<{
     <Box
       key={tier.id}
       className={css`
-        margin-bottom: 0.5rem;
         background: var(--mi-darken-background-color);
       `}
       noPadding
@@ -105,10 +104,10 @@ const ManageSubscriptionTierBox: React.FC<{
                 display: flex;
               `}
             >
-              <Button
+              <ButtonLink
                 variant="dashed"
                 startIcon={<FaPen />}
-                onClick={() => setManageTier(true)}
+                to={getArtistManageTiersUrl(artist.id) + `/${tier.id}`}
               />
 
               <Button

--- a/client/src/components/ManageArtist/ManageSubscriptionTierPage.tsx
+++ b/client/src/components/ManageArtist/ManageSubscriptionTierPage.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  queryManagedArtist,
+  queryManagedArtistSubscriptionTier,
+} from "queries";
+import SubscriptionForm from "./SubscriptionForm";
+import { useTranslation } from "react-i18next";
+import LoadingBlocks from "components/Artist/LoadingBlocks";
+
+const ManageSubscriptionTierPage: React.FC = () => {
+  const { artistId, tierId } = useParams();
+  const { t } = useTranslation("translation", {
+    keyPrefix: "subscriptionForm",
+  });
+  const queryClient = useQueryClient();
+
+  const { data: artist } = useQuery(queryManagedArtist(Number(artistId)));
+
+  const { data: tier, isLoading } = useQuery(
+    queryManagedArtistSubscriptionTier({
+      artistId: Number(artistId),
+      tierId: Number(tierId),
+    })
+  );
+
+  const handleReload = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: queryManagedArtistSubscriptionTier({
+        artistId: Number(artistId),
+        tierId: Number(tierId),
+      }).queryKey,
+    });
+  };
+
+  if (isLoading || !artist) {
+    return <LoadingBlocks rows={5} />;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">
+        {tier?.name || t("newSubscriptionTier")}
+      </h1>
+      <SubscriptionForm artist={artist} existing={tier} reload={handleReload} />
+    </div>
+  );
+};
+
+export default ManageSubscriptionTierPage;

--- a/client/src/components/ManageArtist/SubscriptionForm.tsx
+++ b/client/src/components/ManageArtist/SubscriptionForm.tsx
@@ -160,7 +160,6 @@ const SubscriptionForm: React.FC<{
           dimensions="banner"
           maxDimensions="700x400"
           maxSize="15mb"
-          afterSave={handleSubmit(doSave)}
         />
         <FormSection>
           <FormComponent>

--- a/client/src/components/TrackGroup/PaymentInputElement.tsx
+++ b/client/src/components/TrackGroup/PaymentInputElement.tsx
@@ -80,7 +80,7 @@ const PaymentInputElement: React.FC<{
     Number(chosenPrice) > ((minPrice || 200) / 100) * 10;
 
   return (
-    <>
+    <div className="relative pt-1">
       <label htmlFor="priceInput">
         {t("nameYourPrice", {
           currency: getCurrencySymbol(currency, undefined),
@@ -133,13 +133,16 @@ const PaymentInputElement: React.FC<{
             })}
           </div>
         )}
-      <PlatformPercent
-        percent={platformPercent}
-        chosenPrice={finalPrice}
-        currency={currency}
-        artistName={artistName}
-      />
-    </>
+      <div className="absolute right-0 top-0">
+        <PlatformPercent
+          percent={platformPercent}
+          chosenPrice={finalPrice ?? 0}
+          currency={currency}
+          artistName={artistName}
+          alignRight
+        />
+      </div>
+    </div>
   );
 };
 

--- a/client/src/components/common/Box.tsx
+++ b/client/src/components/common/Box.tsx
@@ -72,7 +72,6 @@ const Box = styled.div<{
   width: 100%;
   padding: ${(props) =>
     props?.noPadding ? "0" : props.compact ? ".25rem .5rem" : "1.25rem"};
-  margin-bottom: 0.5rem;
   border-radius: 5px;
 
   ${(props) => {

--- a/client/src/components/common/PlatformPercent.tsx
+++ b/client/src/components/common/PlatformPercent.tsx
@@ -8,8 +8,16 @@ const PlatformPercent: React.FC<{
   chosenPrice?: string | number;
   currency: string;
   artistName?: string;
-}> = ({ percent, chosenPrice, currency = "USD", artistName }) => {
+  alignRight?: boolean;
+}> = ({
+  percent,
+  chosenPrice,
+  currency = "USD",
+  artistName,
+  alignRight = false,
+}) => {
   const [showTooltip, setShowTooltip] = useState(false);
+  const tooltipId = `platform-percent-tooltip-${Math.random().toString(36).substr(2, 9)}`;
   const { colors } = useGetArtistColors();
   const chosenNumber =
     chosenPrice && isFinite(+chosenPrice) ? Number(chosenPrice) : null;
@@ -25,19 +33,27 @@ const PlatformPercent: React.FC<{
   return (
     <div className="relative inline-block">
       <button
-        className="w-6 h-6 rounded-full flex items-center justify-center text-sm font-semibold cursor-pointer p-0 transition-opacity hover:opacity-80"
+        id={`${tooltipId}-button`}
+        className="w-6 h-6 border-1 rounded-full flex items-center justify-center text-sm font-semibold cursor-pointer p-0 transition-opacity hover:opacity-80"
         style={{
-          backgroundColor: colors?.primary ?? "var(--mi-primary-color)",
-          color: colors?.secondary ?? "var(--mi-secondary-color)",
+          borderColor: colors?.primary ?? "var(--mi-primary-color)",
+          color: colors?.primary ?? "var(--mi-primary-color)",
         }}
         onClick={() => setShowTooltip(!showTooltip)}
         type="button"
+        aria-label={t("helpTooltip") || "Platform percentage information"}
+        aria-expanded={showTooltip}
+        aria-describedby={showTooltip ? tooltipId : undefined}
       >
         ?
       </button>
       {showTooltip && (
         <div
-          className="absolute z-10 rounded shadow p-3 text-sm whitespace-normal w-64 top-8 left-0 border"
+          id={tooltipId}
+          className={`absolute z-10 rounded shadow p-3 text-sm whitespace-normal w-64 top-8 border ${
+            alignRight ? "right-0" : "left-0"
+          }`}
+          role="tooltip"
           style={{
             backgroundColor:
               colors?.background ?? "var(--mi-normal-background-color)",

--- a/client/src/components/common/PlatformPercent.tsx
+++ b/client/src/components/common/PlatformPercent.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { moneyDisplay } from "./Money";
-import { css } from "@emotion/css";
+import { useGetArtistColors } from "components/Artist/ArtistButtons";
 
 const PlatformPercent: React.FC<{
   percent: number;
@@ -9,6 +9,8 @@ const PlatformPercent: React.FC<{
   currency: string;
   artistName?: string;
 }> = ({ percent, chosenPrice, currency = "USD", artistName }) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const { colors } = useGetArtistColors();
   const chosenNumber =
     chosenPrice && isFinite(+chosenPrice) ? Number(chosenPrice) : null;
   const { t } = useTranslation("translation", { keyPrefix: "artist" });
@@ -21,20 +23,43 @@ const PlatformPercent: React.FC<{
   const paymentAmount = chosenNumber * 0.029 + 0.3;
 
   return (
-    <div className="text-sm">
-      {t("platformPercent", {
-        percent: (100 - percent).toFixed(),
-        artistName: artistName ?? "the artist",
-        money: moneyDisplay({ amount, currency }),
-        mirloCut: moneyDisplay({
-          amount: Number(chosenPrice) - amount,
-          currency,
-        }),
-        paymentProcessorCut: moneyDisplay({
-          amount: paymentAmount,
-          currency,
-        }),
-      })}
+    <div className="relative inline-block">
+      <button
+        className="w-6 h-6 rounded-full flex items-center justify-center text-sm font-semibold cursor-pointer p-0 transition-opacity hover:opacity-80"
+        style={{
+          backgroundColor: colors?.primary ?? "var(--mi-primary-color)",
+          color: colors?.secondary ?? "var(--mi-secondary-color)",
+        }}
+        onClick={() => setShowTooltip(!showTooltip)}
+        type="button"
+      >
+        ?
+      </button>
+      {showTooltip && (
+        <div
+          className="absolute z-10 rounded shadow p-3 text-sm whitespace-normal w-64 top-8 left-0 border"
+          style={{
+            backgroundColor:
+              colors?.background ?? "var(--mi-normal-background-color)",
+            borderColor: colors?.primary ?? "var(--mi-primary-color)",
+            color: colors?.foreground ?? "var(--mi-foreground-color)",
+          }}
+        >
+          {t("platformPercent", {
+            percent: (100 - percent).toFixed(),
+            artistName: artistName ?? "the artist",
+            money: moneyDisplay({ amount, currency }),
+            mirloCut: moneyDisplay({
+              amount: Number(chosenPrice) - amount,
+              currency,
+            }),
+            paymentProcessorCut: moneyDisplay({
+              amount: paymentAmount,
+              currency,
+            }),
+          })}
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/queries/artists.ts
+++ b/client/src/queries/artists.ts
@@ -1,4 +1,9 @@
-import { QueryFunction, queryOptions } from "@tanstack/react-query";
+import {
+  QueryFunction,
+  queryOptions,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 import * as api from "./fetch/fetchWrapper";
 import {
   QUERY_KEY_ARTISTS,
@@ -119,6 +124,61 @@ export function queryManagedArtistSubscriptionTiers(opts: {
       QUERY_KEY_TRACK_GROUPS,
     ],
     queryFn: fetchManagedArtistSubscriptionTiers,
+  });
+}
+
+const fetchManagedArtistSubscriptionTier: QueryFunction<
+  ArtistSubscriptionTier,
+  [
+    "fetchManagedArtistSubscriptionTier",
+    { artistId?: number; tierId?: number },
+    ...any,
+  ]
+> = ({ queryKey: [_, { artistId, tierId }], signal }) => {
+  return api
+    .get<{
+      result: ArtistSubscriptionTier;
+    }>(`v1/manage/artists/${artistId}/subscriptionTiers/${tierId}`, { signal })
+    .then((r) => r.result);
+};
+
+export function queryManagedArtistSubscriptionTier(opts: {
+  artistId?: number;
+  tierId?: number;
+}) {
+  return queryOptions({
+    queryKey: [
+      "fetchManagedArtistSubscriptionTier",
+      opts,
+      QUERY_KEY_TRACK_GROUPS,
+    ],
+    queryFn: fetchManagedArtistSubscriptionTier,
+    enabled: Boolean(opts.artistId && opts.tierId),
+  });
+}
+
+async function createSubscriptionTier(opts: {
+  artistId: number;
+  name: string;
+}): Promise<{ result: ArtistSubscriptionTier }> {
+  return api.post(`v1/manage/artists/${opts.artistId}/subscriptionTiers/`, {
+    name: opts.name,
+  });
+}
+
+export function useCreateSubscriptionTierMutation() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: createSubscriptionTier,
+    async onSuccess(_, { artistId }) {
+      await client.invalidateQueries({
+        queryKey: [
+          "fetchManagedArtistSubscriptionTiers",
+          { artistId },
+          QUERY_KEY_TRACK_GROUPS,
+        ],
+      });
+    },
   });
 }
 

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -369,6 +369,15 @@ const routes: RouteObject[] = [
                     },
                   },
                   {
+                    path: "tiers/:tierId",
+                    async lazy() {
+                      const { default: Component } = await import(
+                        "components/ManageArtist/ManageSubscriptionTierPage"
+                      );
+                      return { Component };
+                    },
+                  },
+                  {
                     path: "posts",
                     async lazy() {
                       const { default: Component } = await import(

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -430,6 +430,7 @@
     "labelNotFound": "Label not found"
   },
   "artist": {
+    "editTier": "Edit",
     "failedToAddLocation": "Failed to add location tag",
     "failedToRemoveLocation": "Failed to remove location tag",
     "locationAdded": "Location tag added",
@@ -579,6 +580,7 @@
     "chooseToContinue": "Choose a support tier to continue",
     "purchaseEntireCatalogue": "Purchase entire catalogue for {{amount}}",
     "platformPercent": "{{ artistName }} has chosen that they will get {{ percent }}% ({{ money }}) of this purchase. The platform will receive {{ mirloCut }}. Their payment processor will take a cut of {{ paymentProcessorCut }}.",
+    "helpTooltip": "Platform percentage breakdown",
     "isSubscribed": "Subscribed",
     "moreLinks": "More links"
   },
@@ -1121,6 +1123,7 @@
     "platformPercent": "Platform cut",
     "inCurrency": "In {{ currency }}",
     "subscriptionUpdated": "Subscription updated",
+    "tierCreated": "Tier created",
     "interval": "What's the interval for this subscription?",
     "monthly": "Monthly",
     "yearly": "Yearly",
@@ -1131,6 +1134,8 @@
     "allowVariableDescription": "Allow supporters to enter a larger number?",
     "autoAlbumPurchase": "If a user subscribes at this tier, they'll automatically get every new release you release.",
     "newSubscriptionTierFor": "New subscription tier for {{ artistName }}",
+    "newSubscriptionTier": "New subscription tier",
+    "untitledTier": "Untitled Tier",
     "minimumAmount": "Minimum amount: ",
     "digitalDiscountPercent": "Subscriber discount percent on digital purchases",
     "merchDiscountPercent": "Subscriber discount percent on merch",

--- a/src/routers/v1/api-doc.ts
+++ b/src/routers/v1/api-doc.ts
@@ -134,7 +134,7 @@ const apiDoc = {
     },
     ArtistSubscriptionTierCreate: {
       type: "object",
-      required: ["name", "description"],
+      required: ["name"],
       properties: {
         name: {
           description: "name of the subscription",


### PR DESCRIPTION
Before this change the pricing break down was one of the major parts of the subscription tier: 

<img width="1155" height="513" alt="image" src="https://github.com/user-attachments/assets/8759442a-4f8f-47c3-be72-f0dd354c1024" />

Now it's in a pop up

<img width="658" height="309" alt="image" src="https://github.com/user-attachments/assets/779a2588-943c-41da-92f2-24f511bdf95d" />

I also broke out the subscription page management to its own page, a) so that we can link to it and b) so that we can handle the broken creation process properly. 