### PR TITLE
feat: use JWT playtoken for song streaming

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,10 +1,14 @@
+approvedGitRepositories:
+  - "**"
+
 compressionLevel: mixed
 
-nodeLinker: node-modules
+enableScripts: true
 
 logFilters:
-  # Ignores some known warnings about the react/react-dom versions not satisfying @gumlet/react-hls-player
-  - pattern: "*(paf38f)*"
-    level: discard
-  - pattern: "*(p741fc)*"
-    level: discard
+  - level: discard
+    pattern: "*(paf38f)*"
+  - level: discard
+    pattern: "*(p741fc)*"
+
+nodeLinker: node-modules

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Prerequisites:
 
 - [Docker](https://www.docker.com/get-started/)
 - [Node.js 22](https://nodejs.org/en)
-- [Yarn 4](https://yarnpkg.com)
 
 Once node is installed, you can use [Corepack](https://nodejs.org/api/corepack.html) to automatically install the correct version of yarn (as defined in `package.json`):
 
 ```sh
 corepack enable
+corepack up
 ```
 
 If you'd like to use Nix, we have a basic `shell.nix` that includes Node.js, Yarn, and other tools to develop the client. Activate the shell using `nix-shell` at the top-level of the repository.

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -27,6 +27,7 @@ services:
     environment:
       - NODE_ENV=${NODE_ENV:-development}
       - REDIS_HOST=${REDIS_HOST:-redis}
+      - DATABASE_URL=postgresql://nomads:nomads@pgsql:5432/nomads?schema=public
     depends_on:
       - redis
       - pgsql

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "license": "AGPL-3.0",
   "module": "commonjs",
   "scripts": {
+    "api:debug": "dotenv ts-node src/index.ts  --inspect",
+    "api:start": "ts-node src/index.ts",
     "api:test": "tsc --noEmit && mocha test --exit --extension ts",
     "api:test:docker": "docker compose -f docker-compose.api.yml -f docker-compose.test.yml --profile test run --rm test",
-    "api:watch": "NODE_ENV=development PORT=3000 nodemon src/index.ts",
-    "api:start": "ts-node src/index.ts",
+    "api:watch": "NODE_ENV=development PORT=${PORT:-3000} nodemon src/index.ts",
     "prepare": "husky",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -121,6 +122,7 @@
     "@types/yargs": "^17.0.22",
     "@yarnpkg/pnpify": "^4.0.1",
     "concurrently": "^7.6.0",
+    "dotenv-cli": "^11.0.0",
     "lint-staged": "^15",
     "mocha": "^10.2.0",
     "nodemon": "^2.0.20",
@@ -148,5 +150,5 @@
     "prisma",
     "client"
   ],
-  "packageManager": "yarn@4.1.1"
+  "packageManager": "yarn@4.14.1+sha512.64df448055b2d37ba269d7db535a469b8da93f8ef1140c25fd7a83c00a8fbaacb214ca0e02553b92a2c54cef78bb67d0b4817fab02001df0e24fac0faccc3b42"
 }

--- a/prisma/migrations/20260515074753_add_skip_stream_token_to_client/migration.sql
+++ b/prisma/migrations/20260515074753_add_skip_stream_token_to_client/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Client" ADD COLUMN     "skipStreamToken" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Client {
   allowedCorsOrigins String[]
   secret             String?
   key                String?
+  skipStreamToken    Boolean     @default(false)
   updatedAt          DateTime    @default(now()) @updatedAt
   createdAt          DateTime    @default(now())
   deletedAt          DateTime?
@@ -307,7 +308,7 @@ model Artist {
   linksJson                          Json[]
   location                           String?
   allowPurchaseEntireCatalog         Boolean                              @default(false)
-  purchaseEntireCatalogMinPrice      Int                                  @default(0) // in cents  
+  purchaseEntireCatalogMinPrice      Int                                  @default(0) // in cents
   maxFreePlays                       Int?
   merchStoreURL                      String?
   activityPub                        Boolean                              @default(false)
@@ -784,7 +785,7 @@ model Fundraiser {
   name           String
   createdAt      DateTime           @default(now())
   updatedAt      DateTime           @updatedAt
-  goalAmount     Int                @default(0) // in cents 
+  goalAmount     Int                @default(0) // in cents
   description    String?
   endDate        DateTime?
   // Is the fundraiser all or nothing

--- a/src/auth/cors.ts
+++ b/src/auth/cors.ts
@@ -43,6 +43,7 @@ export const corsCheck = async (...args: [Request, Response, NextFunction]) => {
   // @ts-ignore - req.logger added by middleware
   const log = req.logger || logger;
   try {
+    const isNotCors = req.headers["sec-fetch-mode"] === "no-cors";
     const isSameSite =
       req.headers["sec-fetch-site"] === "same-site" ||
       req.headers["sec-fetch-site"] === "same-origin";
@@ -69,15 +70,27 @@ export const corsCheck = async (...args: [Request, Response, NextFunction]) => {
         req.method === "OPTIONS" &&
         req.headers["access-control-request-method"] &&
         req.headers["access-control-request-headers"];
-      const skipsApiKey =
+      let skipsApiKey =
+        isNotCors ||
         isSameSite ||
         !isAPIEndpointPrivate ||
         isCORSPreflight ||
         isValidActivityPubEndpoint(req.path);
+      const origin = req.get("origin");
 
       log.info(
-        `CORS check for ${req.method} ${req.path} - sameSite: ${isSameSite}, privateEndpoint: ${isAPIEndpointPrivate}, skipsApiKey: ${skipsApiKey}, isCorsPreflight: ${isCORSPreflight}`
+        `CORS check for ${origin} ${req.method} ${req.path} - sameSite: ${isSameSite}, privateEndpoint: ${isAPIEndpointPrivate}, skipsApiKey: ${skipsApiKey}, isCorsPreflight: ${isCORSPreflight}`
       );
+
+      if (origin) {
+        const clientsThatMaySkipToken = await prisma.client.findMany({
+          where: { allowedCorsOrigins: { has: origin }, skipStreamToken: true },
+        });
+        skipsApiKey ||= clientsThatMaySkipToken.length > 0;
+        log.info(
+          `Found clients that don't require token: ${clientsThatMaySkipToken.length}`
+        );
+      }
 
       log.info(
         "headers",

--- a/src/auth/cors.ts
+++ b/src/auth/cors.ts
@@ -75,7 +75,20 @@ export const corsCheck = async (...args: [Request, Response, NextFunction]) => {
         isCORSPreflight ||
         isValidActivityPubEndpoint(req.path);
 
+      log.info(
+        `CORS check for ${req.method} ${req.path} - sameSite: ${isSameSite}, privateEndpoint: ${isAPIEndpointPrivate}, skipsApiKey: ${skipsApiKey}, isCorsPreflight: ${isCORSPreflight}`
+      );
+
+      log.info(
+        "headers",
+        req.headers["access-control-request-method"],
+        req.headers["access-control-request-headers"]
+      );
+
       if (skipsApiKey) {
+        log.info(
+          `${req.method} ${req.path} Skipping API key check for ${req.method} ${req.path}`
+        );
         clients = await prisma.client.findMany();
       } else {
         const apiHeader = req.headers[MIRLO_API_KEY_HEADER];

--- a/src/routers/v1/tracks/{id}/stream/authzd/{segment}.ts
+++ b/src/routers/v1/tracks/{id}/stream/authzd/{segment}.ts
@@ -1,0 +1,169 @@
+import prisma from "@mirlo/prisma";
+import { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+
+import { userLoggedInWithoutRedirect } from "../../../../../../auth/passport";
+import logger from "../../../../../../logger";
+import {
+  finalAudioBucket,
+  getBufferBasedOnStat,
+  statFile,
+} from "../../../../../../utils/minio";
+import { canUserListenToTrack } from "../../../../../../utils/ownership";
+import socialMusic from "../../../../../../utils/socialMusic";
+
+const jwt_secret = process.env.JWT_SECRET ?? "secretkey";
+
+export const fetchFile = async (
+  res: Response,
+  filename: string,
+  segment: string
+) => {
+  const alias = `${filename}/${segment}`;
+
+  const { backblazeStat, minioStat } = await statFile(finalAudioBucket, alias);
+  if (!backblazeStat && !minioStat) {
+    res.send();
+  }
+  try {
+    const buffer = await getBufferBasedOnStat(
+      finalAudioBucket,
+      alias,
+      backblazeStat
+    );
+
+    res.end(buffer, "binary");
+  } catch (e) {
+    console.error("error", e);
+    res.status(400);
+    res.send();
+    return;
+  }
+};
+
+export default function () {
+  const operations = {
+    GET: [userLoggedInWithoutRedirect, GET],
+  };
+
+  async function GET(req: Request, res: Response, next: NextFunction) {
+    const { id, segment }: { id?: string; segment?: string } = req.params;
+    const user = req.user;
+    // @ts-ignore - req.logger added by middleware
+    const log = req.logger || logger;
+
+    try {
+      const track = await prisma.track.findUnique({
+        where: { id: Number(id) },
+        include: {
+          trackGroup: {
+            include: {
+              artist: true,
+            },
+          },
+          audio: true,
+        },
+      });
+
+      const isUserAbleToListenToTrack = await canUserListenToTrack(
+        track?.id,
+        user,
+        req.ip
+      );
+
+      if (!track || !isUserAbleToListenToTrack) {
+        res.status(404);
+        return next();
+      }
+
+      const isManifest = segment.includes("playlist.m3u8");
+      if (isManifest && isUserAbleToListenToTrack === "exceeded") {
+        res.status(402).send("Track play limit exceeded");
+      }
+
+      if (track.audio) {
+        const userid = req.get(socialMusic.HEADER_USERID);
+
+        if (isManifest) {
+          // On manifest request, generate a playtoken for a song and user
+
+          if (!userid) {
+            res.status(400).send(`Header ${socialMusic.HEADER_USERID} missing`);
+            return next();
+          }
+
+          const payload = { song: id, userid };
+          if (userid) {
+            log.debug("Generate playtoken:", payload);
+            const playToken = jwt.sign(payload, jwt_secret, {
+              expiresIn: "4w",
+            });
+            res.setHeader(socialMusic.HEADER_PLAYTOKEN, playToken);
+          }
+        } else {
+          // On a segment request, check that the token matches user and song
+
+          const playToken = req.query[socialMusic.PLAYTOKEN];
+          const reqUserId = req.query[socialMusic.USERID];
+          if (!(playToken && reqUserId)) {
+            res
+              .status(400)
+              .send(
+                `${socialMusic.USERID} or ${socialMusic.PLAYTOKEN} missing`
+              );
+            return next();
+          }
+
+          // @ts-ignore playtoken type may not be a string?
+          const decoded = jwt.verify(playToken, jwt_secret);
+          log.debug("Parsed playtoken:", decoded);
+          log.debug("Request userid:", reqUserId);
+          const { song, userid } = decoded;
+
+          if (song !== id || reqUserId !== userid) {
+            log.debug("Credentials error");
+            res.status(403).send("Token doesn't match song and user");
+          } else {
+            log.debug("Credentials match");
+          }
+        }
+
+        await fetchFile(res, track.audio.id, segment);
+      }
+    } catch (e) {
+      console.error(e);
+      res.status(500);
+      return next();
+    }
+  }
+
+  GET.apiDoc = {
+    summary: "With the right authorization, returns track streaming playlist",
+    parameters: [
+      {
+        in: "path",
+        name: "id",
+        required: true,
+        type: "string",
+      },
+      { in: "query", name: socialMusic.USERID, type: "string" },
+      { in: "query", name: socialMusic.PLAYTOKEN, type: "string" },
+    ],
+    responses: {
+      200: {
+        description: "A track that matches the id",
+        schema: {
+          $ref: "#/definitions/Track",
+        },
+      },
+      default: {
+        description: "An error occurred",
+        schema: {
+          additionalProperties: true,
+        },
+      },
+    },
+  };
+
+  return operations;
+}

--- a/src/routers/v1/tracks/{id}/stream/authzd/{segment}.ts
+++ b/src/routers/v1/tracks/{id}/stream/authzd/{segment}.ts
@@ -4,42 +4,11 @@ import jwt from "jsonwebtoken";
 
 import { userLoggedInWithoutRedirect } from "../../../../../../auth/passport";
 import logger from "../../../../../../logger";
-import {
-  finalAudioBucket,
-  getBufferBasedOnStat,
-  statFile,
-} from "../../../../../../utils/minio";
 import { canUserListenToTrack } from "../../../../../../utils/ownership";
 import socialMusic from "../../../../../../utils/socialMusic";
+import { fetchFile } from "../{segment}";
 
 const jwt_secret = process.env.JWT_SECRET ?? "secretkey";
-
-export const fetchFile = async (
-  res: Response,
-  filename: string,
-  segment: string
-) => {
-  const alias = `${filename}/${segment}`;
-
-  const { backblazeStat, minioStat } = await statFile(finalAudioBucket, alias);
-  if (!backblazeStat && !minioStat) {
-    res.send();
-  }
-  try {
-    const buffer = await getBufferBasedOnStat(
-      finalAudioBucket,
-      alias,
-      backblazeStat
-    );
-
-    res.end(buffer, "binary");
-  } catch (e) {
-    console.error("error", e);
-    res.status(400);
-    res.send();
-    return;
-  }
-};
 
 export default function () {
   const operations = {
@@ -79,6 +48,7 @@ export default function () {
       const isManifest = segment.includes("playlist.m3u8");
       if (isManifest && isUserAbleToListenToTrack === "exceeded") {
         res.status(402).send("Track play limit exceeded");
+        return next();
       }
 
       if (track.audio) {
@@ -126,6 +96,7 @@ export default function () {
           if (song !== id || reqUserId !== userid) {
             log.debug("Credentials error");
             res.status(403).send("Token doesn't match song and user");
+            return next();
           } else {
             log.debug("Credentials match");
           }

--- a/src/routers/v1/tracks/{id}/stream/authzd/{segment}.ts
+++ b/src/routers/v1/tracks/{id}/stream/authzd/{segment}.ts
@@ -116,9 +116,12 @@ export default function () {
 
           // @ts-ignore playtoken type may not be a string?
           const decoded = jwt.verify(playToken, jwt_secret);
-          log.debug("Parsed playtoken:", decoded);
-          log.debug("Request userid:", reqUserId);
           const { song, userid } = decoded;
+
+          log.debug("Matching token to request", {
+            token: { song, userid },
+            request: { song: id, user: reqUserId },
+          });
 
           if (song !== id || reqUserId !== userid) {
             log.debug("Credentials error");

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -34,6 +34,7 @@ const routes = [
   "tracks/{id}/trackPlay",
   "tracks/{id}/favorite",
   "tracks/{id}/stream/{segment}",
+  "tracks/{id}/stream/authzd/{segment}",
   "artists",
   "artists/testExistence",
   "artists/{id}",

--- a/src/utils/socialMusic.ts
+++ b/src/utils/socialMusic.ts
@@ -1,0 +1,9 @@
+const HEADER = "social-music";
+
+const USERID = "userid";
+const PLAYTOKEN = "playtoken";
+
+const HEADER_USERID = `${HEADER}-${USERID}`;
+const HEADER_PLAYTOKEN = `${HEADER}-${PLAYTOKEN}`;
+
+export default { USERID, PLAYTOKEN, HEADER_USERID, HEADER_PLAYTOKEN };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,17 +2,16 @@
   "compilerOptions": {
     "module": "node16",
     "sourceMap": true,
+    "rootDir": ".",
     "outDir": "dist",
     "strict": true,
     "lib": ["esnext"],
     "skipLibCheck": true,
     "esModuleInterop": true,
     "moduleResolution": "node16",
-    "isolatedModules": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "isolatedModules": true
   },
+  "include": ["src"],
   "exclude": ["client"],
   "ts-node": {
     "transpileOnly": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,10 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "moduleResolution": "node16",
-    "isolatedModules": true
+    "isolatedModules": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "exclude": ["client"],
   "ts-node": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@adobe/css-tools@npm:^4.4.0":
@@ -12846,6 +12846,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv-cli@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "dotenv-cli@npm:11.0.0"
+  dependencies:
+    cross-spawn: "npm:^7.0.6"
+    dotenv: "npm:^17.1.0"
+    dotenv-expand: "npm:^12.0.0"
+    minimist: "npm:^1.2.6"
+  bin:
+    dotenv: cli.js
+  checksum: 10/0dab973aa8d94163f9b17f7452f9c9b567baf67e6551c3d883f3ea1df9edbd69a9ea55cbc8e020026c9e8d8f01056087526d011c1829924483c8c72f9c17c79a
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:^12.0.0":
+  version: 12.0.3
+  resolution: "dotenv-expand@npm:12.0.3"
+  dependencies:
+    dotenv: "npm:^16.4.5"
+  checksum: 10/d9aaf051805c8fa64e7e3620936ecb38229a93f5603883e53856d6f57cd4ae93fb74baefdf0b03b1c0608bc3eefbbcb23912972d7303b6191a5c0e1688a8652f
+  languageName: node
+  linkType: hard
+
 "dotenv-safe@npm:^8.2.0":
   version: 8.2.0
   resolution: "dotenv-safe@npm:8.2.0"
@@ -12855,10 +12878,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.3, dotenv@npm:^16.3.1, dotenv@npm:^16.6.1":
+"dotenv@npm:^16.0.3, dotenv@npm:^16.3.1, dotenv@npm:^16.4.5, dotenv@npm:^16.6.1":
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 10/1d1897144344447ffe62aa1a6d664f4cd2e0784e0aff787eeeec1940ded32f8e4b5b506d665134fc87157baa086fce07ec6383970a2b6d2e7985beaed6a4cc14
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^17.1.0":
+  version: 17.4.2
+  resolution: "dotenv@npm:17.4.2"
+  checksum: 10/ca1b6f54d58e39914901e1518958e86083aca8deb5aa2e7f2a51acd53291d97852479b0ab26ed949b6a45a0e9adcc7b0d1c3c72375e8ea670f7005e341c6daba
   languageName: node
   linkType: hard
 
@@ -18537,6 +18567,7 @@ __metadata:
     cors: "npm:^2.8.5"
     crypto: "npm:^1.0.1"
     dotenv: "npm:^16.0.3"
+    dotenv-cli: "npm:^11.0.0"
     dotenv-safe: "npm:^8.2.0"
     email-templates: "npm:^12.0.2"
     eslint: "npm:^9"
@@ -24035,21 +24066,21 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>":
   version: 5.8.2
-  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/6ae9b2c4d3254ec2eaee6f26ed997e19c02177a212422993209f81e87092b2bb0a4738085549c5b0164982a5609364c047c72aeb281f6c8d802cd0d1c6f0d353
+  checksum: 10/97920a082ffc57583b1cb6bc4faa502acc156358e03f54c7fc7fdf0b61c439a717f4c9070c449ee9ee683d4cfc3bb203127c2b9794b2950f66d9d307a4ff262c
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/5d416ad4f2ea564f515a3f919e901edbfa4b497cc17dd325c5726046c3eef7ed22d1f59c787267d478311f6f0a265ff790f8a6c7e9df3ea3471458f5ec81e8b7
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Starting on the Mirlo side of authorized HLS playback as specced in https://codeberg.org/fairplayer/interop/pulls/10.

- Mirlo generates a playback token upon first request for a song from a user (the playlist.m3u8 endpoint) based on headers provided by the client (this means Fairplayer for now)
- For segments, it bases the authorization on the playtoken and userid passed in as a querystring

This doesn't solve CORS for segments though, for which we may need some extra work.

The code could be made cleaner. 