### PR TITLE
fix: Search showing unavailable releases

### DIFF
--- a/src/routers/v1/tracks/index.ts
+++ b/src/routers/v1/tracks/index.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@mirlo/prisma/client";
 import { userHasPermission } from "../../../auth/passport";
 import { addSizesToImage } from "../../../utils/artist";
 import { finalCoversBucket } from "../../../utils/minio";
+import { whereForPublishedTrackGroups } from "../../../utils/trackGroup";
 
 export default function () {
   const operations = {
@@ -19,14 +20,7 @@ export default function () {
         audio: {
           uploadState: "SUCCESS",
         },
-
-        trackGroup: {
-          deletedAt: null,
-          publishedAt: { lte: new Date() },
-          artist: {
-            deletedAt: null,
-          },
-        },
+        trackGroup: whereForPublishedTrackGroups(),
       };
 
       if (title && typeof title === "string") {

--- a/src/utils/trackGroup.ts
+++ b/src/utils/trackGroup.ts
@@ -42,7 +42,8 @@ export const whereForPublishedTrackGroups = (): Prisma.TrackGroupWhereInput => {
     adminEnabled: true,
     artist: {
       enabled: true,
-      user: { canCreateArtists: true },
+      deletedAt: null,
+      user: { canCreateArtists: true, deletedAt: null },
     },
     hideFromSearch: false,
     deletedAt: null,

--- a/test/routers/trackGroups/index.spec.ts
+++ b/test/routers/trackGroups/index.spec.ts
@@ -74,6 +74,49 @@ describe("trackGroups", () => {
       assert(response.statusCode === 200);
     });
 
+    it("should GET / excludes trackGroups from soft-deleted artists", async () => {
+      const { user } = await createUser({ email: "test@testcom" });
+      const artist = await createArtist(user.id);
+      await createTrackGroup(artist.id, { title: "Super Hyper Galaxy" });
+      await prisma.artist.delete({ where: { id: artist.id } });
+
+      const response = await requestApp
+        .get("trackGroups?title=super")
+        .set("Accept", "application/json");
+
+      assert.equal(response.body.results.length, 0);
+      assert(response.statusCode === 200);
+    });
+
+    it("should GET / excludes trackGroups from disabled artists", async () => {
+      const { user } = await createUser({ email: "test@testcom" });
+      const artist = await createArtist(user.id, { enabled: false });
+      await createTrackGroup(artist.id, { title: "Super Hyper Galaxy" });
+
+      const response = await requestApp
+        .get("trackGroups?title=super")
+        .set("Accept", "application/json");
+
+      assert.equal(response.body.results.length, 0);
+      assert(response.statusCode === 200);
+    });
+
+    it("should GET / excludes trackGroups whose artist user cannot create artists", async () => {
+      const { user } = await createUser({
+        email: "test@testcom",
+        canCreateArtists: false,
+      });
+      const artist = await createArtist(user.id);
+      await createTrackGroup(artist.id, { title: "Super Hyper Galaxy" });
+
+      const response = await requestApp
+        .get("trackGroups?title=super")
+        .set("Accept", "application/json");
+
+      assert.equal(response.body.results.length, 0);
+      assert(response.statusCode === 200);
+    });
+
     it("should GET / ordered by release date", async () => {
       const { user } = await createUser({ email: "test@testcom" });
       const artist = await createArtist(user.id);


### PR DESCRIPTION
The Prisma soft-delete extension only auto-filtered `deletedAt` on the top-level, nested where clauses (like `artist: { enabled: true })` are not touched. So `whereForPublishedTrackGroups()` was silently letting trackGroups through whose artist had been soft-deleted. Also, the `/tracks` search endpoint had a looser, duplicated filter (missing adminEnabled, hideFromSearch, cover, artist.enabled, etc.)

Closes #1506