### PR TITLE
fix: add remark breaks to client json package

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,7 @@
     "react-papaparse": "^4.4.0",
     "react-router-dom": "^6.22.3",
     "recharts": "^2.12.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^3.0.1",
     "remirror": "^2.0.38",
     "slugify": "^1.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3650,6 +3650,7 @@ __metadata:
     react-papaparse: "npm:^4.4.0"
     react-router-dom: "npm:^6.22.3"
     recharts: "npm:^2.12.0"
+    remark-breaks: "npm:^4.0.0"
     remark-gfm: "npm:^3.0.1"
     remirror: "npm:^2.0.38"
     rollup: "npm:^4.16.4"


### PR DESCRIPTION
I'm not too sure why this happened, but this issue was making it impossible for me to run Mirlo locally