### PR TITLE
fix: mismatch between label stripe account and user stripe account when purchasing

### DIFF
--- a/client/src/components/Merch/BuyMerchItem.tsx
+++ b/client/src/components/Merch/BuyMerchItem.tsx
@@ -42,8 +42,9 @@ const BuyMerchItem: React.FC<{
   const snackbar = useSnackbar();
   const [isLoadingStripe, setIsLoadingStripe] = React.useState(false);
 
+  const paymentUserId = artist.paymentToUserId ?? artist.userId;
   const { data: stripeAccountStatus } = useQuery(
-    queryUserStripeStatus(artist.userId)
+    queryUserStripeStatus(paymentUserId)
   );
 
   const minPrice = (merch?.minPrice ?? 0) / 100;

--- a/client/src/components/TrackGroup/BuyTrackGroup.tsx
+++ b/client/src/components/TrackGroup/BuyTrackGroup.tsx
@@ -49,8 +49,13 @@ const BuyTrackGroup: React.FC<{
     },
     reValidateMode: "onChange",
   });
+  const paymentUserId =
+    trackGroup.paymentToUser?.id ??
+    trackGroup.artist?.paymentToUserId ??
+    trackGroup.artist?.userId ??
+    0;
   const { data: stripeAccountStatus, isPending } = useQuery(
-    queryUserStripeStatus(trackGroup.artist?.userId ?? 0)
+    queryUserStripeStatus(paymentUserId)
   );
 
   const { watch, handleSubmit, formState } = methods;

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -254,6 +254,7 @@ interface Artist {
   allowDirectMessages?: boolean;
   urlSlug?: string;
   userId: number;
+  paymentToUserId?: number;
   id: number;
   location?: string;
   enabled: boolean;


### PR DESCRIPTION
When an album is released with a label as payment recipient (either with the per-album override or on the whole artist account), the purchase UI was basing the blocking rule on the artist's own Stripe account status instead of the actual payment recipient. So a buyer would see "artist has not set up their payment processor yet" and couldn't purchase, even though the backend would have correctly handled the money through the label's Stripe account.

It also fixes a related issue where the Stripe payment form was pointing to the artist's Stripe account while the actual payment session was set up on the label's account

The fix now replicates the backend's real behavior on the frontend in both BuyTrackGroup.tsx and BuyMerchItem.tsx.