### PR TITLE
fix: dropdown refactor and per track download

### DIFF
--- a/client/src/components/TrackGroup/TrackGroupAdminMenu.tsx
+++ b/client/src/components/TrackGroup/TrackGroupAdminMenu.tsx
@@ -15,7 +15,7 @@ const TrackGroupAdminMenu: React.FC<{
   }
   return (
     <li>
-      <DownloadAlbumButton trackGroup={trackGroup} />
+      <DownloadAlbumButton trackGroup={trackGroup} dropdownItem />
     </li>
   );
 };

--- a/client/src/components/common/DownloadAlbumButton.tsx
+++ b/client/src/components/common/DownloadAlbumButton.tsx
@@ -11,6 +11,7 @@ import {
   ArtistButton,
   ArtistButtonAnchor,
 } from "components/Artist/ArtistButtons";
+import { DropdownMenuItemButton } from "./DropdownMenuItem";
 import useErrorHandler from "services/useErrorHandler";
 
 const formats = ["flac", "wav", "128.opus", "320.mp3", "256.mp3", "128.mp3"];
@@ -31,7 +32,8 @@ const DownloadAlbumButton: React.FC<{
   email?: string;
   track?: Track;
   fixed?: boolean;
-}> = ({ trackGroup, onlyIcon, email, token, track, fixed }) => {
+  dropdownItem?: boolean;
+}> = ({ trackGroup, onlyIcon, email, token, track, fixed, dropdownItem }) => {
   const { t } = useTranslation("translation", { keyPrefix: "trackGroupCard" });
   const [chosenFormat, setChosenFormat] = React.useState("");
   const [isGeneratingAlbum, setIsGeneratingAlbum] = React.useState(0);
@@ -98,7 +100,7 @@ const DownloadAlbumButton: React.FC<{
   }
 
   return (
-    <div>
+    <>
       <Modal
         title={`${t("download")} ${formatsDisplay[chosenFormat]}`}
         open={isPopupOpen}
@@ -186,24 +188,38 @@ const DownloadAlbumButton: React.FC<{
           )}
         </div>
       </Modal>
-      <ArtistButton
-        onlyIcon={onlyIcon}
-        data-testid="download-button"
-        className={css`
-          margin-top: 0;
-          font-size: 1.2rem;
-          background: transparent;
-          color: var(--mi-primary-color);
-        `}
-        startIcon={<RiDownloadLine />}
-        onClick={() => {
-          setChosenFormat("");
-          setIsPopupOpen(true);
-        }}
-      >
-        {onlyIcon ? "" : t("download")}
-      </ArtistButton>
-    </div>
+      {dropdownItem ? (
+        <DropdownMenuItemButton
+          data-testid="download-button"
+          startIcon={<RiDownloadLine />}
+          onClick={(e) => {
+            e.stopPropagation();
+            setChosenFormat("");
+            setIsPopupOpen(true);
+          }}
+        >
+          {t("download")}
+        </DropdownMenuItemButton>
+      ) : (
+        <ArtistButton
+          onlyIcon={onlyIcon}
+          data-testid="download-button"
+          className={css`
+            margin-top: 0;
+            font-size: 1.2rem;
+            background: transparent;
+            color: var(--mi-primary-color);
+          `}
+          startIcon={<RiDownloadLine />}
+          onClick={() => {
+            setChosenFormat("");
+            setIsPopupOpen(true);
+          }}
+        >
+          {onlyIcon ? "" : t("download")}
+        </ArtistButton>
+      )}
+    </>
   );
 };
 

--- a/client/src/components/common/DropdownMenuItem.tsx
+++ b/client/src/components/common/DropdownMenuItem.tsx
@@ -1,0 +1,49 @@
+import { css } from "@emotion/css";
+import React from "react";
+import Button, { ButtonLink } from "./Button";
+
+const dropdownItemStyle = css`
+  .startIcon {
+    padding-left: 1rem;
+  }
+`;
+
+type BaseProps = {
+  startIcon?: React.ReactElement;
+  children?: React.ReactNode;
+  className?: string;
+};
+
+type ButtonProps = BaseProps &
+  Omit<React.ComponentProps<typeof Button>, "size" | "variant">;
+
+export const DropdownMenuItemButton: React.FC<ButtonProps> = ({
+  className,
+  ...rest
+}) => (
+  <Button
+    size="compact"
+    variant="transparent"
+    className={
+      className ? `${dropdownItemStyle} ${className}` : dropdownItemStyle
+    }
+    {...rest}
+  />
+);
+
+type LinkProps = BaseProps &
+  Omit<React.ComponentProps<typeof ButtonLink>, "size" | "variant">;
+
+export const DropdownMenuItemLink: React.FC<LinkProps> = ({
+  className,
+  ...rest
+}) => (
+  <ButtonLink
+    size="compact"
+    variant="transparent"
+    className={
+      className ? `${dropdownItemStyle} ${className}` : dropdownItemStyle
+    }
+    {...rest}
+  />
+);

