### PR TITLE
fix: restore label roster artists avatars, backgrounds and cover mosaics

### DIFF
--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -27,7 +27,11 @@ import {
 } from "./minio";
 import { getSiteSettings } from "./settings";
 import stripe from "./stripe";
-import { deleteTrackGroup, trackGroupPublishedObject } from "./trackGroup";
+import {
+  deleteTrackGroup,
+  trackGroupPublishedObject,
+  whereForPublishedTrackGroups,
+} from "./trackGroup";
 export { processSingleArtist } from "./serialize/artist";
 
 type Params = {
@@ -594,7 +598,25 @@ export const singleInclude = (queryOptions?: {
             artist: { deletedAt: null },
           },
           include: {
-            artist: true,
+            artist: {
+              include: {
+                avatar: {
+                  where: { deletedAt: null },
+                },
+                background: {
+                  where: { deletedAt: null },
+                },
+                trackGroups: {
+                  where: whereForPublishedTrackGroups(),
+                  include: {
+                    cover: true,
+                    tracks: true,
+                  },
+                  orderBy: { releaseDate: "desc" },
+                  take: 4,
+                },
+              },
+            },
           },
         },
       },

--- a/src/utils/serialize/artist.ts
+++ b/src/utils/serialize/artist.ts
@@ -37,6 +37,19 @@ interface LocalArtist extends Artist {
     images?: { image: Image }[];
     releases?: { trackGroup: { cover?: TrackGroupCover | null } }[];
   })[];
+  user?: {
+    artistLabels?: {
+      artist: Artist & {
+        avatar?: ArtistAvatar | null;
+        background?: ArtistBackground | null;
+        trackGroups?: (TrackGroup & {
+          cover?: TrackGroupCover | null;
+          tracks?: Track[];
+        })[];
+      };
+    }[];
+    [key: string]: unknown;
+  } | null;
 }
 
 export const processSingleArtist = (
@@ -77,5 +90,27 @@ export const processSingleArtist = (
         },
       })),
     })),
+    user: artist.user
+      ? {
+          ...artist.user,
+          artistLabels: artist.user.artistLabels?.map((al) => ({
+            ...al,
+            artist: {
+              ...al.artist,
+              avatar: addSizesToImage(
+                finalArtistAvatarBucket,
+                al.artist?.avatar
+              ),
+              background: addSizesToImage(
+                finalArtistBackgroundBucket,
+                al.artist?.background
+              ),
+              trackGroups: al.artist?.trackGroups?.map((tg) =>
+                processSingleTrackGroup(tg, { loggedInUserId: userId })
+              ),
+            },
+          })),
+        }
+      : artist.user,
   };
 };


### PR DESCRIPTION
This is a quick fix for a bug that I realized while testing locally but is already active on prod so I prioritized it immediately because artist avatars don't appear on label pages anymore.

The cause is a change in architecture, where /v1/artists/{slug} endpoint is now returning user.artistLabels but just the artist scalar fields, so no avatar, background and trackgroup. The label roster page (which now reuses queryArtist instead of the old specific endpoint) was rendering an empty placeholder for every artist instead of their actual avatar, or the cover mosaic fallback for artists without an avatar, or the background image.

This adds back the avatar, background and most recent published trackgroups includes on the nested artist.