### PR TITLE
fix: newsletter restyling

### DIFF
--- a/emails/announce-post-published/html.pug
+++ b/emails/announce-post-published/html.pug
@@ -2,18 +2,22 @@ extends ../layout.pug
 
 block content
 
-    if post.featuredImage
-      div.mw600 
-        a(href!=`${client}/post/${post.id}`) 
-          img(src=post.featuredImage.src, alt="Featured Image", style="width:100%;height:auto;max-height:400px;object-fit:cover;margin-bottom:16px;")
-    p  
-    p #{artist.name} just published a new post on Mirlo: 
-    h2 #{post.title}
-    p 
-      a(href!=`${client}/${artist.urlSlug}/posts/${post.urlSlug}`) Read it on Mirlo.
-    div.mw600 
+    div.mw600.email-header
+      if post.featuredImage
+        a(href!=`${client}/post/${post.id}`)
+          img(src=post.featuredImage.src, alt="Featured Image", style="width:100%;height:auto;max-height:400px;object-fit:cover;margin-bottom:8px;")
+
+      p.email-byline #{artist.name} just published a new post on Mirlo
+      h1.email-title #{post.title}
+      p.read-on-mirlo
+        a(href!=`${client}/${artist.urlSlug}/posts/${post.urlSlug}`) Read it on Mirlo.
+
+    div.mw600
       | !{post.htmlContent}
-    hr
-    p.mw600 Don't want to receive emails from #{artist.name} anymore?       
+
+    p.mw600.email-unsubscribe
+      | Don't want to receive emails from #{artist.name} anymore?
+      |
+      |
       a(href!=`${client}/${artist.urlSlug || artist.id}/unsubscribe?email=${email}`) Unsubscribe.
 

--- a/emails/announce-post-published/html.pug
+++ b/emails/announce-post-published/html.pug
@@ -2,7 +2,7 @@ extends ../layout.pug
 
 block content
 
-    div.mw600.email-header
+    div.email-header
       if post.featuredImage
         a(href!=`${client}/post/${post.id}`)
           img(src=post.featuredImage.src, alt="Featured Image", style="width:100%;height:auto;max-height:400px;object-fit:cover;margin-bottom:8px;")
@@ -12,12 +12,11 @@ block content
       p.read-on-mirlo
         a(href!=`${client}/${artist.urlSlug}/posts/${post.urlSlug}`) Read it on Mirlo.
 
-    div.mw600
+    div
       | !{post.htmlContent}
 
-    p.mw600.email-unsubscribe
+    p.email-unsubscribe
       | Don't want to receive emails from #{artist.name} anymore?
       |
       |
       a(href!=`${client}/${artist.urlSlug || artist.id}/unsubscribe?email=${email}`) Unsubscribe.
-

--- a/emails/announce-post-published/html.pug
+++ b/emails/announce-post-published/html.pug
@@ -4,7 +4,7 @@ block content
 
     div.email-header
       if post.featuredImage
-        a(href!=`${client}/post/${post.id}`)
+        a(href!=`${client}/${artist.urlSlug}/posts/${post.urlSlug}`)
           img(src=post.featuredImage.src, alt="Featured Image", style="width:100%;height:auto;max-height:400px;object-fit:cover;margin-bottom:8px;")
 
       p.email-byline #{artist.name} just published a new post on Mirlo

--- a/emails/layout.pug
+++ b/emails/layout.pug
@@ -12,5 +12,4 @@ html
     div.mw600
       block content
       block footer
-        p
-          | This email was sent using Mirlo.
+        p.email-footer This email was sent using Mirlo.

--- a/emails/layout.pug
+++ b/emails/layout.pug
@@ -6,10 +6,11 @@ html
       meta(name="viewport", content="width=device-width")
       meta(http-equiv="X-UA-Compatible", content="IE=edge")
       meta(name="x-apple-disable-message-reformatting")
-      style 
+      style
         include ./style.css
-  body.sans-serif
-    div.mw600
-      block content
+  body.sans-serif.email-body
+    div.email-background
+      div.email-card.mw600
+        block content
       block footer
         p.email-footer This email was sent using Mirlo.

--- a/emails/style.css
+++ b/emails/style.css
@@ -30,8 +30,26 @@ img {
   height: auto;
 }
 
+.email-body {
+  margin: 0;
+  padding: 0;
+  max-width: none;
+}
+
+.email-background {
+  width: 100%;
+  padding: 2rem 1rem;
+  background-color: #fdf4f4;
+}
+
+.email-card {
+  background-color: #ffffff;
+  padding: 2rem;
+  border-radius: 6px;
+}
+
 .email-header {
-  padding-bottom: 1rem;
+  padding-bottom: 1.5rem;
   margin-bottom: 1.5rem;
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 }

--- a/emails/style.css
+++ b/emails/style.css
@@ -1,19 +1,58 @@
 .sans-serif {
   font-family:
-    -apple-system, BlinkMacSystemFont, "avenir next", avenir, "helvetica neue",
-    helvetica, ubuntu, roboto, noto, "segoe ui", arial, sans-serif;
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
 }
 
 body {
-  font-size: 16px;
+  font-size: 18px;
   line-height: 1.5;
   padding: 0.5rem;
   max-width: 540px;
   margin: 0 auto;
+  font-weight: 400;
 }
 
 p {
   margin-bottom: 0.75rem;
+}
+
+h2 {
+  font-weight: 500;
+}
+
+h2 strong {
+  font-weight: 600;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+.email-header {
+  padding-bottom: 1rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.email-byline {
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(0, 0, 0, 0.55);
+  margin: 0 0 0.5rem;
+}
+
+.email-title {
+  font-size: 1.75rem;
+  line-height: 1.2;
+  margin: 0 0 0.5rem;
+}
+
+.read-on-mirlo {
+  font-size: 0.875rem;
+  margin: 0;
 }
 
 .b {
@@ -30,6 +69,23 @@ p {
 
 .mw600 {
   max-width: 600px;
+  margin: 0 auto;
+  font-size: 18px;
+}
+
+.email-unsubscribe {
+  margin-top: 2rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  font-size: 0.8125rem;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.email-footer {
+  margin-top: 1.5rem;
+  text-align: center;
+  font-size: 0.75rem;
+  color: rgba(0, 0, 0, 0.6);
 }
 
 .w-100 {


### PR DESCRIPTION
First and foremost, the biggest point of this PR was to fix text being displayed in full bold weight in emails.

This was due to the "Avenir" font, which defaulted to "Avenir Black" depending on which system you were on (that's why emails worked on Mobile, and in other OS, but not on Windows). When switching to other fonts it all worked fine.

Also recentered images and text, and added some light styling to better differenciate things like blogpost title, "artist just published a new post", Unsubscribe and "sent using Mirlo".