### PR TITLE
Declutter artist pages

### DIFF
--- a/client/src/components/Artist/Artist.tsx
+++ b/client/src/components/Artist/Artist.tsx
@@ -8,7 +8,7 @@ import {
 } from "queries";
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { FaChevronRight, FaEdit } from "react-icons/fa";
+import { FaChevronRight } from "react-icons/fa";
 import {
   NavLink,
   Outlet,
@@ -18,14 +18,9 @@ import {
 } from "react-router-dom";
 import api from "services/api";
 import { useAuthContext } from "state/AuthContext";
-import { getArtistManageUrl } from "utils/artist";
 import { TabConfig, TabId, sortTabsByOrder } from "utils/artistTabs";
-import useArtistQuery from "utils/useArtistQuery";
-import useManagedArtistQuery from "utils/useManagedArtistQuery";
 
 import Box from "../common/Box";
-
-import { ArtistButtonLink } from "./ArtistButtons";
 
 export const ArtistSection: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
   className,
@@ -41,32 +36,6 @@ export const ArtistSection: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
     {children}
   </div>
 );
-
-export const ArtistButtonQuickLink: React.FC<{
-  ariaLabel: string;
-  to: string;
-  icon: React.ReactElement;
-}> = ({ ariaLabel, to, icon }) => {
-  const { user } = useAuthContext();
-  const { data: viewingArtist } = useArtistQuery();
-  const { data: managedArtist } = useManagedArtistQuery();
-
-  const artist = viewingArtist ?? managedArtist;
-  const isArtistUser = artist?.userId === user?.id;
-
-  const canEdit = isArtistUser || user?.isAdmin;
-  if (!canEdit) return null;
-
-  return (
-    <ArtistButtonLink
-      aria-label={ariaLabel}
-      startIcon={icon}
-      to={to}
-      variant="dashed"
-      className="edit ml-1 -mt-2"
-    />
-  );
-};
 
 function Artist() {
   const { t } = useTranslation("translation", { keyPrefix: "artist" });
@@ -173,8 +142,6 @@ function Artist() {
       visible:
         artist.isLabelProfile && (artist.user?.artistLabels?.length ?? 0) > 0,
       to: "roster",
-      editTo: "/profile/label",
-      editAriaLabel: t("editTitled", { title: rosterTitle }),
     },
     {
       id: "releases",
@@ -184,8 +151,6 @@ function Artist() {
         (releases?.results.length ?? 0) > 0,
       to: "releases",
       navLinkId: "artist-navlink-releases",
-      editTo: getArtistManageUrl(artist.id) + "/releases",
-      editAriaLabel: t("editTitled", { title: releasesTitle }),
     },
     {
       id: "posts",
@@ -193,8 +158,6 @@ function Artist() {
       visible: (artist?.posts.length ?? 0) > 0,
       to: "posts",
       navLinkId: "artist-navlink-updates",
-      editTo: getArtistManageUrl(artist.id) + "/posts",
-      editAriaLabel: t("editTitled", { title: postsTitle }),
     },
     {
       id: "support",
@@ -204,16 +167,12 @@ function Artist() {
         (artist?.subscriptionTiers.filter((tier) => !tier.isDefaultTier)
           .length ?? 0) > 0,
       to: "support",
-      editTo: getArtistManageUrl(artist.id) + "/tiers",
-      editAriaLabel: t("editTitled", { title: supportTitle }),
     },
     {
       id: "merch",
       label: merchTitle,
       visible: (artist.merch.length ?? 0) > 0,
       to: "merch",
-      editTo: getArtistManageUrl(artist.id) + "/merch",
-      editAriaLabel: t("editTitled", { title: merchTitle }),
     },
   ];
 
@@ -234,22 +193,11 @@ function Artist() {
           {tabs
             .filter((tab) => tab.visible)
             .map((tab) => (
-              <React.Fragment key={tab.id}>
-                <li className="tab-primary">
-                  <NavLink to={tab.to} id={tab.navLinkId}>
-                    {tab.label}
-                  </NavLink>
-                </li>
-                {tab.editTo && (
-                  <li className="tab-secondary">
-                    <ArtistButtonQuickLink
-                      ariaLabel={tab.editAriaLabel ?? ""}
-                      to={tab.editTo}
-                      icon={<FaEdit />}
-                    />
-                  </li>
-                )}
-              </React.Fragment>
+              <li key={tab.id}>
+                <NavLink to={tab.to} id={tab.navLinkId}>
+                  {tab.label}
+                </NavLink>
+              </li>
             ))}
           {user && isArtistUser && !canReceivePayments && (
             <li>

--- a/client/src/components/ManageArtist/ManageArtist.tsx
+++ b/client/src/components/ManageArtist/ManageArtist.tsx
@@ -1,14 +1,11 @@
 import { css } from "@emotion/css";
 import { useQuery } from "@tanstack/react-query";
-import { ArtistButtonQuickLink } from "components/Artist/Artist";
 import Box from "components/common/Box";
 import { ArtistTabs } from "components/common/Tabs";
 import { queryManagedArtist } from "queries";
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { FaEye } from "react-icons/fa";
 import { NavLink, Outlet, useLocation, useParams } from "react-router-dom";
-import { getArtistUrl } from "utils/artist";
 import { TabConfig, TabId, sortTabsByOrder } from "utils/artistTabs";
 
 const ManageArtist: React.FC<{}> = () => {
@@ -42,40 +39,30 @@ const ManageArtist: React.FC<{}> = () => {
       label: rosterTitle,
       visible: !!artist.isLabelProfile,
       to: "/profile/label",
-      editTo: getArtistUrl(artist) + "/roster",
-      editAriaLabel: t("viewLiveTitled", { title: rosterTitle }),
     },
     {
       id: "releases",
       label: releasesTitle,
       visible: true,
       to: "releases",
-      editTo: getArtistUrl(artist) + "/releases",
-      editAriaLabel: t("viewLiveTitled", { title: releasesTitle }),
     },
     {
       id: "posts",
       label: postsTitle,
       visible: true,
       to: "posts",
-      editTo: getArtistUrl(artist) + "/posts",
-      editAriaLabel: t("viewLiveTitled", { title: postsTitle }),
     },
     {
       id: "support",
       label: supportTitle,
       visible: true,
       to: "tiers",
-      editTo: getArtistUrl(artist) + "/support",
-      editAriaLabel: t("viewLiveTitled", { title: supportTitle }),
     },
     {
       id: "merch",
       label: merchTitle,
       visible: true,
       to: "merch",
-      editTo: getArtistUrl(artist) + "/merch",
-      editAriaLabel: t("viewLiveTitled", { title: merchTitle }),
     },
   ];
 
@@ -111,20 +98,9 @@ const ManageArtist: React.FC<{}> = () => {
             {tabs
               .filter((tab) => tab.visible)
               .map((tab) => (
-                <React.Fragment key={tab.id}>
-                  <li className="tab-primary">
-                    <NavLink to={tab.to}>{tab.label}</NavLink>
-                  </li>
-                  {tab.editTo && (
-                    <li className="tab-secondary">
-                      <ArtistButtonQuickLink
-                        ariaLabel={tab.editAriaLabel ?? ""}
-                        to={tab.editTo}
-                        icon={<FaEye />}
-                      />
-                    </li>
-                  )}
-                </React.Fragment>
+                <li key={tab.id}>
+                  <NavLink to={tab.to}>{tab.label}</NavLink>
+                </li>
               ))}
           </ArtistTabs>
         </nav>

--- a/client/src/components/Post/PostHeader.tsx
+++ b/client/src/components/Post/PostHeader.tsx
@@ -45,10 +45,7 @@ const AvatarLink: React.FC<{
   </Link>
 );
 
-const PostHeader: React.FC<{ post: Post; hasTracks: boolean }> = ({
-  post,
-  hasTracks,
-}) => {
+const PostHeader: React.FC<{ post: Post }> = ({ post }) => {
   const { t, i18n } = useTranslation("translation", { keyPrefix: "post" });
 
   const featuredImage = post.featuredImage?.src;
@@ -104,8 +101,7 @@ const PostHeader: React.FC<{ post: Post; hasTracks: boolean }> = ({
       >
         <div
           className={
-            (hasTracks ? "max-w-6xl" : "max-w-3xl") +
-            " max-w-3xl p-1 flex pt-8 w-full justify-center " +
+            "max-w-3xl p-1 flex pt-8 w-full justify-center " +
             css`
               margin: 0 auto 0;
               position: relative;

--- a/client/src/components/Post/index.tsx
+++ b/client/src/components/Post/index.tsx
@@ -6,14 +6,12 @@ import LazyIframe from "components/common/LazyIframe";
 import MarkdownWrapper from "components/common/MarkdownWrapper";
 import { MetaCard } from "components/common/MetaCard";
 import SupportArtistPopUp from "components/common/SupportArtistPopUp";
-import PublicTrackGroupListing from "components/common/TrackTable/PublicTrackGroupListing";
 import parse, { Element } from "html-react-parser";
 import { queryPost } from "queries";
-import React, { useMemo } from "react";
+import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link, useParams } from "react-router-dom";
 import useArtistQuery from "utils/useArtistQuery";
-import { useTracksQuery } from "utils/useTracksQuery";
 
 import PostHeader from "./PostHeader";
 
@@ -75,13 +73,6 @@ const Post: React.FC = () => {
     queryPost({ postId: postId ?? "", artistId: artistId ?? "" })
   );
 
-  // Fetch full track details if post has associated tracks
-  const trackIds = useMemo(() => {
-    return post?.tracks?.map((t) => t.trackId) ?? [];
-  }, [post?.tracks]);
-
-  const { data: tracksData } = useTracksQuery(trackIds);
-
   if (!post) {
     if (!isLoading) {
       return (
@@ -111,59 +102,36 @@ const Post: React.FC = () => {
         description={post.content.slice(0, 500)}
         image={post.featuredImage?.src}
       />
-      <PostHeader post={post} hasTracks={trackIds.length > 0} />
+      <PostHeader post={post} />
 
-      <div className="max-w-6xl mx-auto px-4 pt-8">
-        <div
-          className={`grid gap-8 ${trackIds.length > 0 ? "grid-cols-1 lg:grid-cols-[1fr_400px]" : "grid-cols-1"}`}
-        >
-          <div
-            className={`${trackIds.length > 0 ? "lg:col-span-2" : "max-w-3xl mx-auto w-full"}`}
-          ></div>
-          <div
-            className={trackIds.length > 0 ? "" : "max-w-3xl mx-auto w-full"}
-          >
-            <PageMarkdownWrapper>
-              {post.isContentHidden && (
-                <div className="py-8">
-                  <Trans
-                    t={t}
-                    i18nKey="notAvailable"
-                    components={{
-                      support: (
-                        <Link to={`/${post.artist?.urlSlug}/support`}></Link>
-                      ),
-                    }}
-                  />
-                </div>
-              )}
-              {!post.isContentHidden && (
-                <MarkdownWrapper>
-                  {parse(post.content, {
-                    replace(node) {
-                      if (
-                        node instanceof Element &&
-                        node.tagName === "iframe"
-                      ) {
-                        const { loading: _loading, ...attribs } = node.attribs;
-                        return <LazyIframe {...attribs} />;
-                      }
-                    },
-                  })}
-                </MarkdownWrapper>
-              )}
-            </PageMarkdownWrapper>
-          </div>
-          {tracksData && tracksData.length > 0 && (
-            <div className="lg:col-start-2">
-              <PublicTrackGroupListing
-                tracks={tracksData}
-                trackGroup={tracksData[0]?.trackGroup}
-                size="small"
+      <div className="max-w-3xl mx-auto px-4 pt-8">
+        <PageMarkdownWrapper>
+          {post.isContentHidden && (
+            <div className="py-8">
+              <Trans
+                t={t}
+                i18nKey="notAvailable"
+                components={{
+                  support: (
+                    <Link to={`/${post.artist?.urlSlug}/support`}></Link>
+                  ),
+                }}
               />
             </div>
           )}
-        </div>
+          {!post.isContentHidden && (
+            <MarkdownWrapper>
+              {parse(post.content, {
+                replace(node) {
+                  if (node instanceof Element && node.tagName === "iframe") {
+                    const { loading: _loading, ...attribs } = node.attribs;
+                    return <LazyIframe {...attribs} />;
+                  }
+                },
+              })}
+            </MarkdownWrapper>
+          )}
+        </PageMarkdownWrapper>
       </div>
       {post.artist && (
         <SupportArtistPopUp

--- a/client/src/components/common/Tabs.tsx
+++ b/client/src/components/common/Tabs.tsx
@@ -11,7 +11,7 @@ const Tabs = styled.ul`
     margin-right: 1rem;
     margin-top: 0.5rem;
 
-    > a:not(.edit),
+    > a,
     button {
       border-radius: none;
       text-decoration: none;
@@ -48,7 +48,7 @@ export const ArtistTabs = styled(Tabs)`
   }
 
   > li {
-    > a:not(.edit),
+    > a,
     button {
       color: var(--mi-button-color) !important;
 
@@ -59,14 +59,6 @@ export const ArtistTabs = styled(Tabs)`
         border-bottom: 4px solid var(--mi-button-color) !important;
       }
     }
-  }
-
-  > .tab-primary {
-    margin-inline-end: 0;
-  }
-
-  > .tab-primary + .tab-secondary {
-    margin-inline-start: 0;
   }
 `;
 

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -448,7 +448,6 @@
     "contactMessageLabel": "Your message",
     "sendMessage": "Send message",
     "contactMessageSent": "Message sent",
-    "editTitled": "Edit {{ title }}",
     "editTier": "Edit",
     "failedToAddLocation": "Failed to add location tag",
     "failedToRemoveLocation": "Failed to remove location tag",
@@ -756,7 +755,6 @@
     "noReleases": "No releases found",
     "selected": "Selected",
     "saving": "Saving changes...",
-    "viewLiveTitled": "View live {{ title }}",
     "doesNotExist": "This artist page does not exist."
   },
   "managePost": {

--- a/client/src/utils/artistTabs.ts
+++ b/client/src/utils/artistTabs.ts
@@ -6,8 +6,6 @@ export interface TabConfig {
   visible: boolean;
   to: string;
   navLinkId?: string;
-  editTo?: string;
-  editAriaLabel?: string;
 }
 
 export function sortTabsByOrder(


### PR DESCRIPTION
There was a lot of visual noise on the artist pages related to editing EVEN when in "view mode", which meant an artist could never really see their page "as listeners see it". The problem was particularly pronounced on mobile, with lots of duplicated icons, sometimes even going as far as breaking the visual layout on smaller smartphones.