### PR TITLE
fix: preserve album price when toggling to no-payments mode (#1557)

### DIFF
--- a/client/cypress/e2e/manage-album-pricing.cy.ts
+++ b/client/cypress/e2e/manage-album-pricing.cy.ts
@@ -62,10 +62,13 @@ describe("manage album pricing", () => {
     cy.wait("@updateTrackGroup")
       .its("request.body")
       .should((body) => {
+        // Toggling to "No payments" only flips isGettable; minPrice and
+        // suggestedPrice are preserved so a round-trip back to a paid mode
+        // restores the user's previously set values (#1557).
         expect(body).to.include({
           artistId,
           isGettable: false,
-          minPrice: 0,
+          minPrice: 300,
           suggestedPrice: null,
         });
       });

--- a/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/PriceAndSuch.tsx
+++ b/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/PriceAndSuch.tsx
@@ -105,9 +105,9 @@ const PriceAndSuch: React.FC<{
         : null;
 
       if (mode === "no-payments") {
+        // Only disable purchase; preserve prices so a round-trip back to a
+        // payment-enabled mode restores the user's previously set values.
         isGettable = false;
-        nextMinPrice = 0;
-        nextSuggestedPrice = null;
       }
 
       if (mode === "free-or-donate") {


### PR DESCRIPTION
Closes #1557 