### PR TITLE
Newsletter signup redesign

### DIFF
--- a/client/cypress/e2e/home.cy.ts
+++ b/client/cypress/e2e/home.cy.ts
@@ -154,6 +154,93 @@ describe("home page", () => {
     ]);
   });
 
+  describe("newsletter signup", () => {
+    const scrollToNewsletter = () => {
+      cy.contains("Get on the mailing list").scrollIntoView();
+    };
+
+    it("sign up button is disabled until an email is entered", () => {
+      scrollToNewsletter();
+      cy.contains("button", "Sign up").should("be.disabled");
+      cy.get("#input-newsletter-email").type(newsletterEmail);
+      cy.contains("button", "Sign up").should("not.be.disabled");
+    });
+
+    it("completes the full signup flow", () => {
+      scrollToNewsletter();
+      cy.get("#input-newsletter-email").type(newsletterEmail);
+      cy.contains("button", "Sign up").click();
+      cy.wait("@verifyEmail");
+
+      cy.get("[data-cy='modal']").should("be.visible");
+      cy.contains("Check your inbox").should("be.visible");
+      cy.contains(`We sent a verification code to ${newsletterEmail}`).should(
+        "be.visible"
+      );
+
+      cy.get("#input-newsletter-code").type(verificationCode);
+      cy.contains("button", "Verify & subscribe").click();
+      cy.wait("@verifyEmail");
+      cy.wait("@followArtist");
+
+      cy.contains("Thanks! You're now on the list.").should("be.visible");
+      cy.get("[data-cy='modal']").should("not.exist");
+    });
+
+    it("resends the verification code", () => {
+      scrollToNewsletter();
+      cy.get("#input-newsletter-email").type(newsletterEmail);
+      cy.contains("button", "Sign up").click();
+      cy.wait("@verifyEmail");
+
+      cy.contains("button", "Resend code").click();
+      cy.wait("@verifyEmail");
+      cy.contains("Code resent!").should("be.visible");
+    });
+
+    it("shows an error when verification fails", () => {
+      cy.intercept("POST", "/auth/verify-email", (req) => {
+        if ("code" in req.body) {
+          req.reply({
+            statusCode: 400,
+            body: { error: "Invalid verification code" },
+          });
+          return;
+        }
+        req.reply({ statusCode: 200, body: {} });
+      }).as("verifyEmailFail");
+
+      scrollToNewsletter();
+      cy.get("#input-newsletter-email").type(newsletterEmail);
+      cy.contains("button", "Sign up").click();
+      cy.wait("@verifyEmailFail");
+
+      cy.get("#input-newsletter-code").type("000000");
+      cy.contains("button", "Verify & subscribe").click();
+      cy.wait("@verifyEmailFail");
+
+      cy.contains(
+        "That code doesn't look right. Make sure you entered the correct number, or click resend code."
+      ).should("be.visible");
+      cy.get("[data-cy='modal']").should("be.visible");
+    });
+
+    it("resets code and step when modal is closed and reopened", () => {
+      scrollToNewsletter();
+      cy.get("#input-newsletter-email").type(newsletterEmail);
+      cy.contains("button", "Sign up").click();
+      cy.wait("@verifyEmail");
+
+      cy.get("#input-newsletter-code").type("9999");
+      cy.get("[aria-label='close']").click();
+      cy.get("[data-cy='modal']").should("not.exist");
+
+      cy.contains("button", "Sign up").click();
+      cy.wait("@verifyEmail");
+      cy.get("#input-newsletter-code").should("have.value", "");
+    });
+  });
+
   it("renders curated sections with links to releases, posts, and tags", () => {
     cy.contains("Recent releases").scrollIntoView().should("be.visible");
     cy.contains("a", featuredRelease.title)

--- a/client/src/components/Home/NewsletterSignup.tsx
+++ b/client/src/components/Home/NewsletterSignup.tsx
@@ -1,26 +1,31 @@
 import { css } from "@emotion/css";
-import { SplashTitle } from "./Splash";
-import { useTranslation } from "react-i18next";
-import { useSnackbar } from "state/SnackbarContext";
-import React from "react";
-import Button from "components/common/Button";
-import { bp } from "../../constants";
-import api from "services/api";
-import { useQuery } from "@tanstack/react-query";
-import { queryInstanceArtist } from "queries/settings";
-import EmailVerification from "components/common/EmailVerification";
 import { Turnstile } from "@marsidev/react-turnstile";
+import { useQuery } from "@tanstack/react-query";
+import Button from "components/common/Button";
+import FormComponent from "components/common/FormComponent";
+import { InputEl } from "components/common/Input";
+import Modal from "components/common/Modal";
+import { queryInstanceArtist } from "queries/settings";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import api from "services/api";
+import { APIResponseError } from "services/APIInstance";
+import { useSnackbar } from "state/SnackbarContext";
 
-type TurnstileGlobal = {
-  reset: (container?: string | HTMLElement) => void;
-};
+import { bp } from "../../constants";
+
+import { SplashTitle } from "./Splash";
 
 const containerStyles = css`
   width: 100%;
-  background-color: var(--mi-lighten-background-color);
+  background-color: color-mix(
+    in srgb,
+    var(--mi-normal-foreground-color) 6%,
+    var(--mi-normal-background-color)
+  );
   display: flex;
   justify-content: center;
-  padding: 4rem 1rem;
+  padding: 7rem 1rem;
 
   @media screen and (max-width: ${bp.medium}px) {
     padding: 3rem 1.5rem;
@@ -37,234 +42,225 @@ const innerStyles = css`
   @media screen and (max-width: ${bp.medium}px) {
     flex-direction: column;
     align-items: stretch;
-    text-align: left;
   }
-`;
-
-const copyStyles = css`
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  max-width: 420px;
-
-  p {
-    color: var(--mi-light-foreground-color);
-    line-height: 1.5;
-  }
-`;
-
-const formStyles = css`
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  flex: 1;
-  max-width: 500px;
-
-  form {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    align-items: flex-start;
-
-    @media screen and (max-width: ${bp.medium}px) {
-      align-items: stretch;
-    }
-  }
-`;
-
-const helperTextStyles = css`
-  color: var(--mi-normal-foreground-color);
-  font-size: 0.85rem;
-`;
-
-const verificationStyles = css`
-  width: 100%;
-
-  @media screen and (max-width: ${bp.medium}px) {
-    margin-top: 0.75rem;
-  }
-`;
-
-const turnstileStyles = css`
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  width: 100%;
-`;
-
-const turnstileRowStyles = css`
-  display: flex;
-  gap: 1rem;
-  width: 100%;
-  align-items: center;
-  flex-wrap: wrap;
-`;
-
-const verifiedEmailStyles = css`
-  justify-content: space-between;
-  width: 100%;
-  display: flex;
-  gap: 0.5rem;
-  color: var(--mi-normal-foreground-color);
 `;
 
 const NewsletterSignup: React.FC = () => {
   const { t } = useTranslation("translation", { keyPrefix: "home" });
   const snackbar = useSnackbar();
-  const [verifiedEmail, setVerifiedEmail] = React.useState<string | null>(null);
-  const [verifiedEmailDisplay, setVerifiedEmailDisplay] = React.useState<
-    string | null
-  >(null);
+  const [email, setEmail] = React.useState("");
+  const [modalOpen, setModalOpen] = React.useState(false);
+  const [step, setStep] = React.useState<1 | 2>(1);
+  const [code, setCode] = React.useState("");
   const [isSubmitting, setIsSubmitting] = React.useState(false);
-  const [turnstileToken, setTurnstileToken] = React.useState<string | null>(
-    null
-  );
-  const [verificationKey, setVerificationKey] = React.useState(0);
-  const { data: instanceArtist, isPending } = useQuery(queryInstanceArtist());
+  const [isVerifying, setIsVerifying] = React.useState(false);
+  const [isResending, setIsResending] = React.useState(false);
+  const [verifyError, setVerifyError] = React.useState<string | null>(null);
+  const codeInputRef = React.useRef<HTMLInputElement>(null);
   const turnstileSiteKey = import.meta.env.VITE_CLOUDFLARE_CLIENT_KEY;
+  const { data: instanceArtist, isPending } = useQuery(queryInstanceArtist());
 
-  const handleVerifiedEmail = React.useCallback((value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return;
-    }
-    setVerifiedEmail(trimmed.toLowerCase());
-    setVerifiedEmailDisplay(trimmed);
-  }, []);
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!email.trim() || !instanceArtist?.id || isSubmitting) return;
 
-  const handleResetVerification = React.useCallback(() => {
-    setVerifiedEmail(null);
-    setVerifiedEmailDisplay(null);
-    setVerificationKey((current) => current + 1);
-  }, []);
-
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    if (!verifiedEmail || isSubmitting) {
-      return;
-    }
-
-    if (!instanceArtist?.id) {
-      snackbar(t("newsletterError"), { type: "warning" });
-      return;
-    }
-
-    if (!verifiedEmail) {
-      snackbar(t("newsletterVerificationRequired"), { type: "warning" });
-      return;
-    }
-
-    if (turnstileSiteKey && !turnstileToken) {
-      snackbar(t("newsletterCaptchaRequired"), { type: "warning" });
+    if (turnstileSiteKey) {
+      setStep(1);
+      setModalOpen(true);
       return;
     }
 
     try {
       setIsSubmitting(true);
-      const cfTurnstile = turnstileSiteKey
-        ? (turnstileToken ?? undefined)
-        : undefined;
-
-      await api.post(`artists/${instanceArtist.id}/follow`, {
-        email: verifiedEmail,
-        ...(cfTurnstile ? { cfTurnstile } : {}),
-      });
-      if (turnstileSiteKey && typeof window !== "undefined") {
-        try {
-          (
-            window as typeof window & {
-              turnstile?: TurnstileGlobal;
-            }
-          ).turnstile?.reset();
-        } catch (error) {
-          console.error(error);
-        }
-      }
-      setTurnstileToken(null);
-      snackbar(t("newsletterSuccess"), { type: "success" });
-    } catch (error) {
-      const message =
-        error instanceof Error && error.message
-          ? error.message
-          : t("newsletterError");
-      snackbar(message, { type: "warning" });
+      await api.post("verify-email", { email });
+      setStep(2);
+      setModalOpen(true);
+    } catch {
+      snackbar(t("newsletterError"), { type: "warning" });
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  const hasVerifiedEmail = Boolean(verifiedEmail);
+  const handleTurnstileSuccess = async (token: string) => {
+    try {
+      await api.post("verify-email", { email, cfTurnstile: token });
+      setStep(2);
+    } catch {
+      snackbar(t("newsletterError"), { type: "warning" });
+    }
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+    setCode("");
+    setStep(1);
+    setVerifyError(null);
+  };
+
+  const handleVerify = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!code.trim() || isVerifying || !instanceArtist?.id) return;
+
+    try {
+      setIsVerifying(true);
+      setVerifyError(null);
+      const response = await api.post<
+        { email: string; code: string },
+        { userId: string }
+      >("verify-email", { code: code.trim(), email });
+
+      if (!response.userId) {
+        setVerifyError(t("newsletterInvalidCode"));
+        return;
+      }
+
+      await api.post(`artists/${instanceArtist.id}/follow`, { email });
+
+      snackbar(t("newsletterSuccess"), { type: "success" });
+      setModalOpen(false);
+      setEmail("");
+      setCode("");
+      setStep(1);
+    } catch (error) {
+      if (error instanceof APIResponseError && error.status === 400) {
+        setVerifyError(t("newsletterInvalidCode"));
+      } else {
+        setVerifyError(t("newsletterError"));
+      }
+      codeInputRef.current?.focus();
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (isResending) return;
+    try {
+      setIsResending(true);
+      await api.post("verify-email", { email });
+      snackbar(t("newsletterResendSuccess"), { type: "success" });
+    } catch {
+      snackbar(t("newsletterError"), { type: "warning" });
+    } finally {
+      setIsResending(false);
+    }
+  };
 
   if (!instanceArtist && !isPending) {
     return null;
   }
 
+  const modalTitle =
+    step === 1 ? t("newsletterVerifyingTitle") : t("newsletterCheckInbox");
+
   return (
     <section className={containerStyles}>
       <div className={innerStyles}>
-        <div className={copyStyles}>
+        <div className="flex flex-col gap-3 max-w-[420px]">
           <SplashTitle as="h2">{t("mailingList")}</SplashTitle>
-          <p>{t("newsletterDescription")}</p>
+          <p className="text-(--mi-light-foreground-color) leading-[1.6]">
+            {t("newsletterDescription")}
+          </p>
         </div>
-        <div className={formStyles}>
-          <form onSubmit={handleSubmit}>
-            <div className={turnstileRowStyles}>
-              {turnstileSiteKey ? (
-                <div className={turnstileStyles}>
-                  <Turnstile
-                    siteKey={turnstileSiteKey}
-                    onSuccess={(token) => setTurnstileToken(token)}
-                    onExpire={() => setTurnstileToken(null)}
-                  />
-                </div>
-              ) : null}
-            </div>
-            {!hasVerifiedEmail ? (
-              <small className={helperTextStyles}>
-                {t("newsletterVerificationHint")}
-              </small>
-            ) : (
-              <div className={verifiedEmailStyles}>
-                <span>
-                  {t("newsletterVerifiedEmail", {
-                    email: verifiedEmailDisplay ?? verifiedEmail,
-                  })}
-                </span>
-                <Button
-                  type="button"
-                  variant="link"
-                  size="compact"
-                  onClick={handleResetVerification}
-                >
-                  {t("newsletterChangeEmail")}
-                </Button>
-              </div>
-            )}
+        <div className="bg-(--mi-normal-background-color) border border-(--mi-darken-x-background-color) rounded-[var(--mi-border-radius-x)] p-8 flex-1 max-w-[460px] max-md:max-w-full max-md:p-6">
+          <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+            <label
+              htmlFor="input-newsletter-email"
+              className="text-sm font-medium text-(--mi-normal-foreground-color)"
+            >
+              {t("newsletterEmailLabel")}
+            </label>
+            <InputEl
+              id="input-newsletter-email"
+              type="email"
+              required
+              value={email}
+              placeholder={t("newsletterPlaceholder")}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <Button
+              type="submit"
+              isLoading={isSubmitting}
+              disabled={!email.trim() || !instanceArtist?.id || isSubmitting}
+              size="big"
+              className="w-full justify-center mt-1"
+            >
+              {t("newsletterButton")}
+            </Button>
           </form>
-          {!hasVerifiedEmail ? (
-            <div className={verificationStyles}>
-              <EmailVerification
-                key={verificationKey}
-                setVerifiedEmail={handleVerifiedEmail}
-                smallText="newsletterVerificationInfo"
-              />
-            </div>
-          ) : null}
-          <Button
-            type="submit"
-            isLoading={isSubmitting}
-            disabled={
-              !hasVerifiedEmail ||
-              isSubmitting ||
-              !instanceArtist?.id ||
-              (Boolean(turnstileSiteKey) && !turnstileToken)
-            }
-          >
-            {t("newsletterButton")}
-          </Button>
         </div>
       </div>
+      <Modal
+        open={modalOpen}
+        onClose={handleCloseModal}
+        title={modalTitle}
+        size="small"
+        focusTrapOptions={{ delayInitialFocus: true }}
+      >
+        {step === 1 && turnstileSiteKey ? (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-(--mi-light-foreground-color)">
+              {t("newsletterVerifyingDescription")}
+            </p>
+            <Turnstile
+              siteKey={turnstileSiteKey}
+              onSuccess={handleTurnstileSuccess}
+            />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-(--mi-light-foreground-color)">
+              {t("newsletterCodeSentTo", { email })}
+            </p>
+            <form onSubmit={handleVerify} className="flex flex-col gap-3">
+              <FormComponent>
+                <label htmlFor="input-newsletter-code">
+                  {t("newsletterEnterCode")}
+                </label>
+                <InputEl
+                  id="input-newsletter-code"
+                  ref={codeInputRef}
+                  type="text"
+                  inputMode="numeric"
+                  autoFocus
+                  required
+                  value={code}
+                  onChange={(e) => {
+                    setCode(e.target.value);
+                    setVerifyError(null);
+                  }}
+                />
+              </FormComponent>
+              <p
+                role="alert"
+                aria-atomic="true"
+                className="text-sm text-(--mi-red-700)"
+              >
+                {verifyError}
+              </p>
+              <Button
+                type="submit"
+                isLoading={isVerifying}
+                disabled={!code.trim() || isVerifying}
+                className="w-full justify-center"
+              >
+                {t("newsletterVerifyAndSubscribe")}
+              </Button>
+            </form>
+            <Button
+              type="button"
+              variant="link"
+              size="compact"
+              isLoading={isResending}
+              disabled={isResending}
+              onClick={handleResend}
+            >
+              {t("newsletterResend")}
+            </Button>
+          </div>
+        )}
+      </Modal>
     </section>
   );
 };

--- a/client/src/components/common/EmailVerification.tsx
+++ b/client/src/components/common/EmailVerification.tsx
@@ -1,16 +1,14 @@
+import { useQueryClient } from "@tanstack/react-query";
+import Box from "components/common/Box";
 import Button from "components/common/Button";
+import FormComponent from "components/common/FormComponent";
+import { Input, InputEl } from "components/common/Input";
+import { QUERY_KEY_AUTH, queryKeyIncludes } from "queries/queryKeys";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import api from "services/api";
-import { useSnackbar } from "state/SnackbarContext";
-
-import { Input, InputEl } from "components/common/Input";
-import FormComponent from "components/common/FormComponent";
 import { useAuthContext } from "state/AuthContext";
-import Box from "components/common/Box";
-import { useQueryClient } from "@tanstack/react-query";
-import { QUERY_KEY_AUTH, queryKeyIncludes } from "queries/queryKeys";
-import { css } from "@emotion/css";
+import { useSnackbar } from "state/SnackbarContext";
 
 const EmailVerification: React.FC<{
   setVerifiedEmail: (verifiedEmail: string) => void;
@@ -82,30 +80,30 @@ const EmailVerification: React.FC<{
     <>
       {waitingForVerification ? (
         <Box variant="info">
-          {t("checkEmail")}
-          <FormComponent>
-            <label htmlFor="input-verification-code">
-              {t("verificationCode")}
-            </label>
-            <InputEl
-              id="input-verification-code"
-              required
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
-            />
-          </FormComponent>{" "}
-          <Button type="button" isLoading={isLoading} onClick={verifyCode}>
-            {t("verifyEmailCode")}
-          </Button>
+          <p className="text-sm mb-3">{t("checkEmail")}</p>
+          <div className="flex flex-col gap-3">
+            <FormComponent>
+              <label htmlFor="input-verification-code">
+                {t("verificationCode")}
+              </label>
+              <InputEl
+                id="input-verification-code"
+                type="text"
+                inputMode="numeric"
+                required
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+              />
+            </FormComponent>
+            <Button type="button" isLoading={isLoading} onClick={verifyCode}>
+              {t("verifyEmailCode")}
+            </Button>
+          </div>
         </Box>
       ) : (
-        <FormComponent
-          className={css`
-            width: 100%;
-          `}
-        >
-          <label htmlFor="input-email-verify">{t("email")}</label>
-          <div className="inline-button">
+        <div className="flex flex-col gap-3 w-full">
+          <FormComponent>
+            <label htmlFor="input-email-verify">{t("email")}</label>
             <Input
               autoComplete="on"
               id="input-email-verify"
@@ -113,16 +111,22 @@ const EmailVerification: React.FC<{
               type="email"
               value={email}
               required
+              aria-describedby="hint-email-verify"
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 setEmail(e.target.value);
               }}
             />
-            <Button type="button" onClick={verifyEmail}>
-              {t("verifyEmail")}
-            </Button>
-          </div>
-          <small>{t(smallText)}</small>
-        </FormComponent>
+          </FormComponent>
+          <Button type="button" isLoading={isLoading} onClick={verifyEmail}>
+            {t("verifyEmail")}
+          </Button>
+          <small
+            id="hint-email-verify"
+            className="text-(--mi-light-foreground-color)"
+          >
+            {t(smallText)}
+          </small>
+        </div>
       )}
     </>
   );

--- a/client/src/components/common/Modal.tsx
+++ b/client/src/components/common/Modal.tsx
@@ -1,13 +1,15 @@
-import React from "react";
 import { css } from "@emotion/css";
 import styled from "@emotion/styled";
-import { bp } from "../../constants";
-import ReactDOM from "react-dom";
-import Background from "./Background";
-import { FaTimes } from "react-icons/fa";
-import SpaceBetweenDiv from "./SpaceBetweenDiv";
-import Button from "./Button";
 import { FocusTrap } from "focus-trap-react";
+import React from "react";
+import ReactDOM from "react-dom";
+import { FaTimes } from "react-icons/fa";
+
+import { bp } from "../../constants";
+
+import Background from "./Background";
+import Button from "./Button";
+import SpaceBetweenDiv from "./SpaceBetweenDiv";
 
 const wrapper = css`
   position: fixed;
@@ -150,6 +152,7 @@ export const Modal: React.FC<{
   className?: string;
   contentClassName?: string;
   noPadding?: boolean;
+  focusTrapOptions?: React.ComponentProps<typeof FocusTrap>["focusTrapOptions"];
 }> = ({
   children,
   open,
@@ -161,6 +164,7 @@ export const Modal: React.FC<{
   className,
   contentClassName,
   noPadding,
+  focusTrapOptions,
 }) => {
   const [container] = React.useState(() => {
     // This will be executed only on the initial render
@@ -204,6 +208,7 @@ export const Modal: React.FC<{
     <FocusTrap
       focusTrapOptions={{
         initialFocus: ".".concat(close),
+        ...focusTrapOptions,
       }}
     >
       <div

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -1531,11 +1531,20 @@
     "newsletterButton": "Sign up",
     "newsletterSuccess": "Thanks! You're now on the list.",
     "newsletterError": "We couldn't add you to the mailing list. Please try again.",
+    "newsletterInvalidCode": "That code doesn't look right. Make sure you entered the correct number, or click resend code.",
     "newsletterVerificationHint": "Verify your email below before signing up.",
     "newsletterVerificationRequired": "Please verify your email before signing up.",
     "newsletterCaptchaRequired": "Please complete the spam check before signing up.",
     "newsletterVerifiedEmail": "Ready to subscribe with {{email}}.",
-    "newsletterChangeEmail": "Use a different email"
+    "newsletterChangeEmail": "Use a different email",
+    "newsletterVerifyingTitle": "One moment...",
+    "newsletterVerifyingDescription": "We're making sure you're not a robot.",
+    "newsletterCheckInbox": "Check your inbox",
+    "newsletterCodeSentTo": "We sent a verification code to {{email}}.",
+    "newsletterEnterCode": "Verification code",
+    "newsletterVerifyAndSubscribe": "Verify & subscribe",
+    "newsletterResend": "Resend code",
+    "newsletterResendSuccess": "Code resent!"
   },
   "mobileApp.searchScreen": {
     "bestSelling": "Best Selling",

--- a/src/routers/auth/index.ts
+++ b/src/routers/auth/index.ts
@@ -1,26 +1,34 @@
-import express, { Response } from "express";
-import { userAuthenticated } from "../../auth/passport";
-import prisma from "@mirlo/prisma";
+import express from "express";
+import { rateLimit } from "express-rate-limit";
 
-import profile from "./profile";
-import signup from "./signup";
-import refresh from "./refresh";
-import login from "./login";
-import verifyEmail from "./verifyEmail";
-import resendVerificationEmail from "./resendVerificationEmail";
+import { userAuthenticated } from "../../auth/passport";
+
 import confirmEmailToken from "./confirmEmailToken";
+import login from "./login";
 import {
   passwordResetConfirmation,
   passwordResetInitiate,
   passwordResetSetPassword,
 } from "./passwordReset";
+import profile from "./profile";
+import refresh from "./refresh";
+import resendVerificationEmail from "./resendVerificationEmail";
+import signup from "./signup";
 import { clearJWT, setTokens } from "./utils";
+import verifyEmail from "./verifyEmail";
 
 const router = express.Router();
 
 router.post(`/signup`, signup);
 
-router.post(`/verify-email`, verifyEmail);
+const verifyEmailLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 10,
+  standardHeaders: true,
+  skip: (req) => !!req.body?.code, // only limit email-sending, not code verification
+});
+
+router.post(`/verify-email`, verifyEmailLimiter, verifyEmail);
 
 router.post(`/confirm-email-token`, confirmEmailToken);
 


### PR DESCRIPTION
This is a really simple redesign of the newsletter signup flow on the frontpage so that it just presents itself as an "enter email + sign up button" box. After that, the modal opens up, cloudflare does its thing, and when/if it completes properly, the next step loads telling the user an email has been sent to their adress with a code : They enter the code and signup. The flow should have error messages for every step that doesn't work. Only backend change is the addition of a specific spam protection with rate limiting of 10 requests per minute, but that doesn't concern trying several times to input the verification code in case someone gets it wrong. Also added the E2E cypress tests for all the flow I could think of.