--- a/client/src/components/common/TrackTable/EmbedLink.tsx
+++ b/client/src/components/common/TrackTable/EmbedLink.tsx
@@ -1,9 +1,8 @@
-import { css } from "@emotion/css";
-import Button from "../Button";
 import { widgetUrl } from "utils/tracks";
 import { useSnackbar } from "state/SnackbarContext";
 import { useTranslation } from "react-i18next";
 import { ImEmbed } from "react-icons/im";
+import { DropdownMenuItemButton } from "../DropdownMenuItem";
 
 const EmbedLink: React.FC<{ track: Track; trackGroupArtistId?: number }> = ({
   track,
@@ -13,27 +12,16 @@ const EmbedLink: React.FC<{ track: Track; trackGroupArtistId?: number }> = ({
     keyPrefix: "trackGroupDetails",
   });
   return (
-    <Button
-      size="compact"
-      variant="transparent"
+    <DropdownMenuItemButton
       onClick={(e) => {
         e.stopPropagation();
         navigator.clipboard.writeText(widgetUrl(track.id, "track"));
         snackbar(t("copiedTrackUrl"), { type: "success" });
       }}
       startIcon={<ImEmbed />}
-      className={css`
-        .startIcon {
-          padding-left: 1rem;
-        }
-        :hover {
-          background: transparent !important;
-          opacity: 0.6;
-        }
-      `}
     >
       {t("embedCode")}
-    </Button>
+    </DropdownMenuItemButton>
   );
 };
 

--- a/client/src/components/common/TrackTable/LyricsModal.tsx
+++ b/client/src/components/common/TrackTable/LyricsModal.tsx
@@ -1,10 +1,9 @@
 import { css } from "@emotion/css";
-import Button from "../Button";
 import { useTranslation } from "react-i18next";
-import { ImEmbed } from "react-icons/im";
 import Modal from "../Modal";
 import React from "react";
 import { MdLyrics } from "react-icons/md";
+import { DropdownMenuItemButton } from "../DropdownMenuItem";
 
 const LyricsModal: React.FC<{ track: Track; trackGroupArtistId?: number }> = ({
   track,
@@ -16,26 +15,15 @@ const LyricsModal: React.FC<{ track: Track; trackGroupArtistId?: number }> = ({
 
   return (
     <>
-      <Button
-        size="compact"
-        variant="transparent"
+      <DropdownMenuItemButton
         onClick={(e) => {
           e.stopPropagation();
           setIsOpen(true);
         }}
         startIcon={<MdLyrics />}
-        className={css`
-          .startIcon {
-            padding-left: 1rem;
-          }
-          :hover {
-            background: transparent !important;
-            opacity: 0.6;
-          }
-        `}
       >
         {t("viewLyrics")}
-      </Button>
+      </DropdownMenuItemButton>
       <Modal onClose={() => setIsOpen(false)} open={isOpen} title={t("lyrics")}>
         <div
           className={css`

--- a/client/src/components/common/TrackTable/TrackLink.tsx
+++ b/client/src/components/common/TrackTable/TrackLink.tsx
@@ -1,10 +1,8 @@
-import { css } from "@emotion/css";
-import { ButtonLink } from "../Button";
-
 import { FaLink } from "react-icons/fa";
 import { getReleaseUrl } from "utils/artist";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
+import { DropdownMenuItemLink } from "../DropdownMenuItem";
 
 const TrackLink: React.FC<{
   track: Track;
@@ -16,28 +14,16 @@ const TrackLink: React.FC<{
     keyPrefix: "trackGroupDetails",
   });
 
-  // If we're looking at the current track, don't show the link
   if (Number(trackId) === track.id) {
     return null;
   }
   return (
-    <ButtonLink
-      size="compact"
-      variant="transparent"
+    <DropdownMenuItemLink
       to={`${getReleaseUrl(artist, trackGroup)}/tracks/${track.id}`}
       startIcon={<FaLink />}
-      className={css`
-        .startIcon {
-          padding-left: 1rem;
-        }
-        :hover {
-          background: transparent !important;
-          opacity: 0.6;
-        }
-      `}
     >
       {t("viewTrack")}
-    </ButtonLink>
+    </DropdownMenuItemLink>
   );
 };
 

--- a/client/src/components/common/TrackTable/TrackRow.tsx
+++ b/client/src/components/common/TrackTable/TrackRow.tsx
@@ -17,6 +17,7 @@ import FavoriteTrack from "components/TrackGroup/Favorite";
 import { useGetArtistColors } from "components/Artist/ArtistButtons";
 import { useTranslation } from "react-i18next";
 import { FaExternalLinkAlt } from "react-icons/fa";
+import DownloadAlbumButton from "components/common/DownloadAlbumButton";
 
 const LicenseSpan = styled.a`
   text-wrap: nowrap;
@@ -172,6 +173,16 @@ const TrackRow: React.FC<{
 
   const canPlayTrack = isTrackOwnedOrPreview(track, user, trackGroup);
 
+  const ownsTrack = !!user?.userTrackPurchases?.find(
+    (p) => p.trackId === track.id
+  );
+  const ownsTrackGroup = !!user?.userTrackGroupPurchases?.find(
+    (p) => p.trackGroupId === trackGroup.id
+  );
+  const isOwned = ownsTrack || ownsTrackGroup;
+  const canDownloadTrack =
+    isOwned && (!trackGroup.isPreorder || track.isPreview);
+
   const onTrackPlay = React.useCallback(() => {
     if (canPlayTrack) {
       addTracksToQueue?.(track.id);
@@ -284,6 +295,15 @@ const TrackRow: React.FC<{
               {track.lyrics && (
                 <li>
                   <LyricsModal track={track} />
+                </li>
+              )}
+              {canDownloadTrack && (
+                <li>
+                  <DownloadAlbumButton
+                    track={track}
+                    trackGroup={trackGroup}
+                    dropdownItem
+                  />
                 </li>
               )}
               <li>


### PR DESCRIPTION
Note : The pre-order feature itself is in PR #1950 This PR only touches the dropdown abstraction and the track-level download.

## Summary

I put those two commits together because the feature uses the refactor. While working on the pre-order feature I wanted to add a "download" button in the per-track dropdown menu, but noticed the dropdown-item styling (`size=compact`, `variant=transparent`, `.startIcon padding-left: 1rem`) was duplicated on EmbedLink, TrackLink, and LyricsModal. Extracted it into a shared DropdownMenuItem component first, then added the new download button on top of it.

## What's in this PR

1. **Extract DropdownMenuItem** — turns the duplicated pattern into a shared `DropdownMenuItemButton` / `DropdownMenuItemLink`, used by EmbedLink, TrackLink, and LyricsModal. Also removed the `:hover { background: transparent; opacity: 0.6 }` override each of those files had — I couldn't find any reason for it, and it was fighting DropdownMenu's black hover and creating an inconsistency with FavoriteTrack (which was the only one without the override?). All dropdown items now share the same hover look.

2. **Per-track download** — before, the only way to download was the whole-album button. Adds a download entry in the per-track dropdown in TrackRow, visible when `isOwned && (!trackGroup.isPreorder || track.isPreview)` — so you can download a single track you own, or a free-listen track during a pre-order. DownloadAlbumButton got a new `dropdownItem` prop that renders it as a DropdownMenuItemButton. Also removed the wrapping `<div>` around the button — it was breaking DropdownMenu's `li > button:hover` rule because it expected the button to be a direct child of the `li`, and the wrapper was unnecessary anyway (Modal uses createPortal). TrackGroupAdminMenu also switched to `dropdownItem` for visual consistency.

## Testing

- [ ] Open the track dropdown in TrackRow on an album you own → "Download" entry appears with the same styling and hover as the other entries
- [ ] Same on a pre-ordered album → "Download" only appears for preview tracks
- [ ] Same on an album you don't own → no "Download" entry
- [ ] All dropdown items (Favorite, Embed, Link, Lyrics, Download) share the same black hover
- [ ] Album-level download button on the artist admin menu still works and matches the dropdown look

## What's Next

There are other things we could do to improve the pre-order flow, but I think they're less critical / priority. Schedule publication could come back under a more "opt-in" version (thinking of a "schedule" button next to the big green publish button). We could also (and I think we should) disable autosave once an album is Published, to avoid updates to go live as people write them, and let them update the page once they're ready with everything.