### PR TITLE
test(cypress): wait for managed-artist load before interacting in customize-look spec

### DIFF
--- a/client/cypress/e2e/artist-customize-look.cy.ts
+++ b/client/cypress/e2e/artist-customize-look.cy.ts
@@ -35,11 +35,17 @@ describe("artist customize look", () => {
     cy.login({ email: userEmail, password: userPassword });
 
     cy.intercept("GET", "/auth/profile").as("authProfile");
+    cy.intercept("GET", `/v1/manage/artists/${artistId}*`).as(
+      "getManagedArtist"
+    );
     cy.intercept("PUT", `/v1/manage/artists/${artistId}`).as("updateArtist");
     cy.intercept("GET", `/v1/artists/${urlSlug}*`).as("getArtist");
 
     cy.visit(`/manage/artists/${artistId}/customize`);
     cy.wait("@authProfile");
+    // Wait for the managed-artist fetch so the form's defaults useEffect
+    // resets BEFORE we interact; otherwise a late reset wipes our checkbox.
+    cy.wait("@getManagedArtist");
   });
 
   it("toggles transparent container and persists it to artist properties", () => {

--- a/client/src/components/common/DownloadAlbumButton.tsx
+++ b/client/src/components/common/DownloadAlbumButton.tsx
@@ -37,6 +37,7 @@ const DownloadAlbumButton: React.FC<{
   const { t } = useTranslation("translation", { keyPrefix: "trackGroupCard" });
   const [chosenFormat, setChosenFormat] = React.useState("");
   const [isGeneratingAlbum, setIsGeneratingAlbum] = React.useState(0);
+  const [isCheckingGeneration, setIsCheckingGeneration] = React.useState(false);
   const [isPopupOpen, setIsPopupOpen] = React.useState(false);
   const [isDownloading, setIsDownloading] = React.useState(false);
   const errorHandler = useErrorHandler();
@@ -60,6 +61,7 @@ const DownloadAlbumButton: React.FC<{
 
   const generateAlbum = React.useCallback(
     async (format: string) => {
+      setIsCheckingGeneration(true);
       try {
         const queryParams = new URLSearchParams();
         queryParams.append("format", format);
@@ -73,6 +75,8 @@ const DownloadAlbumButton: React.FC<{
         }
       } catch (e) {
         errorHandler(e);
+      } finally {
+        setIsCheckingGeneration(false);
       }
     },
     [chosenFormat, trackGroup.id, t, prefix, errorHandler]
@@ -145,7 +149,7 @@ const DownloadAlbumButton: React.FC<{
             </>
           ) : (
             <>
-              {isGeneratingAlbum > 0 ? (
+              {isCheckingGeneration || isGeneratingAlbum > 0 ? (
                 <p
                   className={css`
                     svg {


### PR DESCRIPTION
Two CI runs on the same SHA `49d05cbd` (one passed, one failed) confirmed this is timing-dependent, fix CI flake on main

Related: #1977