### PR TITLE
fix: fixes minor a11y and UI

### DIFF
--- a/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/PaymentSlider.tsx
+++ b/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/PaymentSlider.tsx
@@ -104,7 +104,8 @@ const PaymentSlider: React.FC<{
                 width: 25px;
                 height: 25px;
                 border-radius: 50%;
-                background: ${artist?.properties?.colors?.primary};
+                background: ${artist?.properties?.colors?.primary ??
+                "var(--mi-primary-color)"};
                 cursor: pointer;
               }
 
@@ -112,7 +113,8 @@ const PaymentSlider: React.FC<{
                 width: 25px;
                 height: 25px;
                 border-radius: 50%;
-                background: ${artist?.properties?.colors?.primary};
+                background: ${artist?.properties?.colors?.primary ??
+                "var(--mi-primary-color)"};
                 cursor: pointer;
               }
             `}

--- a/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/SavingInput.tsx
+++ b/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/SavingInput.tsx
@@ -81,14 +81,14 @@ const SavingInput: React.FC<{
         formKey === "publishedAt" ||
         formKey === "fundraisingEndDate"
       ) {
-        value = new Date(value).toISOString();
+        value = value ? new Date(value).toISOString() : null;
       } else if (
         formKey === "minPrice" ||
         formKey === "suggestedPrice" ||
         !!currency ||
         multiplyBy100
       ) {
-        value = value ? value * 100 : undefined;
+        value = value ? value * 100 : null;
       }
 
       if (valueTransform) {

--- a/client/src/components/ManageArtist/UploadFiles.tsx
+++ b/client/src/components/ManageArtist/UploadFiles.tsx
@@ -17,7 +17,7 @@ const UploadFiles = React.forwardRef<
   const inputId = `input-${nameForId}`;
 
   return (
-    <div className="relative">
+    <div className="relative w-full">
       {/* The `label` element displays the drop/click area and the `input` element and its default UI are visually hidden. `input` is before `label` so that a focus ring can be applied to `label` while the `input` has focus. */}
       <input
         accept={accept}

--- a/client/src/components/common/Toggle.tsx
+++ b/client/src/components/common/Toggle.tsx
@@ -30,24 +30,29 @@ export const Toggle: React.FC<{
     >
       <input
         type="checkbox"
-        defaultChecked={isToggled}
+        role="switch"
         checked={isToggled}
-        onClick={callback}
+        onChange={callback}
+        aria-checked={isToggled}
         aria-labelledby={labelId}
         id={id}
-        className={css`
-          opacity: 0;
-          width: 0;
-          height: 0;
+        className={
+          "sr-only " +
+          css`
+            &:focus-visible ~ .toggle {
+              outline: 2px solid var(--mi-primary-color);
+              outline-offset: 2px;
+            }
 
-          &:checked + .toggle {
-            background-color: #00c853;
-          }
+            &:checked ~ .toggle {
+              background-color: var(--mi-green-500);
+            }
 
-          &:checked + .toggle:before {
-            transform: translateX(14px);
-          }
-        `}
+            &:checked ~ .toggle:before {
+              transform: translateX(14px);
+            }
+          `
+        }
       />
       <span
         className={
@@ -60,7 +65,7 @@ export const Toggle: React.FC<{
 
             transition: 0.3s;
             cursor: pointer;
-            background: #2c3e50;
+            background: var(--mi-neutral-500);
             border-radius: 30px;
 
             &:before {
@@ -69,7 +74,7 @@ export const Toggle: React.FC<{
               height: 12px;
               width: 12px;
               left: 2px;
-              background-color: #fff;
+              background-color: var(--mi-normal-background-color);
               border-radius: 50%;
               transition: 0.3s;
             }

--- a/client/src/styles/theme.css
+++ b/client/src/styles/theme.css
@@ -39,9 +39,12 @@ html {
   --mi-neutral-500: #8b8083;
   --mi-red-100: #ffe5ea;
   --mi-red-700: #6e162d;
+  --mi-red-800: #43141e;
   --mi-blue-100: #e1f4fc;
   --mi-blue-700: #34515c;
   --mi-green-100: #dff2dc;
+  --mi-green-500: #44633f;
+  --mi-green-700: #21381d;
 
   --mi-warning-color: #f2897a;
   --mi-warning-background-color: var(--mi-warning-color);


### PR DESCRIPTION
## Summary


First of a series of PR meant to rethinking the publishing / pre-order flow for an album release.

This one is just a batch of 5 small, unrelated fixes bundled for easier review. None of them depend on each other or on the pre-order feature — they just came up while building out that flow and are safe to merge on their own.

## What's in this PR

- **add: missing color variables to theme** — `--mi-green-500`, `--mi-green-700`, `--mi-red-800` added so Toggle and PublishButton can reference them instead of hardcoded hex.
- **fix: Toggle now follows the WAI-ARIA switch pattern** — controlled `checked`/`onChange` instead of `defaultChecked`/`onClick`, `role=switch` + `aria-checked`, `sr-only` instead of opacity-hidden input (so screen readers can see it), focus-visible outline, CSS variables for colors.
- **fix: SavingInput sends `null` instead of `undefined`** — empty price/date fields were being sent as `undefined`, which `JSON.stringify` silently drops. Clearing a date that was already set never reached the backend and the old value stuck. `null` fixes it.
- **fix: PaymentSlider thumb visible on default Mirlo theme** — the slider handle was invisible for artists who hadn't manually set theme colors (fell back to `undefined`). Now falls back to `var(--mi-primary-color)`.
- **fix: UploadFiles zone full width** — adds `w-full` so the drop zone fills its parent.

## Testing

- [ ] Toggle: tab to it, space toggles, focus outline visible, screen reader announces "switch, on/off"
- [ ] SavingInput: set then clear a release date (or min price), save, reload — the field should actually be empty server-side
- [ ] PaymentSlider: open the album form as an artist using the default Mirlo theme — slider thumb should be visible
- [ ] UploadFiles: drop zone fills the width of its container

## Not in there

The rest of the pre-order work is in separate PRs (pre-order feature, dropdown refactor, per-track download).
