### PR TITLE
fix: switch to claiming e-mail on send rather than one transaction

### DIFF
--- a/emails/announce-post-published/html.pug
+++ b/emails/announce-post-published/html.pug
@@ -18,5 +18,4 @@ block content
     p.email-unsubscribe
       | Don't want to receive emails from #{artist.name} anymore?
       |
-      |
       a(href!=`${client}/${artist.urlSlug || artist.id}/unsubscribe?email=${email}`) Unsubscribe.

--- a/src/jobs/parse-out-iframes.ts
+++ b/src/jobs/parse-out-iframes.ts
@@ -65,7 +65,7 @@ export const parseOutIframes = async (
         : Promise.resolve([]),
       trackIds.length
         ? prisma.track.findMany({
-            where: { id: { in: trackIds } },
+            where: { id: { in: trackIds }, deletedAt: null },
             include: { trackGroup: { include: { artist: true } } },
           })
         : Promise.resolve([]),

--- a/src/jobs/send-post-notification.ts
+++ b/src/jobs/send-post-notification.ts
@@ -90,16 +90,26 @@ export default async function sendPostNotification(job: {
       return;
     }
 
-    // Only process published, non-draft posts that should send email
     const hasContent = post.content && post.content.trim().length > 0;
-    if (
-      post.isDraft ||
-      !post.shouldSendEmail ||
-      !hasContent ||
-      post.hasAnnounceEmailBeenSent
-    ) {
+    if (post.isDraft || !post.shouldSendEmail || !hasContent) {
       logger.info(
-        `sendPostNotification: skipping post ${postId} (draft=${post.isDraft}, shouldSendEmail=${post.shouldSendEmail}, hasContent=${hasContent}, alreadySent=${post.hasAnnounceEmailBeenSent})`
+        `sendPostNotification: skipping post ${postId} (draft=${post.isDraft}, shouldSendEmail=${post.shouldSendEmail}, hasContent=${hasContent})`
+      );
+      return;
+    }
+
+    // Atomically claim the post for sending. updateMany with the condition
+    // acts as a mutex — only one job execution (across retries or concurrent
+    // cron-queued duplicates) will get count=1 here. Any subsequent attempt
+    // sees count=0 and exits early, preventing duplicate emails.
+    const claim = await prisma.post.updateMany({
+      where: { id: postId, hasAnnounceEmailBeenSent: false },
+      data: { hasAnnounceEmailBeenSent: true },
+    });
+
+    if (claim.count === 0) {
+      logger.info(
+        `sendPostNotification: post ${postId} already claimed by another job, skipping`
       );
       return;
     }
@@ -120,122 +130,107 @@ export default async function sendPostNotification(job: {
       `sendPostNotification: found ${uniqueSubscribers.length} subscribers for post ${postId}`
     );
 
-    // Create notifications and queue emails in a transaction
-    // This ensures atomicity - if it fails halfway, the transaction rolls back
-    await prisma.$transaction(async (tx) => {
-      // Create notifications (skipDuplicates prevents duplicate emails)
-      const createdNotifications = await tx.notification.createMany({
-        data: uniqueSubscribers.map((subscriber) => ({
+    // Create notifications in the DB
+    const createdNotifications = await prisma.notification.createMany({
+      data: uniqueSubscribers.map((subscriber) => ({
+        postId,
+        userId: subscriber.id,
+        notificationType: "NEW_ARTIST_POST" as const,
+        deliveryMethod: post.artist?.activityPub
+          ? ("BOTH" as const)
+          : ("EMAIL" as const),
+      })),
+      skipDuplicates: true,
+    });
+
+    logger.info(
+      `sendPostNotification: created ${createdNotifications.count} new notifications for post ${postId}`
+    );
+
+    const notificationsToEmail = await prisma.notification.findMany({
+      where: {
+        postId,
+        deliveryMethod: { in: ["EMAIL", "BOTH"] },
+      },
+      include: {
+        user: { select: { email: true } },
+      },
+    });
+
+    logger.info(
+      `sendPostNotification: queueing ${notificationsToEmail.length} email(s) for post ${postId}`
+    );
+
+    // Pass the post URL as a fallback so embedded tracks/trackGroups link
+    // to the post when their parent album is unreachable (draft, private,
+    // unreleased, deleted). Otherwise the email link 404s. See #1703.
+    const { applicationUrl } = await getClient();
+    const postUrl = `${applicationUrl}/${post.artist?.urlSlug ?? ""}/posts/${post.urlSlug ?? post.id}`;
+    const htmlContent = await parseOutIframes(post.content || "", postUrl);
+
+    for (const notification of notificationsToEmail) {
+      if (!notification.user?.email) {
+        logger.warn(
+          `sendPostNotification: skipping notification ${notification.id} for post ${postId} because recipient email is missing`
+        );
+        continue;
+      }
+
+      const postForEmail = serializePost({
+        id: post.id,
+        title: post.title,
+        urlSlug: post.urlSlug,
+        featuredImage: post.featuredImage,
+        content: post.content,
+        isPublic: post.isPublic,
+      });
+
+      await sendMailQueue.add(
+        "send-mail",
+        {
+          template: "announce-post-published",
+          message: {
+            to: notification.user.email,
+          },
+          locals: {
+            artist: {
+              id: post.artist?.id,
+              name: post.artist?.name,
+              urlSlug: post.artist?.urlSlug,
+            },
+            post: {
+              ...postForEmail,
+              htmlContent,
+            },
+            email: encodeURIComponent(notification.user.email),
+            host: process.env.API_DOMAIN,
+            client: (await getClient()).applicationUrl,
+          },
+        },
+        {
+          jobId: `announce-post-published:${postId}:${notification.id}`,
+        }
+      );
+    }
+
+    // Create in-app notifications for mentioned local artists
+    const mentionedArtistUserIds = await findMentionedLocalArtistUserIds(
+      post.content || ""
+    );
+    if (mentionedArtistUserIds.length > 0) {
+      await prisma.notification.createMany({
+        data: mentionedArtistUserIds.map((userId) => ({
           postId,
-          userId: subscriber.id,
-          notificationType: "NEW_ARTIST_POST" as const,
-          deliveryMethod: post.artist?.activityPub
-            ? ("BOTH" as const)
-            : ("EMAIL" as const),
+          userId,
+          notificationType: "MENTION_IN_POST" as const,
+          deliveryMethod: "IN_APP" as const,
         })),
         skipDuplicates: true,
       });
-
       logger.info(
-        `sendPostNotification: created ${createdNotifications.count} new notifications for post ${postId}`
+        `sendPostNotification: created ${mentionedArtistUserIds.length} mention notification(s) for post ${postId}`
       );
-
-      // Find ALL notifications for this post (both newly created and existing)
-      // to queue emails for them
-      const notificationsToEmail = await tx.notification.findMany({
-        where: {
-          postId,
-          deliveryMethod: { in: ["EMAIL", "BOTH"] },
-        },
-        include: {
-          user: { select: { email: true } },
-        },
-      });
-
-      logger.info(
-        `sendPostNotification: queueing ${notificationsToEmail.length} email(s) for post ${postId}`
-      );
-
-      // Pass the post URL as a fallback so embedded tracks/trackGroups link
-      // to the post when their parent album is unreachable (draft, private,
-      // unreleased, deleted). Otherwise the email link 404s. See #1703.
-      const { applicationUrl } = await getClient();
-      const postUrl = `${applicationUrl}/${post.artist?.urlSlug ?? ""}/posts/${post.urlSlug ?? post.id}`;
-      const htmlContent = await parseOutIframes(post.content || "", postUrl);
-
-      // Queue emails for all notifications
-      for (const notification of notificationsToEmail) {
-        if (!notification.user?.email) {
-          logger.warn(
-            `sendPostNotification: skipping notification ${notification.id} for post ${postId} because recipient email is missing`
-          );
-          continue;
-        }
-
-        const postForEmail = serializePost({
-          id: post.id,
-          title: post.title,
-          urlSlug: post.urlSlug,
-          featuredImage: post.featuredImage,
-          content: post.content,
-          isPublic: post.isPublic,
-        });
-
-        await sendMailQueue.add(
-          "send-mail",
-          {
-            template: "announce-post-published",
-            message: {
-              to: notification.user.email,
-            },
-            locals: {
-              artist: {
-                id: post.artist?.id,
-                name: post.artist?.name,
-                urlSlug: post.artist?.urlSlug,
-              },
-              post: {
-                ...postForEmail,
-                htmlContent,
-              },
-              email: encodeURIComponent(notification.user.email),
-              host: process.env.API_DOMAIN,
-              client: (await getClient()).applicationUrl,
-            },
-          },
-          {
-            // Stable job IDs make email enqueue idempotent across retries.
-            jobId: `announce-post-published:${postId}:${notification.id}`,
-          }
-        );
-      }
-
-      // Create in-app notifications for mentioned local artists
-      const mentionedArtistUserIds = await findMentionedLocalArtistUserIds(
-        post.content || ""
-      );
-      if (mentionedArtistUserIds.length > 0) {
-        await tx.notification.createMany({
-          data: mentionedArtistUserIds.map((userId) => ({
-            postId,
-            userId,
-            notificationType: "MENTION_IN_POST" as const,
-            deliveryMethod: "IN_APP" as const,
-          })),
-          skipDuplicates: true,
-        });
-        logger.info(
-          `sendPostNotification: created ${mentionedArtistUserIds.length} mention notification(s) for post ${postId}`
-        );
-      }
-
-      // Mark post as having email announcement sent
-      // This prevents re-processing on job retry
-      await tx.post.update({
-        where: { id: postId },
-        data: { hasAnnounceEmailBeenSent: true },
-      });
-    });
+    }
 
     logger.info(`sendPostNotification: completed for post ${postId}`);
   } catch (error) {

--- a/src/jobs/send-post-to-activitypub-followers.ts
+++ b/src/jobs/send-post-to-activitypub-followers.ts
@@ -113,13 +113,18 @@ const sendPostToActivityPubFollowers = async () => {
     // Deliver to mentioned actors not already covered by the followers fanout.
     // Only skip a mentioned actor if they are a follower WITH a known inbox —
     // if inboxUrl is null the fanout skipped them, so we must deliver here.
+    // Local actors (same instance) are skipped: they receive in-app notifications
+    // via sendPostNotification and don't need AP HTTP delivery.
+    const localActorPrefix = `https://${root}/`;
     const followerActorIdsWithInbox = new Set(
       post.artist.activityPubArtistFollowers
         .filter((f) => f.inboxUrl !== null)
         .map((f) => f.actor)
     );
     const mentionsToDeliver = mentions.filter(
-      (m) => !followerActorIdsWithInbox.has(m.href)
+      (m) =>
+        !m.href.startsWith(localActorPrefix) &&
+        !followerActorIdsWithInbox.has(m.href)
     );
 
     if (mentionsToDeliver.length > 0) {

--- a/src/jobs/trigger-post-notifications.ts
+++ b/src/jobs/trigger-post-notifications.ts
@@ -1,4 +1,5 @@
 import prisma from "@mirlo/prisma";
+
 import logger from "../logger";
 import { sendPostNotificationQueue } from "../queues/send-post-notification-queue";
 
@@ -48,7 +49,10 @@ export async function triggerPostNotifications() {
     await sendPostNotificationQueue.add(
       "send-post-notification",
       { postId: post.id },
-      { removeOnComplete: true }
+      {
+        jobId: `post-notification:${post.id}`,
+        removeOnComplete: true,
+      }
     );
   }
 }

--- a/test/jobs/send-post-notification.spec.ts
+++ b/test/jobs/send-post-notification.spec.ts
@@ -1,0 +1,332 @@
+import * as dotenv from "dotenv";
+
+dotenv.config();
+import assert from "assert";
+
+import prisma from "@mirlo/prisma";
+import { describe, it } from "mocha";
+import sinon from "sinon";
+
+import sendPostNotification from "../../src/jobs/send-post-notification";
+import { sendMailQueue } from "../../src/queues/send-mail-queue";
+import { clearTables, createUser } from "../utils";
+
+describe("send-post-notification", () => {
+  let mailQueueStub: sinon.SinonStub;
+
+  beforeEach(async () => {
+    try {
+      await clearTables();
+    } catch (e) {
+      console.error(e);
+    }
+    mailQueueStub = sinon.stub(sendMailQueue, "add").resolves({} as any);
+  });
+
+  afterEach(() => {
+    mailQueueStub.restore();
+  });
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  // A sentinel value meaning "omit emailConfirmationToken so the DB default UUID applies"
+  const UNCONFIRMED = Symbol("UNCONFIRMED");
+
+  async function createArtistWithSubscriber(
+    subscriberEmail: string,
+    subscriberOverrides: {
+      emailConfirmationToken?: typeof UNCONFIRMED | null;
+      deletedAt?: Date | null;
+    } = {}
+  ) {
+    const { user: artistUser } = await createUser({
+      email: "artist@test.com",
+      emailConfirmationToken: null,
+    });
+    const tokenOverride = subscriberOverrides.emailConfirmationToken;
+    const { user: subscriber } = await createUser({
+      email: subscriberEmail,
+      // null = confirmed (explicit); UNCONFIRMED = let DB set uuid default
+      ...(tokenOverride !== UNCONFIRMED && {
+        emailConfirmationToken: tokenOverride ?? null,
+      }),
+      ...(subscriberOverrides.deletedAt !== undefined && {
+        deletedAt: subscriberOverrides.deletedAt,
+      }),
+    });
+
+    const artist = await prisma.artist.create({
+      data: {
+        name: "Test Artist",
+        urlSlug: "test-artist",
+        userId: artistUser.id,
+        enabled: true,
+        subscriptionTiers: { create: { name: "Fan tier" } },
+      },
+      include: { subscriptionTiers: true },
+    });
+
+    await prisma.artistUserSubscription.create({
+      data: {
+        userId: subscriber.id,
+        artistSubscriptionTierId: artist.subscriptionTiers[0].id,
+        amount: 5,
+      },
+    });
+
+    return { artist, subscriber };
+  }
+
+  async function createPublishedPost(
+    artistId: number,
+    overrides: Record<string, any> = {}
+  ) {
+    return prisma.post.create({
+      data: {
+        title: "Test Post",
+        artistId,
+        content: "Hello world",
+        isDraft: false,
+        isPublic: true,
+        shouldSendEmail: true,
+        urlSlug: "test-post",
+        publishedAt: new Date(),
+        hasAnnounceEmailBeenSent: false,
+        ...overrides,
+      },
+    });
+  }
+
+  // ── Basic behaviour ────────────────────────────────────────────────────────
+
+  it("queues an email for each confirmed subscriber", async () => {
+    const { artist } = await createArtistWithSubscriber("sub@test.com");
+    const post = await createPublishedPost(artist.id);
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    assert.strictEqual(mailQueueStub.callCount, 1);
+    const [, jobData] = mailQueueStub.firstCall.args;
+    assert.strictEqual(jobData.template, "announce-post-published");
+    assert.strictEqual(jobData.message.to, "sub@test.com");
+  });
+
+  it("creates a NEW_ARTIST_POST notification in the DB", async () => {
+    const { artist } = await createArtistWithSubscriber("sub@test.com");
+    const post = await createPublishedPost(artist.id);
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    const notification = await prisma.notification.findFirst({
+      where: { postId: post.id, notificationType: "NEW_ARTIST_POST" },
+    });
+    assert.ok(notification, "notification should exist");
+  });
+
+  it("marks the post as hasAnnounceEmailBeenSent after processing", async () => {
+    const { artist } = await createArtistWithSubscriber("sub@test.com");
+    const post = await createPublishedPost(artist.id);
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    const updated = await prisma.post.findUnique({ where: { id: post.id } });
+    assert.strictEqual(updated?.hasAnnounceEmailBeenSent, true);
+  });
+
+  // ── Claim / idempotency (the triple-send regression) ──────────────────────
+
+  it("only sends emails once when called twice sequentially for the same post", async () => {
+    const { artist } = await createArtistWithSubscriber("sub@test.com");
+    const post = await createPublishedPost(artist.id);
+
+    // Simulates two BullMQ jobs created for the same post (e.g. cron fired
+    // twice before hasAnnounceEmailBeenSent was set, or 3-attempt retry loop).
+    await sendPostNotification({ data: { postId: post.id } });
+    await sendPostNotification({ data: { postId: post.id } });
+
+    assert.strictEqual(
+      mailQueueStub.callCount,
+      1,
+      "email should be queued exactly once across both executions"
+    );
+  });
+
+  it("skips immediately when post is already marked as sent", async () => {
+    const { artist } = await createArtistWithSubscriber("sub@test.com");
+    const post = await createPublishedPost(artist.id, {
+      hasAnnounceEmailBeenSent: true,
+    });
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    assert.strictEqual(mailQueueStub.callCount, 0);
+  });
+
+  it("uses a stable jobId per notification to support BullMQ deduplication", async () => {
+    const { artist } = await createArtistWithSubscriber("sub@test.com");
+    const post = await createPublishedPost(artist.id);
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    const [, , jobOptions] = mailQueueStub.firstCall.args;
+    assert.ok(
+      typeof jobOptions?.jobId === "string" &&
+        jobOptions.jobId.startsWith(`announce-post-published:${post.id}:`),
+      `jobId should be stable and scoped to postId, got: ${jobOptions?.jobId}`
+    );
+  });
+
+  // ── Skip conditions ────────────────────────────────────────────────────────
+
+  it("skips draft posts", async () => {
+    const { artist } = await createArtistWithSubscriber("sub@test.com");
+    const post = await createPublishedPost(artist.id, { isDraft: true });
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    assert.strictEqual(mailQueueStub.callCount, 0);
+    const updated = await prisma.post.findUnique({ where: { id: post.id } });
+    assert.strictEqual(updated?.hasAnnounceEmailBeenSent, false);
+  });
+
+  it("skips posts with shouldSendEmail: false", async () => {
+    const { artist } = await createArtistWithSubscriber("sub@test.com");
+    const post = await createPublishedPost(artist.id, {
+      shouldSendEmail: false,
+    });
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    assert.strictEqual(mailQueueStub.callCount, 0);
+  });
+
+  it("skips posts with empty content", async () => {
+    const { artist } = await createArtistWithSubscriber("sub@test.com");
+    const post = await createPublishedPost(artist.id, { content: "   " });
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    assert.strictEqual(mailQueueStub.callCount, 0);
+  });
+
+  it("returns without error when post does not exist", async () => {
+    await sendPostNotification({ data: { postId: 999999 } });
+    assert.strictEqual(mailQueueStub.callCount, 0);
+  });
+
+  // ── Subscriber filtering ───────────────────────────────────────────────────
+
+  it("does not email unconfirmed subscribers (emailConfirmationToken set)", async () => {
+    const { artist } = await createArtistWithSubscriber(
+      "unconfirmed@test.com",
+      {
+        emailConfirmationToken: UNCONFIRMED,
+      }
+    );
+    const post = await createPublishedPost(artist.id);
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    assert.strictEqual(mailQueueStub.callCount, 0);
+  });
+
+  it("does not email deleted subscribers", async () => {
+    const { artist } = await createArtistWithSubscriber("deleted@test.com", {
+      deletedAt: new Date(),
+    });
+    const post = await createPublishedPost(artist.id);
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    assert.strictEqual(mailQueueStub.callCount, 0);
+  });
+
+  it("deduplicates subscribers who appear in multiple tiers", async () => {
+    const { user: artistUser } = await createUser({
+      email: "artist2@test.com",
+      emailConfirmationToken: null,
+    });
+    const { user: subscriber } = await createUser({
+      email: "multi@test.com",
+      emailConfirmationToken: null,
+    });
+
+    const artist = await prisma.artist.create({
+      data: {
+        name: "Multi Tier Artist",
+        urlSlug: "multi-tier-artist",
+        userId: artistUser.id,
+        enabled: true,
+        subscriptionTiers: {
+          create: [{ name: "Tier A" }, { name: "Tier B" }],
+        },
+      },
+      include: { subscriptionTiers: true },
+    });
+
+    // Subscribe the same user to both tiers
+    for (const tier of artist.subscriptionTiers) {
+      await prisma.artistUserSubscription.create({
+        data: {
+          userId: subscriber.id,
+          artistSubscriptionTierId: tier.id,
+          amount: 5,
+        },
+      });
+    }
+
+    const post = await createPublishedPost(artist.id);
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    // Despite two subscriptions, only one email should be queued
+    assert.strictEqual(mailQueueStub.callCount, 1);
+  });
+
+  // ── Local mention notifications ────────────────────────────────────────────
+
+  it("creates MENTION_IN_POST notification for a mentioned local artist", async () => {
+    const { user: artistUser } = await createUser({
+      email: "poster@test.com",
+      emailConfirmationToken: null,
+    });
+    const { user: mentionedUser } = await createUser({
+      email: "mentioned@test.com",
+      emailConfirmationToken: null,
+    });
+
+    const postingArtist = await prisma.artist.create({
+      data: {
+        name: "Posting Artist",
+        urlSlug: "posting-artist",
+        userId: artistUser.id,
+        enabled: true,
+      },
+    });
+
+    await prisma.artist.create({
+      data: {
+        name: "Mentioned Artist",
+        urlSlug: "mentioned-artist",
+        userId: mentionedUser.id,
+        enabled: true,
+      },
+    });
+
+    const post = await createPublishedPost(postingArtist.id, {
+      content: `Hello <a href="/v1/artists/mentioned-artist" data-mention-actor="http://localhost/v1/ap/artists/mentioned-artist">@mentioned-artist</a>`,
+    });
+
+    await sendPostNotification({ data: { postId: post.id } });
+
+    const mention = await prisma.notification.findFirst({
+      where: {
+        postId: post.id,
+        userId: mentionedUser.id,
+        notificationType: "MENTION_IN_POST",
+      },
+    });
+    assert.ok(mention, "MENTION_IN_POST notification should be created");
+    assert.strictEqual(mention?.deliveryMethod, "IN_APP");
+  });
+});

--- a/test/jobs/send-post-to-activitypub-followers.spec.ts
+++ b/test/jobs/send-post-to-activitypub-followers.spec.ts
@@ -388,6 +388,13 @@ describe("send-post-to-activitypub-followers", () => {
         ok: true,
         json: async () => ({ inbox: mentionedInboxUrl }),
       });
+      // Allow the inbox POST to complete so fedify's sendActivity resolves
+      fetchStub.withArgs(mentionedInboxUrl, sinon.match.any).resolves({
+        ok: true,
+        status: 202,
+        text: async () => "",
+        headers: new Headers(),
+      });
 
       await sendPostToActivityPubFollowers();
 


### PR DESCRIPTION
The transaction to send everything was timing out, which was causing the job to abort. This refactor basically claims an post for the job and then works on it. 