### PR TITLE
Post notications going wrong order

### DIFF
--- a/prisma/migrations/20260505215222_has_activity_pub_been_sent/migration.sql
+++ b/prisma/migrations/20260505215222_has_activity_pub_been_sent/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "hasActivityPubBeenSent" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -249,6 +249,7 @@ model Post {
   minimumSubscriptionTierId Int?
   minimumSubscriptionTier   ArtistSubscriptionTier? @relation(fields: [minimumSubscriptionTierId], references: [id])
   hasAnnounceEmailBeenSent  Boolean                 @default(false)
+  hasActivityPubBeenSent    Boolean                 @default(false)
   postSubscriptionTiers     PostSubscriptionTier[]
   notifications             Notification[]
   shouldSendEmail           Boolean                 @default(true)

--- a/src/jobs/send-post-to-activitypub-followers.ts
+++ b/src/jobs/send-post-to-activitypub-followers.ts
@@ -27,106 +27,72 @@ export function parseMentionsFromContent(content: string): ApMention[] {
   return mentions;
 }
 
-/**
- * Sends published posts to ActivityPub followers' inboxes
+/** * Sends published posts to ActivityPub followers' inboxes
  * This job should run periodically to deliver new posts to federated servers
  */
 const sendPostToActivityPubFollowers = async () => {
   const date = new Date();
 
-  const notifications = await prisma.notification.findMany({
+  const posts = await prisma.post.findMany({
     where: {
-      isRead: false,
-      createdAt: { lte: date },
-      notificationType: "NEW_ARTIST_POST",
-      deliveryMethod: { in: ["ACTIVITYPUB", "BOTH"] },
-      post: {
-        deletedAt: null,
-        isDraft: false,
-        isPublic: true,
-        publishedAt: { lte: date },
-      },
+      deletedAt: null,
+      isDraft: false,
+      isPublic: true,
+      publishedAt: { lte: date },
+      hasActivityPubBeenSent: false,
+      artist: { activityPub: true },
     },
     select: {
       id: true,
-      post: {
+      title: true,
+      content: true,
+      urlSlug: true,
+      publishedAt: true,
+      artist: {
         select: {
           id: true,
-          title: true,
-          content: true,
           urlSlug: true,
-          publishedAt: true,
-          artistId: true,
-          artist: {
-            select: {
-              id: true,
-              urlSlug: true,
-              name: true,
-              activityPub: true,
-              activityPubArtistFollowers: { select: { actor: true } },
-            },
-          },
+          name: true,
+          activityPub: true,
+          activityPubArtistFollowers: { select: { actor: true } },
         },
       },
     },
   });
 
   logger.info(
-    `sendPostToActivityPubFollowers: found ${notifications.length} notifications to process`
+    `sendPostToActivityPubFollowers: found ${posts.length} posts to process`
   );
 
-  const postMap = new Map<
-    number,
-    { post: (typeof notifications)[0]["post"]; notificationIds: string[] }
-  >();
-
-  for (const notif of notifications) {
-    if (!notif.post) continue;
-    const postId = notif.post.id;
-    if (!postMap.has(postId)) {
-      postMap.set(postId, { post: notif.post, notificationIds: [notif.id] });
-    } else {
-      postMap.get(postId)!.notificationIds.push(notif.id);
-    }
-  }
-
-  logger.info(
-    `sendPostToActivityPubFollowers: grouped into ${postMap.size} unique posts`
-  );
-
-  for (const { post, notificationIds } of Array.from(postMap.values())) {
-    if (!post?.artist) {
+  for (const post of posts) {
+    if (!post.artist) {
       logger.warn(
-        `sendPostToActivityPubFollowers: post ${post?.id} has no artist`
+        `sendPostToActivityPubFollowers: post ${post.id} has no artist, skipping`
       );
-      await prisma.notification.updateMany({
-        where: { id: { in: notificationIds } },
-        data: { isRead: true },
+      await prisma.post.update({
+        where: { id: post.id },
+        data: { hasActivityPubBeenSent: true },
       });
       continue;
     }
 
-    if (!post.artist.activityPub) {
+    const mentions = parseMentionsFromContent(post.content ?? "");
+    const hasFollowers = post.artist.activityPubArtistFollowers.length > 0;
+
+    if (!hasFollowers && mentions.length === 0) {
       logger.info(
-        `sendPostToActivityPubFollowers: artist ${post.artist.urlSlug} does not have ActivityPub enabled`
+        `sendPostToActivityPubFollowers: artist ${post.artist.urlSlug} has no followers and no mentions, skipping`
       );
-      await prisma.notification.updateMany({
-        where: { id: { in: notificationIds } },
-        data: { isRead: true },
+      await prisma.post.update({
+        where: { id: post.id },
+        data: { hasActivityPubBeenSent: true },
       });
       continue;
     }
 
-    if (post.artist.activityPubArtistFollowers.length === 0) {
-      logger.info(
-        `sendPostToActivityPubFollowers: artist ${post.artist.urlSlug} has no followers`
-      );
-      await prisma.notification.updateMany({
-        where: { id: { in: notificationIds } },
-        data: { isRead: true },
-      });
-      continue;
-    }
+    logger.info(
+      `sendPostToActivityPubFollowers: processing post ${post.id} (${mentions.length} mention(s), hasFollowers=${hasFollowers})`
+    );
 
     const identifier = post.artist.urlSlug;
     const actorUri = new URL(`https://${root}/v1/ap/artists/${identifier}`);
@@ -139,7 +105,6 @@ const sendPostToActivityPubFollowers = async () => {
       new Request(`https://${root}`),
       undefined
     );
-    const mentions = parseMentionsFromContent(post.content ?? "");
 
     const createActivity = new Create({
       id: new URL(`${noteId.href}#activity-${guid}`),
@@ -161,19 +126,20 @@ const sendPostToActivityPubFollowers = async () => {
       }),
     });
 
-    try {
-      await ctx.sendActivity({ identifier }, "followers", createActivity, {
-        immediate: true,
-      });
-
-      logger.info(
-        `sendPostToActivityPubFollowers: sent post ${post.id} to followers of ${identifier}`
-      );
-    } catch (error) {
-      logger.error(
-        `sendPostToActivityPubFollowers: failed to send post ${post.id} to followers:`,
-        error
-      );
+    if (hasFollowers) {
+      try {
+        await ctx.sendActivity({ identifier }, "followers", createActivity, {
+          immediate: true,
+        });
+        logger.info(
+          `sendPostToActivityPubFollowers: sent post ${post.id} to followers of ${identifier}`
+        );
+      } catch (error) {
+        logger.error(
+          `sendPostToActivityPubFollowers: failed to send post ${post.id} to followers:`,
+          error
+        );
+      }
     }
 
     // Deliver to mentioned actors not already covered by the followers fanout
@@ -224,11 +190,22 @@ const sendPostToActivityPubFollowers = async () => {
       }
     }
 
-    // Mark all notifications for this post as read even if some deliveries failed
-    await prisma.notification.updateMany({
-      where: { id: { in: notificationIds } },
-      data: { isRead: true },
-    });
+    // Mark post as sent and clean up any related subscriber notifications,
+    // even if some deliveries failed.
+    await prisma.$transaction([
+      prisma.post.update({
+        where: { id: post.id },
+        data: { hasActivityPubBeenSent: true },
+      }),
+      prisma.notification.updateMany({
+        where: {
+          postId: post.id,
+          notificationType: "NEW_ARTIST_POST",
+          deliveryMethod: { in: ["ACTIVITYPUB", "BOTH"] },
+        },
+        data: { isRead: true },
+      }),
+    ]);
   }
 };
 

--- a/test/jobs/send-post-to-activitypub-followers.spec.ts
+++ b/test/jobs/send-post-to-activitypub-followers.spec.ts
@@ -98,46 +98,6 @@ describe("send-post-to-activitypub-followers", () => {
     assert.strictEqual(updatedNotif2?.isRead, true);
   });
 
-  it("should mark notification as read even if artist has no followers", async () => {
-    const { user: artistUser } = await createUser({
-      email: "artist2@test.com",
-    });
-
-    const artist = await createArtist(artistUser.id, {
-      name: "Test Artist",
-      urlSlug: "test-artist",
-      activityPub: true,
-    });
-
-    const post = await createPost(artist.id, {
-      title: "Lonely Post",
-      content: "This post has no followers",
-      isDraft: false,
-      isPublic: true,
-      publishedAt: new Date(),
-    });
-
-    const subscriber = await createUser({ email: "sub@test.com" });
-
-    const notification = await prisma.notification.create({
-      data: {
-        postId: post.id,
-        userId: subscriber.user.id,
-        notificationType: "NEW_ARTIST_POST",
-        deliveryMethod: "BOTH",
-        isRead: false,
-      },
-    });
-
-    await sendPostToActivityPubFollowers();
-
-    const updatedNotif = await prisma.notification.findUnique({
-      where: { id: notification.id },
-    });
-
-    assert.strictEqual(updatedNotif?.isRead, true);
-  });
-
   it("should not process notifications with deliveryMethod EMAIL only", async () => {
     const { user: artistUser } = await createUser({
       email: "artist3@test.com",
@@ -185,7 +145,7 @@ describe("send-post-to-activitypub-followers", () => {
     assert.strictEqual(updatedNotif?.isRead, false);
   });
 
-  it("should mark notification as read even when ActivityPub is disabled for artist", async () => {
+  it("should not process posts for artists with ActivityPub disabled", async () => {
     const { user: artistUser } = await createUser({
       email: "artist4@test.com",
     });
@@ -204,35 +164,19 @@ describe("send-post-to-activitypub-followers", () => {
       publishedAt: new Date(),
     });
 
-    const subscriber = await createUser({ email: "sub@test.com" });
-
-    const notification = await prisma.notification.create({
-      data: {
-        postId: post.id,
-        userId: subscriber.user.id,
-        notificationType: "NEW_ARTIST_POST",
-        deliveryMethod: "BOTH",
-        isRead: false,
-      },
-    });
-
-    await prisma.activityPubArtistFollowers.create({
-      data: {
-        artistId: artist.id,
-        actor: "https://example.com/user",
-      },
-    });
-
     await sendPostToActivityPubFollowers();
 
-    const updatedNotif = await prisma.notification.findUnique({
-      where: { id: notification.id },
-    });
+    // Job should not have attempted any delivery
+    assert.strictEqual(fetchStub.callCount, 0);
 
-    assert.strictEqual(updatedNotif?.isRead, true);
+    // Post should not be marked as sent (it was never eligible)
+    const updatedPost = await prisma.post.findUnique({
+      where: { id: post.id },
+    });
+    assert.strictEqual(updatedPost?.hasActivityPubBeenSent, false);
   });
 
-  it("should not process already read notifications", async () => {
+  it("should not re-process posts already marked as sent", async () => {
     const { user: artistUser } = await createUser({
       email: "artist5@test.com",
     });
@@ -243,29 +187,25 @@ describe("send-post-to-activitypub-followers", () => {
       activityPub: true,
     });
 
-    const post = await createPost(artist.id, {
-      title: "Already Read",
-      content: "This notification is already read",
+    await createPost(artist.id, {
+      title: "Already Sent",
+      content: "This post was already sent via ActivityPub",
       isDraft: false,
       isPublic: true,
       publishedAt: new Date(),
+      hasActivityPubBeenSent: true,
     });
 
-    const subscriber = await createUser({ email: "sub@test.com" });
-
-    await prisma.notification.create({
+    await prisma.activityPubArtistFollowers.create({
       data: {
-        postId: post.id,
-        userId: subscriber.user.id,
-        notificationType: "NEW_ARTIST_POST",
-        deliveryMethod: "BOTH",
-        isRead: true,
+        artistId: artist.id,
+        actor: "https://mastodon.example/users/follower",
       },
     });
 
     await sendPostToActivityPubFollowers();
 
-    // Job should not have made any fetch calls (notification already read, skipped)
+    // Job should not have made any fetch calls (post already sent)
     assert.strictEqual(fetchStub.callCount, 0);
   });
 
@@ -565,6 +505,64 @@ describe("send-post-to-activitypub-followers", () => {
       });
 
       assert.strictEqual(updatedNotif?.isRead, true);
+    });
+
+    it("should deliver to mentioned actors even when artist has no followers", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist-mention-only@test.com",
+      });
+
+      const artist = await createArtist(artistUser.id, {
+        name: "Test Artist",
+        urlSlug: "test-artist-mention-only",
+        activityPub: true,
+      });
+
+      const mentionedActorUrl = "https://mastodon.example/users/mentioned-only";
+      const mentionedInboxUrl =
+        "https://mastodon.example/users/mentioned-only/inbox";
+
+      const post = await createPost(artist.id, {
+        title: "Post with Mention and No Followers",
+        content: `Check this out: <a href="${mentionedActorUrl}" data-mention-actor="${mentionedActorUrl}">@mentioned-only</a>`,
+        isDraft: false,
+        isPublic: true,
+        publishedAt: new Date(),
+      });
+
+      const subscriber = await createUser({
+        email: "sub-mention-only@test.com",
+      });
+
+      const notification = await prisma.notification.create({
+        data: {
+          postId: post.id,
+          userId: subscriber.user.id,
+          notificationType: "NEW_ARTIST_POST",
+          deliveryMethod: "BOTH",
+          isRead: false,
+        },
+      });
+
+      // No followers added — artist has zero followers
+
+      fetchStub.withArgs(mentionedActorUrl, sinon.match.any).resolves({
+        ok: true,
+        json: async () => ({ inbox: mentionedInboxUrl }),
+      });
+
+      await sendPostToActivityPubFollowers();
+
+      const updatedNotif = await prisma.notification.findUnique({
+        where: { id: notification.id },
+      });
+
+      assert.strictEqual(updatedNotif?.isRead, true);
+
+      assert(
+        fetchStub.calledWith(mentionedActorUrl, sinon.match.any),
+        "Should fetch the mentioned actor document even when there are no followers"
+      );
     });
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -121,6 +121,7 @@ export const createPost = async (
       shouldSendEmail: data?.shouldSendEmail,
       isDraft: data?.isDraft ?? true,
       publishedAt: data?.publishedAt ?? new Date(),
+      hasActivityPubBeenSent: data?.hasActivityPubBeenSent ?? false,
     },
   });
   return post;


### PR DESCRIPTION
Because posts notifications in AP were based on notifications, if an artist had no followers there were no notifications generated and mentions weren't getting sent out.