### PR TITLE
fix: remove currency dropdown, inherit payout currency from Stripe

### DIFF
--- a/client/src/components/ManageArtist/Manage.tsx
+++ b/client/src/components/ManageArtist/Manage.tsx
@@ -5,7 +5,6 @@ import api from "services/api";
 import { ButtonLink } from "../common/Button";
 import { bp } from "../../constants";
 import { useTranslation } from "react-i18next";
-import CountrySelect from "./CountrySelectForm";
 import WidthContainer from "components/common/WidthContainer";
 import { useAuthContext } from "state/AuthContext";
 
@@ -110,7 +109,6 @@ export const Manage: React.FC = () => {
             `}
           >
             <h2>{t("managePayment")}</h2>
-            <CountrySelect />
             <StripeStatus />
           </div>
         </WidthContainer>

--- a/client/src/components/common/stripe/StripeStatusAndButton.tsx
+++ b/client/src/components/common/stripe/StripeStatusAndButton.tsx
@@ -29,6 +29,9 @@ const StripeStatus = () => {
             stripeAccountStatus?.detailsSubmitted &&
             t("waitingStripeAccountVerification")}
           {stripeAccountStatus?.chargesEnabled && t("stripeAccountVerified")}
+          {stripeAccountStatus?.defaultCurrency && (
+            <p>{t("payoutCurrency", { currency: stripeAccountStatus.defaultCurrency })}</p>
+          )}
         </Box>
       )}
       {userId && (

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -628,8 +628,7 @@
     "createNewArtist": "Create new artist",
     "waitingOnStripe": "We're waiting on Stripe to verify your account",
     "updateBankAccount": "Change bank account information",
-    "countryCurrencyCode": "Country currency code:",
-    "saveCountryCode": "Save",
+    "payoutCurrency": "Payout currency: {{currency}}",
     "success": "Details saved!",
     "label": "(Label)",
     "payoutsInfo": "See our documentation for more information on payouts and fees: <link>https://docs.mirlo.com/payouts</link>"

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -467,6 +467,7 @@ type AccountStatus = {
   chargesEnabled: boolean;
   detailsSubmitted: boolean;
   stripeAccountId: string;
+  defaultCurrency?: string;
 };
 
 interface License {

--- a/src/routers/v1/users/{userId}/stripe/checkAccountStatus.ts
+++ b/src/routers/v1/users/{userId}/stripe/checkAccountStatus.ts
@@ -42,6 +42,7 @@ export default function () {
             result: {
               chargesEnabled: account?.charges_enabled ?? false,
               stripeAccountId: accountId,
+              defaultCurrency: account?.default_currency?.toUpperCase(),
               ...(loggedInUser
                 ? { detailsSubmitted: account?.details_submitted ?? false }
                 : {}),


### PR DESCRIPTION
Closes #1910 