### PR TITLE
refactor: wrap bulksettracksispreview into a usemutation hook with au…

### DIFF
--- a/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/ManageTrackDefaults.tsx
+++ b/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/ManageTrackDefaults.tsx
@@ -1,12 +1,12 @@
-import styled from "@emotion/styled";
+import { openOutsideLinkAfter } from "components/Merch/IncludesDigitalDownload";
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { FormProvider, useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
+import styled from "@emotion/styled";
 
 import { ArtistButton } from "components/Artist/ArtistButtons";
-import { openOutsideLinkAfter } from "components/Merch/IncludesDigitalDownload";
-import api from "services/api";
+import { useBulkSetTracksIsPreviewMutation } from "queries/trackGroups";
 import { useSnackbar } from "state/SnackbarContext";
 import SavingInput from "./SavingInput";
 
@@ -30,18 +30,22 @@ const ManageTrackDefaults: React.FC<BulkUpdateTracksProps> = ({
   const { t } = useTranslation("translation", { keyPrefix: "manageAlbum" });
   const methods = useForm<TrackGroup>({ defaultValues: trackGroup });
   const snackbar = useSnackbar();
+  const { mutate: bulkSetTracksIsPreview } =
+    useBulkSetTracksIsPreviewMutation();
 
-  const handleSetAllTracksPreview = async (isPreview: boolean) => {
-    try {
-      await api.put<{ isPreview: boolean }, { result: TrackGroup }>(
-        `manage/trackGroups/${trackGroup.id}/tracks`,
-        { isPreview }
-      );
-      snackbar(t("updatedAllTracks"), { type: "success" });
-      reload();
-    } catch (e) {
-      console.error("Error updating tracks:", e);
-    }
+  const handleSetAllTracksPreview = (isPreview: boolean) => {
+    bulkSetTracksIsPreview(
+      { trackGroupId: trackGroup.id, isPreview },
+      {
+        onSuccess: () => {
+          snackbar(t("updatedAllTracks"), { type: "success" });
+          reload();
+        },
+        onError: (e) => {
+          console.error("Error updating tracks:", e);
+        },
+      }
+    );
   };
 
   return (

--- a/client/src/queries/trackGroups.ts
+++ b/client/src/queries/trackGroups.ts
@@ -161,6 +161,27 @@ export function useUpdateTrackGroupMutation() {
   });
 }
 
+async function bulkSetTracksIsPreview(opts: {
+  trackGroupId: number;
+  isPreview: boolean;
+}) {
+  return api.put(`v1/manage/trackGroups/${opts.trackGroupId}/tracks`, {
+    isPreview: opts.isPreview,
+  });
+}
+
+export function useBulkSetTracksIsPreviewMutation() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: bulkSetTracksIsPreview,
+    async onSuccess() {
+      await client.invalidateQueries({
+        predicate: (query) => queryKeyIncludes(query, QUERY_KEY_TRACK_GROUPS),
+      });
+    },
+  });
+}
+
 async function updatePledge(opts: { fundraiserId: number; amount: number }) {
   await api.put(`v1/fundraisers/${opts.fundraiserId}/changePledge`, {
     amount: opts.amount,


### PR DESCRIPTION
## Summary

@peterklingelhofer PR #1926 merged the bulk-set-tracks-preview endpoint with an inline `api.put` call from ManageTrackDefaults. Here I've been wrapping it in a TanStack Query `useMutation` hook because the upcoming pre-order feature will call the same endpoint from PreOrderSection, and this is the pattern we use everywhere else for things like this. The hook invalidates the trackgroup queries on success so the caller doesn't need to manually trigger a reload anymore.

## What's in this PR

- Adds `useBulkSetTracksIsPreviewMutation()` in `client/src/queries/trackGroups.ts`
- ManageTrackDefaults now calls `mutate({ ... })` instead of constructing the URL and payload inline

## Testing

- [ ] In the album form, click the "set all tracks as preview / must-own" bulk buttons — track preview states should update and the UI should refresh on its own

## Not in there

No backend changes — the endpoint itself is already on main from #1926.