### PR TITLE
Player overhaul

### DIFF
--- a/client/cypress/e2e/player-continuity.cy.ts
+++ b/client/cypress/e2e/player-continuity.cy.ts
@@ -1,0 +1,92 @@
+import { ARTIST_EXAMPLE, TRACK_GROUP_EXAMPLE } from "../../../client/test/mocks";
+
+const trackId = 1;
+const artistSlug = "example-artist";
+
+const track = {
+  id: trackId,
+  title: "Example Track",
+  order: 1,
+  trackGroupId: TRACK_GROUP_EXAMPLE.id,
+  trackGroup: {
+    ...TRACK_GROUP_EXAMPLE,
+    artist: { ...TRACK_GROUP_EXAMPLE.artist },
+  },
+  isPreview: true,
+  audio: {
+    id: "audio-1",
+    duration: 60,
+    uploadState: "SUCCESS",
+  },
+  trackArtists: [],
+  license: null,
+};
+
+describe("player continuity across navigation", () => {
+  beforeEach(() => {
+    cy.window().then((win) => {
+      win.localStorage.setItem(
+        "nomadState",
+        JSON.stringify({
+          playerQueueIds: [trackId],
+          currentlyPlayingIndex: 0,
+        })
+      );
+    });
+
+    cy.intercept("GET", "/auth/profile", {
+      statusCode: 200,
+      body: { result: null },
+    });
+
+    cy.intercept("GET", `/v1/tracks/${trackId}`, {
+      statusCode: 200,
+      body: { result: track },
+    });
+
+    cy.intercept("GET", `/v1/artists/${artistSlug}*`, {
+      statusCode: 200,
+      body: {
+        result: {
+          ...ARTIST_EXAMPLE,
+          urlSlug: artistSlug,
+          user: { artistLabels: [] },
+        },
+      },
+    });
+
+    cy.intercept("GET", "/v1/settings/instanceArtist", {
+      statusCode: 200,
+      body: { result: null },
+    });
+
+    cy.intercept("GET", "/v1/trackGroups*", {
+      statusCode: 200,
+      body: { results: [], total: 0 },
+    });
+
+    cy.intercept("GET", "/v1/tags*", {
+      statusCode: 200,
+      body: { results: [], total: 0 },
+    });
+  });
+
+  it("keeps the Player mounted across route changes", () => {
+    cy.visit("/");
+    cy.get("#player", { timeout: 10000 })
+      .invoke("attr", "data-mount-id")
+      .as("originalMountId")
+      .should("be.a", "string")
+      .and("not.be.empty");
+
+    cy.visit(`/${artistSlug}`);
+    cy.get("@originalMountId").then((id) => {
+      cy.get("#player").should("have.attr", "data-mount-id", id);
+    });
+
+    cy.visit("/");
+    cy.get("@originalMountId").then((id) => {
+      cy.get("#player").should("have.attr", "data-mount-id", id);
+    });
+  });
+});

--- a/client/cypress/e2e/player-continuity.cy.ts
+++ b/client/cypress/e2e/player-continuity.cy.ts
@@ -1,17 +1,28 @@
-import { ARTIST_EXAMPLE, TRACK_GROUP_EXAMPLE } from "../../../client/test/mocks";
+import {
+  ARTIST_EXAMPLE,
+  TRACK_GROUP_EXAMPLE,
+} from "../../../client/test/mocks";
 
 const trackId = 1;
 const artistSlug = "example-artist";
+
+const artist = {
+  ...ARTIST_EXAMPLE,
+  urlSlug: artistSlug,
+  user: { artistLabels: [] },
+};
+
+const featuredRelease = {
+  ...TRACK_GROUP_EXAMPLE,
+  artist: { ...TRACK_GROUP_EXAMPLE.artist, urlSlug: artistSlug },
+};
 
 const track = {
   id: trackId,
   title: "Example Track",
   order: 1,
   trackGroupId: TRACK_GROUP_EXAMPLE.id,
-  trackGroup: {
-    ...TRACK_GROUP_EXAMPLE,
-    artist: { ...TRACK_GROUP_EXAMPLE.artist },
-  },
+  trackGroup: featuredRelease,
   isPreview: true,
   audio: {
     id: "audio-1",
@@ -24,16 +35,6 @@ const track = {
 
 describe("player continuity across navigation", () => {
   beforeEach(() => {
-    cy.window().then((win) => {
-      win.localStorage.setItem(
-        "nomadState",
-        JSON.stringify({
-          playerQueueIds: [trackId],
-          currentlyPlayingIndex: 0,
-        })
-      );
-    });
-
     cy.intercept("GET", "/auth/profile", {
       statusCode: 200,
       body: { result: null },
@@ -46,13 +47,7 @@ describe("player continuity across navigation", () => {
 
     cy.intercept("GET", `/v1/artists/${artistSlug}*`, {
       statusCode: 200,
-      body: {
-        result: {
-          ...ARTIST_EXAMPLE,
-          urlSlug: artistSlug,
-          user: { artistLabels: [] },
-        },
-      },
+      body: { result: artist },
     });
 
     cy.intercept("GET", "/v1/settings/instanceArtist", {
@@ -62,6 +57,11 @@ describe("player continuity across navigation", () => {
 
     cy.intercept("GET", "/v1/trackGroups*", {
       statusCode: 200,
+      body: { results: [featuredRelease], total: 1 },
+    });
+
+    cy.intercept("GET", "/v1/trackGroups/topSold*", {
+      statusCode: 200,
       body: { results: [], total: 0 },
     });
 
@@ -69,22 +69,42 @@ describe("player continuity across navigation", () => {
       statusCode: 200,
       body: { results: [], total: 0 },
     });
+
+    cy.intercept("GET", "/v1/posts*", {
+      statusCode: 200,
+      body: { results: [], total: 0 },
+    });
   });
 
-  it("keeps the Player mounted across route changes", () => {
-    cy.visit("/");
+  it("keeps the Player mounted across client-side navigation", () => {
+    cy.visit("/", {
+      onBeforeLoad(win) {
+        win.localStorage.setItem(
+          "nomadState",
+          JSON.stringify({
+            playerQueueIds: [trackId],
+            currentlyPlayingIndex: 0,
+          })
+        );
+      },
+    });
+
     cy.get("#player", { timeout: 10000 })
       .invoke("attr", "data-mount-id")
       .as("originalMountId")
       .should("be.a", "string")
       .and("not.be.empty");
 
-    cy.visit(`/${artistSlug}`);
+    cy.get(`a[href="/${artistSlug}"]`).first().click();
+    cy.url().should("include", `/${artistSlug}`);
+
     cy.get("@originalMountId").then((id) => {
       cy.get("#player").should("have.attr", "data-mount-id", id);
     });
 
-    cy.visit("/");
+    cy.get('a[aria-label="Mirlo"]').first().click();
+    cy.url().should("not.include", `/${artistSlug}`);
+
     cy.get("@originalMountId").then((id) => {
       cy.get("#player").should("have.attr", "data-mount-id", id);
     });

--- a/client/cypress/support/e2e.ts
+++ b/client/cypress/support/e2e.ts
@@ -15,3 +15,10 @@
 
 // Import commands.js using ES2015 syntax:
 import "./commands";
+
+beforeEach(() => {
+  cy.intercept("POST", "/auth/refresh", {
+    statusCode: 200,
+    body: {},
+  });
+});

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -119,9 +119,9 @@ function App() {
               <Footer />
             </div>
           </div>
+          <Player />
         </>
       </ArtistColorsProvider>
-      <Player />
       <UploadProgressPanel />
     </>
   );

--- a/client/src/components/ArtistColorsProvider.tsx
+++ b/client/src/components/ArtistColorsProvider.tsx
@@ -172,9 +172,7 @@ const ArtistColorsProvider: React.FC<{ children: React.ReactElement }> = ({
       ? colors.background
       : "var(--mi-background-color)";
   const rootFg =
-    hasArtist && isDefined(colors.text)
-      ? colors.text
-      : "var(--mi-text-color)";
+    hasArtist && isDefined(colors.text) ? colors.text : "var(--mi-text-color)";
 
   return (
     <ArtistColorsContext.Provider value={hasArtist ? contextValue : null}>

--- a/client/src/components/ArtistColorsProvider.tsx
+++ b/client/src/components/ArtistColorsProvider.tsx
@@ -5,7 +5,7 @@ import { queryArtist, queryManagedArtist } from "queries";
 import React from "react";
 import { useParams } from "react-router-dom";
 
-import { isLight } from "../utils/colors";
+import { getBrightness, isLight } from "../utils/colors";
 
 const RootDiv = styled.div`
   min-height: 100vh;
@@ -39,6 +39,15 @@ export const useTransparentContainer = (): boolean => {
   return Boolean(ctx?.transparentContainer);
 };
 
+export const useIsArtistPageLight = (): boolean | null => {
+  const ctx = React.useContext(ArtistColorsContext);
+  const bg = ctx?.colors.background;
+  if (!bg) return null;
+  const brightness = getBrightness(bg);
+  if (brightness === undefined) return true;
+  return brightness > 100;
+};
+
 const isDefined = (value?: string) => Boolean(value && value !== "");
 
 export const resolveColors = (raw?: ArtistColors): ArtistColors => {
@@ -64,9 +73,7 @@ const buildVarMap = (colors: ArtistColors): Record<string, string> => {
   return map;
 };
 
-const tintStyleFor = (
-  surface: string | undefined
-): React.CSSProperties => {
+const tintStyleFor = (surface: string | undefined): React.CSSProperties => {
   if (!surface) return {};
   const light = isLight(surface);
   return {
@@ -98,10 +105,26 @@ const buttonTintStyleFor = (
   } as React.CSSProperties;
 };
 
-const ArtistColorsInner: React.FC<{
-  artistId: string;
-  children: React.ReactElement;
-}> = ({ artistId, children }) => {
+const fixedStyleFor = (surface: string | undefined): React.CSSProperties => {
+  if (!surface) return {};
+  const brightness = getBrightness(surface);
+  const pageLight = brightness === undefined ? true : brightness > 100;
+  return {
+    "--mi-fixed-bg-color": pageLight
+      ? "var(--mi-off-white)"
+      : "var(--mi-black)",
+    "--mi-fixed-fg-color": pageLight
+      ? "var(--mi-black)"
+      : "var(--mi-off-white)",
+  } as React.CSSProperties;
+};
+
+const ArtistColorsProvider: React.FC<{ children: React.ReactElement }> = ({
+  children,
+}) => {
+  const params = useParams();
+  const artistId = params?.artistId ?? "";
+
   const { data: managedArtist } = useQuery(
     queryManagedArtist(Number(artistId))
   );
@@ -117,7 +140,7 @@ const ArtistColorsInner: React.FC<{
 
   const savedTransparent = Boolean(
     managedArtist?.properties?.transparentContainer ??
-      artist?.properties?.transparentContainer
+    artist?.properties?.transparentContainer
   );
   const transparentContainer =
     transparentPreview === null ? savedTransparent : transparentPreview;
@@ -134,45 +157,42 @@ const ArtistColorsInner: React.FC<{
     [colors, transparentContainer]
   );
 
-  if (!artist && !managedArtist) {
-    return <RootDiv>{children}</RootDiv>;
-  }
+  const hasArtist = artistId !== "" && (artist || managedArtist);
 
-  const varStyle: React.CSSProperties = {
-    ...(buildVarMap(colors) as React.CSSProperties),
-    ...tintStyleFor(colors.background),
-    ...buttonTintStyleFor(colors.button),
-  };
-  const rootBg = isDefined(colors.background)
-    ? colors.background
-    : "var(--mi-background-color)";
-  const rootFg = isDefined(colors.text) ? colors.text : "var(--mi-text-color)";
+  const varStyle: React.CSSProperties = hasArtist
+    ? {
+        ...(buildVarMap(colors) as React.CSSProperties),
+        ...tintStyleFor(colors.background),
+        ...buttonTintStyleFor(colors.button),
+        ...fixedStyleFor(colors.background),
+      }
+    : {};
+  const rootBg =
+    hasArtist && isDefined(colors.background)
+      ? colors.background
+      : "var(--mi-background-color)";
+  const rootFg =
+    hasArtist && isDefined(colors.text)
+      ? colors.text
+      : "var(--mi-text-color)";
 
   return (
-    <ArtistColorsContext.Provider value={contextValue}>
+    <ArtistColorsContext.Provider value={hasArtist ? contextValue : null}>
       <RootDiv
         id="artist-colors-root"
         style={varStyle}
-        className={cx(transparentContainer && "transparent-container", css`
-          background-color: ${rootBg};
-          color: ${rootFg};
-        `)}
+        className={cx(
+          hasArtist && transparentContainer && "transparent-container",
+          css`
+            background-color: ${rootBg};
+            color: ${rootFg};
+          `
+        )}
       >
         {children}
       </RootDiv>
     </ArtistColorsContext.Provider>
   );
-};
-
-const ArtistColorsProvider: React.FC<{ children: React.ReactElement }> = ({
-  children,
-}) => {
-  const params = useParams();
-  const artistId = params?.artistId ?? "";
-  if (artistId === "") {
-    return <RootDiv>{children}</RootDiv>;
-  }
-  return <ArtistColorsInner artistId={artistId}>{children}</ArtistColorsInner>;
 };
 
 export default ArtistColorsProvider;

--- a/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/FundraisingGoal.tsx
+++ b/client/src/components/ManageArtist/ManageTrackGroup/AlbumFormComponents/FundraisingGoal.tsx
@@ -132,10 +132,18 @@ const FundraisingGoal: React.FC<{
 
   if (!fundraiser) {
     return (
-      <div>
+      <div className="flex flex-col items-start">
         <h2>{t("addFundraiser")}</h2>
-        <p>{t("addFundraiserDescription")}</p>
-        <Button type="button" onClick={onAddFundraiser} isLoading={isLoading}>
+        <small id="description-add-fundraiser">
+          {t("addFundraiserDescription")}
+        </small>
+        <Button
+          type="button"
+          onClick={onAddFundraiser}
+          isLoading={isLoading}
+          aria-describedby="description-add-fundraiser"
+          className="mt-4"
+        >
           {t("addFundraiserToThisRelease")}
         </Button>
       </div>

--- a/client/src/components/ManageArtist/ManageTrackGroup/ManageTrackTable.tsx
+++ b/client/src/components/ManageArtist/ManageTrackGroup/ManageTrackTable.tsx
@@ -137,12 +137,12 @@ export const ManageTrackTable: React.FC<{
 
   const addTracksToQueue = React.useCallback(
     (id: number) => {
-      const idx = tracks.findIndex((track) => track.id === id);
+      const ids = tracks.map((track) => track.id);
+      const startingIndex = ids.indexOf(id);
       dispatch({
         type: "startPlayingIds",
-        playerQueueIds: tracks
-          .slice(idx, tracks.length)
-          .map((track) => track.id),
+        playerQueueIds: ids,
+        startingIndex: startingIndex >= 0 ? startingIndex : 0,
       });
     },
     [dispatch, tracks]

--- a/client/src/components/Player/AudioWrapper.tsx
+++ b/client/src/components/Player/AudioWrapper.tsx
@@ -6,7 +6,7 @@ import { useGlobalStateContext } from "state/GlobalState";
 import SongTimeDisplay from "../common/SongTimeDisplay";
 
 import BuyTrackModal from "./BuyTrackModal";
-import PlayLimitNotice, { PlayLimit } from "./PlayLimitNotice";
+import { PlayLimit } from "./PlayLimitNotice";
 
 // Load react-hls-player asynchronously (the hls bundle is quite big)
 const ReactHlsPlayer = React.lazy(() => import("@mirlo/react-hls-player"));
@@ -43,7 +43,7 @@ export const AudioWrapper: React.FC<{
   setCurrentSeconds: (time: number) => void;
   currentSeconds: number;
   compact?: boolean;
-  showPlayLimit?: boolean;
+  onPlayLimitChange?: (limit: PlayLimit | null) => void;
 }> = ({
   currentTrack,
   position,
@@ -51,19 +51,41 @@ export const AudioWrapper: React.FC<{
   setCurrentSeconds,
   currentSeconds,
   compact,
-  showPlayLimit,
+  onPlayLimitChange,
 }) => {
   const [showBuyModal, setShowBuyModal] = React.useState(false);
   const [hasShownBuyModalBeenShown, setHasShownBuyModalBeenShown] =
     React.useState(false);
   const [hasOverplayedSong, setHasOverplayedSong] = React.useState(false);
-  const [playLimit, setPlayLimit] = React.useState<PlayLimit | null>(null);
+  const setPlayLimit = React.useCallback(
+    (limit: PlayLimit | null) => {
+      onPlayLimitChange?.(limit);
+    },
+    [onPlayLimitChange]
+  );
   const {
     state: { playerQueueIds, currentlyPlayingIndex, playing, looping },
     dispatch,
   } = useGlobalStateContext();
   const [mostlyListened, setMostlyListened] = React.useState(false);
   const playerRef = React.useRef<HTMLVideoElement>(null);
+  const playingRef = React.useRef(playing);
+  const showBuyModalRef = React.useRef(showBuyModal);
+  playingRef.current = playing;
+  showBuyModalRef.current = showBuyModal;
+
+  const onHLSInstance = React.useCallback(
+    (hls: Hls) => {
+      hls.once(Hls.Events.MANIFEST_PARSED, () => {
+        if (playingRef.current && !showBuyModalRef.current) {
+          playerRef.current?.play().catch(() => {
+            dispatch({ type: "setPlaying", playing: false });
+          });
+        }
+      });
+    },
+    [dispatch]
+  );
 
   const onEnded = React.useCallback(async () => {
     if (looping === "loopTrack") {
@@ -80,6 +102,7 @@ export const AudioWrapper: React.FC<{
       setHasOverplayedSong(false);
       setHasShownBuyModalBeenShown(false);
       setPlayLimit(null);
+      document.documentElement.style.setProperty("--mi-track-progress", "0%");
     }
   }, [currentTrack.id]);
 
@@ -99,6 +122,14 @@ export const AudioWrapper: React.FC<{
       }
       setHasShownBuyModalBeenShown(false);
       setCurrentSeconds(e.target.currentTime);
+      const duration = e.target.duration;
+      if (duration > 0) {
+        const percent = (e.target.currentTime / duration) * 100;
+        document.documentElement.style.setProperty(
+          "--mi-track-progress",
+          `${percent}%`
+        );
+      }
     },
     [currentTrack, mostlyListened]
   );
@@ -223,13 +254,18 @@ export const AudioWrapper: React.FC<{
     }
   }, [volume]);
 
+  React.useEffect(() => {
+    return () => {
+      document.documentElement.style.removeProperty("--mi-track-progress");
+    };
+  }, []);
+
   if (!streamUrl) {
     return null;
   }
 
   return (
     <>
-      {showPlayLimit && playLimit && <PlayLimitNotice playLimit={playLimit} />}
       <BuyTrackModal
         showBuyModal={showBuyModal}
         setShowBuyModal={setShowBuyModal}
@@ -244,6 +280,7 @@ export const AudioWrapper: React.FC<{
           // controls={true}
           // @ts-ignore
           hlsConfig={hlsConfig}
+          getHLSInstance={onHLSInstance}
           onError={(event: any, data: any) => {
             if (data.details === Hls.ErrorDetails.MANIFEST_LOAD_ERROR) {
               if (data.networkDetails?.responseText) {

--- a/client/src/components/Player/AudioWrapper.tsx
+++ b/client/src/components/Player/AudioWrapper.tsx
@@ -57,12 +57,6 @@ export const AudioWrapper: React.FC<{
   const [hasShownBuyModalBeenShown, setHasShownBuyModalBeenShown] =
     React.useState(false);
   const [hasOverplayedSong, setHasOverplayedSong] = React.useState(false);
-  const setPlayLimit = React.useCallback(
-    (limit: PlayLimit | null) => {
-      onPlayLimitChange?.(limit);
-    },
-    [onPlayLimitChange]
-  );
   const {
     state: { playerQueueIds, currentlyPlayingIndex, playing, looping },
     dispatch,
@@ -71,8 +65,12 @@ export const AudioWrapper: React.FC<{
   const playerRef = React.useRef<HTMLVideoElement>(null);
   const playingRef = React.useRef(playing);
   const showBuyModalRef = React.useRef(showBuyModal);
-  playingRef.current = playing;
-  showBuyModalRef.current = showBuyModal;
+  React.useEffect(() => {
+    playingRef.current = playing;
+  }, [playing]);
+  React.useEffect(() => {
+    showBuyModalRef.current = showBuyModal;
+  }, [showBuyModal]);
 
   const onHLSInstance = React.useCallback(
     (hls: Hls) => {
@@ -101,8 +99,7 @@ export const AudioWrapper: React.FC<{
       setMostlyListened(false);
       setHasOverplayedSong(false);
       setHasShownBuyModalBeenShown(false);
-      setPlayLimit(null);
-      document.documentElement.style.setProperty("--mi-track-progress", "0%");
+      onPlayLimitChange?.(null);
     }
   }, [currentTrack.id]);
 
@@ -115,21 +112,13 @@ export const AudioWrapper: React.FC<{
           const resp = await api.get<{ playLimit: PlayLimit | null }>(
             `tracks/${currentTrack.id}/trackPlay`
           );
-          setPlayLimit(resp.result?.playLimit ?? null);
+          onPlayLimitChange?.(resp.result?.playLimit ?? null);
         } catch (e) {
           console.error(e);
         }
       }
       setHasShownBuyModalBeenShown(false);
       setCurrentSeconds(e.target.currentTime);
-      const duration = e.target.duration;
-      if (duration > 0) {
-        const percent = (e.target.currentTime / duration) * 100;
-        document.documentElement.style.setProperty(
-          "--mi-track-progress",
-          `${percent}%`
-        );
-      }
     },
     [currentTrack, mostlyListened]
   );
@@ -253,12 +242,6 @@ export const AudioWrapper: React.FC<{
       playerRef.current.volume = volume;
     }
   }, [volume]);
-
-  React.useEffect(() => {
-    return () => {
-      document.documentElement.style.removeProperty("--mi-track-progress");
-    };
-  }, []);
 
   if (!streamUrl) {
     return null;

--- a/client/src/components/Player/PlayLimitNotice.tsx
+++ b/client/src/components/Player/PlayLimitNotice.tsx
@@ -1,10 +1,5 @@
-import TipArtist from "components/common/TipArtist";
-import PurchaseOrDownloadAlbum from "components/TrackGroup/PurchaseOrDownloadAlbumModal";
-import Wishlist from "components/TrackGroup/Wishlist";
 import React from "react";
 import { useTranslation } from "react-i18next";
-
-import useCurrentTrackHook from "./useCurrentTrackHook";
 
 export type PlayLimit = {
   remaining: number;
@@ -15,55 +10,38 @@ export type PlayLimit = {
 // Show the soft "free plays left" notice once the listener is within this
 // many plays of the cap — gives them a heads-up without nagging on the very
 // first listen (per #1760's discussion).
-const PLAYS_REMAINING_NOTICE_THRESHOLD = 2;
+export const PLAYS_REMAINING_NOTICE_THRESHOLD = 2;
 
-const PlayingTrack: React.FC = () => {
-  const { currentTrack, isLoading } = useCurrentTrackHook();
-
-  if (!currentTrack || isLoading) {
-    return null;
-  }
-
-  return (
-    <div className="flex gap-1 mr-2">
-      <Wishlist trackGroup={{ id: currentTrack.trackGroupId }} fixed />
-      {currentTrack.trackGroup.artistId && (
-        <TipArtist artistId={currentTrack.trackGroup.artistId} fixed />
-      )}
-      {currentTrack.trackGroup && (
-        <PurchaseOrDownloadAlbum trackGroup={currentTrack.trackGroup} fixed />
-      )}
-    </div>
-  );
-};
-
-const PlayLimitNotice: React.FC<{ playLimit: PlayLimit }> = ({ playLimit }) => {
+export const PlayLimitText: React.FC<{
+  playLimit: PlayLimit;
+  hideLastPlay?: boolean;
+  short?: boolean;
+}> = ({ playLimit, hideLastPlay, short }) => {
   const { t } = useTranslation("translation", { keyPrefix: "player" });
 
-  return (
-    <>
-      {playLimit.remaining === 0 && (
-        <small
-          data-cy="play-limit-exceeded-notice"
-          className="block text-center py-1 px-2 opacity-[0.85] [color:var(--mi-error-text-color,inherit)]"
-        >
-          {t("thisIsYourLastPlay")}
-        </small>
-      )}
-      {playLimit.remaining > 0 &&
-        playLimit.remaining <= PLAYS_REMAINING_NOTICE_THRESHOLD && (
-          <small
-            data-cy="plays-remaining-notice"
-            className="block text-center py-1 px-2 opacity-[0.85] [color:var(--mi-warning-text-color,inherit)]"
-          >
-            {t("playsRemaining", {
-              count: playLimit.remaining,
-            })}
-          </small>
-        )}
-      <PlayingTrack />
-    </>
-  );
+  if (playLimit.remaining === 0) {
+    if (hideLastPlay) return null;
+    return (
+      <small
+        data-cy="play-limit-exceeded-notice"
+        className="text-[0.65rem] leading-none whitespace-nowrap opacity-80"
+      >
+        {t("thisIsYourLastPlay")}
+      </small>
+    );
+  }
+  if (playLimit.remaining <= PLAYS_REMAINING_NOTICE_THRESHOLD) {
+    return (
+      <small
+        data-cy="plays-remaining-notice"
+        className="text-[0.65rem] leading-none whitespace-nowrap opacity-80"
+      >
+        {short && <span aria-hidden>{"· "}</span>}
+        {t(short ? "playsRemainingShort" : "playsRemaining", {
+          count: playLimit.remaining,
+        })}
+      </small>
+    );
+  }
+  return null;
 };
-
-export default PlayLimitNotice;

--- a/client/src/components/Player/PlayerActions.tsx
+++ b/client/src/components/Player/PlayerActions.tsx
@@ -1,0 +1,44 @@
+import { css } from "@emotion/css";
+import TipArtist from "components/common/TipArtist";
+import PurchaseOrDownloadAlbum from "components/TrackGroup/PurchaseOrDownloadAlbumModal";
+import Wishlist from "components/TrackGroup/Wishlist";
+import React from "react";
+import { useGlobalStateContext } from "state/GlobalState";
+
+import useCurrentTrackHook from "./useCurrentTrackHook";
+
+const PlayerActions: React.FC = () => {
+  const { state } = useGlobalStateContext();
+  const { currentTrack, isLoading } = useCurrentTrackHook();
+
+  if (!state.playing) {
+    return null;
+  }
+
+  if (!currentTrack || isLoading) {
+    return null;
+  }
+
+  return (
+    <div
+      className={css`
+        z-index: 999999;
+        bottom: 80px;
+        right: 1rem;
+        position: fixed;
+        display: flex;
+        gap: 0.5rem;
+      `}
+    >
+      <Wishlist trackGroup={{ id: currentTrack.trackGroupId }} fixed />
+      {currentTrack.trackGroup.artistId && (
+        <TipArtist artistId={currentTrack.trackGroup.artistId} fixed />
+      )}
+      {currentTrack.trackGroup && (
+        <PurchaseOrDownloadAlbum trackGroup={currentTrack.trackGroup} fixed />
+      )}
+    </div>
+  );
+};
+
+export default PlayerActions;

--- a/client/src/components/Player/PlayingTrackDetails.tsx
+++ b/client/src/components/Player/PlayingTrackDetails.tsx
@@ -1,8 +1,9 @@
 import { css } from "@emotion/css";
 import ImageWithPlaceholder from "components/common/ImageWithPlaceholder";
+import { TrackTitleContent } from "components/Widget/TrackTitleContent";
 import React from "react";
 import { Link } from "react-router-dom";
-import { getReleaseUrl, getTrackUrl } from "utils/artist";
+import { getTrackUrl } from "utils/artist";
 
 import { bp } from "../../constants";
 
@@ -52,9 +53,10 @@ export const TrackArtistLinks: React.FC<{
   ));
 };
 
-const PlayingTrackDetails: React.FC<{ currentTrack: Track }> = ({
-  currentTrack,
-}) => {
+const PlayingTrackDetails: React.FC<{
+  currentTrack: Track;
+  byLineEnd?: React.ReactNode;
+}> = ({ currentTrack, byLineEnd }) => {
   return (
     <div
       className={css`
@@ -97,67 +99,27 @@ const PlayingTrackDetails: React.FC<{ currentTrack: Track }> = ({
           flex: 80%;
           display: flex;
           flex-direction: column;
+          min-width: 0;
           @media (max-width: ${bp.small}px) {
             max-width: 70%;
             flex: 70%;
           }
         `}
       >
-        <div
-          className={css`
-            overflow: hidden;
-            white-space: nowrap;
-            text-overflow: ellipsis;
-            font-size: var(--mi-font-size-normal);
-          `}
-          id="player-track-title"
-          title={currentTrack?.title}
-        >
-          <Link
-            to={getTrackUrl(
-              currentTrack.trackGroup.artist,
-              currentTrack.trackGroup,
-              currentTrack
-            )}
-          >
-            {currentTrack?.title}
-          </Link>
-        </div>
-        {currentTrack?.trackGroup && (
-          <>
-            <div
-              className={css`
-                opacity: 0.6;
-                color: grey;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-              `}
-              title={currentTrack.trackGroup.title}
-            >
-              {currentTrack.trackGroup.artist && (
-                <Link
-                  to={getReleaseUrl(
-                    currentTrack.trackGroup.artist,
-                    currentTrack.trackGroup
-                  )}
-                  id="player-trackGroup-title"
-                >
-                  {currentTrack.trackGroup.title}
-                </Link>
-              )}
-            </div>
-            <div
-              className={css`
-                overflow: hidden;
-                white-space: nowrap;
-                text-overflow: ellipsis;
-              `}
-            >
-              <TrackArtistLinks track={currentTrack} />
-            </div>
-          </>
-        )}
+        <TrackTitleContent
+          track={currentTrack}
+          embeddedInMirlo={false}
+          combineFromAndBy
+          useTrackArtistLinks
+          titleLinkTo={getTrackUrl(
+            currentTrack.trackGroup.artist,
+            currentTrack.trackGroup,
+            currentTrack
+          )}
+          byLineEnd={byLineEnd}
+          foldByLineAtSm
+          compactTitle
+        />
       </div>
     </div>
   );

--- a/client/src/components/Player/VolumeControl.tsx
+++ b/client/src/components/Player/VolumeControl.tsx
@@ -1,8 +1,9 @@
 import { css } from "@emotion/css";
 import Button from "components/common/Button";
-import { FaVolumeDown, FaVolumeMute, FaVolumeUp } from "react-icons/fa";
-import { bp } from "../../constants";
+import { FaVolumeMute } from "react-icons/fa";
 import { FaVolumeHigh } from "react-icons/fa6";
+
+import { bp } from "../../constants";
 
 export const VolumeControl: React.FC<{
   setVolume: React.Dispatch<React.SetStateAction<number>>;
@@ -62,15 +63,11 @@ export const VolumeControl: React.FC<{
             overflow: none;
             transition: 0.1s width;
             width: ${volume * 100}%;
-            background: var(--mi-white);
+            background: var(--mi-fixed-fg-color);
             pointer-events: none;
             border-radius: 0.5rem;
             position: absolute;
             top: 0.4rem;
-
-            @media (prefers-color-scheme: light) {
-              background: var(--mi-black);
-            }
           `}
         />
         <div
@@ -78,16 +75,15 @@ export const VolumeControl: React.FC<{
             height: 0.25rem;
             overflow: none;
             width: 100%;
-            background: var(--mi-white);
+            background: color-mix(
+              in srgb,
+              var(--mi-fixed-fg-color) 25%,
+              transparent
+            );
             pointer-events: none;
             position: absolute;
             top: 0.4rem;
             border-radius: 0.5rem;
-            background: var(--mi-lighten-x-background-color);
-
-            @media (prefers-color-scheme: light) {
-              background: var(--mi-darken-x-background-color);
-            }
           `}
         />
       </div>

--- a/client/src/components/Player/index.tsx
+++ b/client/src/components/Player/index.tsx
@@ -47,7 +47,6 @@ const Player = () => {
   const { currentTrack, isLoading } = useCurrentTrackHook();
   const [currentSeconds, setCurrentSeconds] = React.useState(0);
   const [playLimit, setPlayLimit] = React.useState<PlayLimit | null>(null);
-  // Cypress reads data-mount-id (stable per instance) to catch Player remounts on navigation.
   const mountId = React.useId();
   const isArtistPageLight = useIsArtistPageLight();
   const tone =
@@ -120,162 +119,159 @@ const Player = () => {
           @media (max-width: ${bp.small}px) {
             flex-direction: column;
           }
-      `}
-      id="player"
-      data-mount-id={mountId}
-    >
-      <div
-        className={css`
-          width: 100%;
-          margin: auto;
-          background-color: var(--mi-fixed-bg-color);
-          color: var(--mi-fixed-fg-color);
         `}
+        id="player"
+        data-mount-id={mountId}
       >
-        {currentTrack && isTrackOwnedOrPreview(currentTrack, user) && (
-          <AudioWrapper
-            currentTrack={currentTrack}
-            position="absolute"
-            volume={volume}
-            setCurrentSeconds={setCurrentSeconds}
-            currentSeconds={currentSeconds}
-            onPlayLimitChange={setPlayLimit}
-          />
-        )}
         <div
           className={css`
-            margin: 0 auto;
-            display: flex;
-            align-items: center;
-            flex-grow: 1;
-            paddin-right: 0.5rem;
-            font-size: var(--mi-font-size-small);
-            justify-content: space-between;
-
-            @media (max-width: ${bp.small}px) {
-              font-size: var(--mi-font-size-xsmall);
-              flex-grow: initial;
-              justify-content: space-between;
-            }
-
-            a {
-              color: var(--player-link);
-            }
+            width: 100%;
+            margin: auto;
+            background-color: var(--mi-fixed-bg-color);
+            color: var(--mi-fixed-fg-color);
           `}
         >
-          <PlayingTrackDetails
-            currentTrack={currentTrack}
-            byLineEnd={
-              <>
-                <ElapsedTime
-                  current={currentSeconds}
-                  total={currentTrack.audio?.duration}
-                />
-                {playLimit && (
-                  <PlayLimitText playLimit={playLimit} hideLastPlay short />
-                )}
-              </>
-            }
-          />
-
+          {currentTrack && isTrackOwnedOrPreview(currentTrack, user) && (
+            <AudioWrapper
+              currentTrack={currentTrack}
+              position="absolute"
+              volume={volume}
+              setCurrentSeconds={setCurrentSeconds}
+              currentSeconds={currentSeconds}
+              onPlayLimitChange={setPlayLimit}
+            />
+          )}
           <div
             className={css`
-              display: inline-flex;
+              margin: 0 auto;
+              display: flex;
               align-items: center;
-              button {
-                margin-right: 0.25rem;
-              }
+              flex-grow: 1;
+              paddin-right: 0.5rem;
+              font-size: var(--mi-font-size-small);
+              justify-content: space-between;
 
               @media (max-width: ${bp.small}px) {
-                .tip-artist,
-                .wishlist {
-                  display: none;
-                }
+                font-size: var(--mi-font-size-xsmall);
+                flex-grow: initial;
+                justify-content: space-between;
+              }
+
+              a {
+                color: var(--player-link);
               }
             `}
           >
-            {/* The invisible spacers above and below ElapsedTime keep the
-                column symmetric so the timer stays vertically centered in the
-                parent flex row whether or not the play-limit badge is showing. */}
-            <div className="max-sm:hidden! flex flex-col items-end shrink-0 mr-4">
-              <small
-                aria-hidden
-                className="text-[0.65rem] leading-none invisible"
-              >
-                .
-              </small>
-              <span className="whitespace-nowrap inline-block min-w-12 text-right">
-                <ElapsedTime
-                  current={currentSeconds}
-                  total={currentTrack.audio?.duration}
-                />
-              </span>
-              {playLimit ? (
-                <PlayLimitText playLimit={playLimit} />
-              ) : (
+            <PlayingTrackDetails
+              currentTrack={currentTrack}
+              byLineEnd={
+                <>
+                  <ElapsedTime
+                    current={currentSeconds}
+                    total={currentTrack.audio?.duration}
+                  />
+                  {playLimit && (
+                    <PlayLimitText playLimit={playLimit} hideLastPlay short />
+                  )}
+                </>
+              }
+            />
+
+            <div
+              className={css`
+                display: inline-flex;
+                align-items: center;
+                button {
+                  margin-right: 0.25rem;
+                }
+
+                @media (max-width: ${bp.small}px) {
+                  .tip-artist,
+                  .wishlist {
+                    display: none;
+                  }
+                }
+              `}
+            >
+              <div className="max-sm:hidden! flex flex-col items-end shrink-0 mr-4">
                 <small
                   aria-hidden
                   className="text-[0.65rem] leading-none invisible"
                 >
                   .
                 </small>
-              )}
+                <span className="whitespace-nowrap inline-block min-w-12 text-right">
+                  <ElapsedTime
+                    current={currentSeconds}
+                    total={currentTrack.audio?.duration}
+                  />
+                </span>
+                {playLimit ? (
+                  <PlayLimitText playLimit={playLimit} />
+                ) : (
+                  <small
+                    aria-hidden
+                    className="text-[0.65rem] leading-none invisible"
+                  >
+                    .
+                  </small>
+                )}
+              </div>
+
+              <ControlWrapper>
+                <span
+                  className={css`
+                    display: flex;
+                    align-items: center;
+
+                    @media (max-width: ${bp.small}px) {
+                      display: none;
+                    }
+
+                    button {
+                      color: var(--mi-fixed-fg-color);
+                      border: var(--player-control-border);
+                    }
+                  `}
+                >
+                  <LoopButton />
+
+                  <ShuffleButton />
+                </span>
+                <div
+                  className={css`
+                    button svg {
+                      fill: var(--player-icon);
+                    }
+                  `}
+                >
+                  <PreviousButton />
+                </div>
+                <PlayControlButton playerButton />
+                <div
+                  className={css`
+                    button svg {
+                      fill: var(--player-icon);
+                    }
+                  `}
+                >
+                  <NextButton />
+                </div>
+                <div
+                  className={css`
+                    button svg {
+                      fill: var(--player-icon);
+                    }
+                  `}
+                >
+                  <VolumeControl setVolume={setVolume} volume={volume} />
+                </div>
+              </ControlWrapper>
             </div>
-
-            <ControlWrapper>
-              <span
-                className={css`
-                  display: flex;
-                  align-items: center;
-
-                  @media (max-width: ${bp.small}px) {
-                    display: none;
-                  }
-
-                  button {
-                    color: var(--mi-fixed-fg-color);
-                    border: var(--player-control-border);
-                  }
-                `}
-              >
-                <LoopButton />
-
-                <ShuffleButton />
-              </span>
-              <div
-                className={css`
-                  button svg {
-                    fill: var(--player-icon);
-                  }
-                `}
-              >
-                <PreviousButton />
-              </div>
-              <PlayControlButton playerButton />
-              <div
-                className={css`
-                  button svg {
-                    fill: var(--player-icon);
-                  }
-                `}
-              >
-                <NextButton />
-              </div>
-              <div
-                className={css`
-                  button svg {
-                    fill: var(--player-icon);
-                  }
-                `}
-              >
-                <VolumeControl setVolume={setVolume} volume={volume} />
-              </div>
-            </ControlWrapper>
           </div>
+          {!currentTrack && isLoading && <Spinner size="small" />}
         </div>
-        {!currentTrack && isLoading && <Spinner size="small" />}
       </div>
-    </div>
     </div>,
     document.body
   );

--- a/client/src/components/Player/index.tsx
+++ b/client/src/components/Player/index.tsx
@@ -2,21 +2,26 @@ import { css } from "@emotion/css";
 import styled from "@emotion/styled";
 import { isEmpty } from "lodash";
 import React from "react";
+import { createPortal } from "react-dom";
 import { useAuthContext } from "state/AuthContext";
 import { useGlobalStateContext } from "state/GlobalState";
 import { useBroadcastPlayerSync } from "utils/playerSync";
-import { fmtMSS, isTrackOwnedOrPreview } from "utils/tracks";
+import { isTrackOwnedOrPreview } from "utils/tracks";
 
 import { bp } from "../../constants";
+import { useIsArtistPageLight } from "../ArtistColorsProvider";
 import LoopButton from "../common/LoopButton";
 import NextButton from "../common/NextButton";
 import { PlayControlButton } from "../common/PlayControlButton";
 import PreviousButton from "../common/PreviousButton";
 import ShuffleButton from "../common/ShuffleButton";
 import Spinner from "../common/Spinner";
+import { ElapsedTime } from "../Widget/utils";
 
 import { AudioWrapper } from "./AudioWrapper";
+import PlayerActions from "./PlayerActions";
 import PlayingTrackDetails from "./PlayingTrackDetails";
+import { PlayLimit, PlayLimitText } from "./PlayLimitNotice";
 import useCurrentTrackHook from "./useCurrentTrackHook";
 import { VolumeControl } from "./VolumeControl";
 
@@ -41,6 +46,16 @@ const Player = () => {
   const [volume, setVolume] = React.useState(1);
   const { currentTrack, isLoading } = useCurrentTrackHook();
   const [currentSeconds, setCurrentSeconds] = React.useState(0);
+  const [playLimit, setPlayLimit] = React.useState<PlayLimit | null>(null);
+  // Cypress reads data-mount-id (stable per instance) to catch Player remounts on navigation.
+  const mountId = React.useId();
+  const isArtistPageLight = useIsArtistPageLight();
+  const tone =
+    isArtistPageLight === true
+      ? "light"
+      : isArtistPageLight === false
+        ? "dark"
+        : undefined;
 
   useBroadcastPlayerSync(
     React.useMemo(
@@ -68,37 +83,53 @@ const Player = () => {
     return null;
   }
 
-  return (
+  return createPortal(
     <div
+      data-tone={tone}
       className={css`
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        position: fixed;
-        width: 100%;
-        z-index: 10;
-        bottom: 0;
-        filter: drop-shadow(0 0 0.1rem rgba(0, 0, 0, 0.3));
+        --mi-fixed-bg-color: var(--mi-off-white);
+        --mi-fixed-fg-color: var(--mi-black);
 
-        background-color: var(--mi-darken-x-background-color);
-
-        @media (max-width: ${bp.small}px) {
-          flex-direction: column;
+        &[data-tone="dark"] {
+          --mi-fixed-bg-color: var(--mi-black);
+          --mi-fixed-fg-color: var(--mi-off-white);
         }
       `}
-      id="player"
     >
+      <PlayerActions />
       <div
         className={css`
           display: flex;
-          align-items: center;
-          justify-content: flex-end;
-          flex-grow: 1;
+          flex-direction: column;
+          justify-content: space-between;
+          position: fixed;
+          width: 100%;
+          z-index: 10;
+          bottom: 0;
+          filter: drop-shadow(
+            0 0 0.1rem
+              color-mix(in srgb, var(--mi-fixed-fg-color) 30%, transparent)
+          );
+
+          background-color: var(--mi-darken-x-background-color);
+
+          --player-link: var(--mi-fixed-fg-color);
+          --player-icon: currentColor;
+          --player-control-border: none;
 
           @media (max-width: ${bp.small}px) {
-            width: 100%;
-            flex-grow: initial;
+            flex-direction: column;
           }
+      `}
+      id="player"
+      data-mount-id={mountId}
+    >
+      <div
+        className={css`
+          width: 100%;
+          margin: auto;
+          background-color: var(--mi-fixed-bg-color);
+          color: var(--mi-fixed-fg-color);
         `}
       >
         {currentTrack && isTrackOwnedOrPreview(currentTrack, user) && (
@@ -108,24 +139,9 @@ const Player = () => {
             volume={volume}
             setCurrentSeconds={setCurrentSeconds}
             currentSeconds={currentSeconds}
-            showPlayLimit
+            onPlayLimitChange={setPlayLimit}
           />
         )}
-      </div>
-
-      <div
-        className={css`
-          width: 100%;
-          margin: auto;
-          background-color: var(--mi-off-white);
-          color: var(--mi-black);
-
-          @media (prefers-color-scheme: dark) {
-            background-color: var(--mi-black);
-            color: var(--mi-off-white);
-          }
-        `}
-      >
         <div
           className={css`
             margin: 0 auto;
@@ -142,14 +158,25 @@ const Player = () => {
               justify-content: space-between;
             }
 
-            @media (prefers-color-scheme: dark) {
-              a {
-                color: lightgrey;
-              }
+            a {
+              color: var(--player-link);
             }
           `}
         >
-          <PlayingTrackDetails currentTrack={currentTrack} />
+          <PlayingTrackDetails
+            currentTrack={currentTrack}
+            byLineEnd={
+              <>
+                <ElapsedTime
+                  current={currentSeconds}
+                  total={currentTrack.audio?.duration}
+                />
+                {playLimit && (
+                  <PlayLimitText playLimit={playLimit} hideLastPlay short />
+                )}
+              </>
+            }
+          />
 
           <div
             className={css`
@@ -167,16 +194,33 @@ const Player = () => {
               }
             `}
           >
-            <span
-              className={css`
-                display: inline-block;
-                min-width: 3rem;
-                text-align: right;
-                margin-right: 1rem;
-              `}
-            >
-              {fmtMSS(currentSeconds)}
-            </span>
+            {/* The invisible spacers above and below ElapsedTime keep the
+                column symmetric so the timer stays vertically centered in the
+                parent flex row whether or not the play-limit badge is showing. */}
+            <div className="max-sm:hidden! flex flex-col items-end shrink-0 mr-4">
+              <small
+                aria-hidden
+                className="text-[0.65rem] leading-none invisible"
+              >
+                .
+              </small>
+              <span className="whitespace-nowrap inline-block min-w-12 text-right">
+                <ElapsedTime
+                  current={currentSeconds}
+                  total={currentTrack.audio?.duration}
+                />
+              </span>
+              {playLimit ? (
+                <PlayLimitText playLimit={playLimit} />
+              ) : (
+                <small
+                  aria-hidden
+                  className="text-[0.65rem] leading-none invisible"
+                >
+                  .
+                </small>
+              )}
+            </div>
 
             <ControlWrapper>
               <span
@@ -188,11 +232,9 @@ const Player = () => {
                     display: none;
                   }
 
-                  @media (prefers-color-scheme: dark) {
-                    button {
-                      color: lightgrey;
-                      border: solid 1px grey;
-                    }
+                  button {
+                    color: var(--mi-fixed-fg-color);
+                    border: var(--player-control-border);
                   }
                 `}
               >
@@ -202,12 +244,8 @@ const Player = () => {
               </span>
               <div
                 className={css`
-                  @media (prefers-color-scheme: dark) {
-                    button {
-                      svg {
-                        fill: lightgrey;
-                      }
-                    }
+                  button svg {
+                    fill: var(--player-icon);
                   }
                 `}
               >
@@ -216,12 +254,8 @@ const Player = () => {
               <PlayControlButton playerButton />
               <div
                 className={css`
-                  @media (prefers-color-scheme: dark) {
-                    button {
-                      svg {
-                        fill: lightgrey;
-                      }
-                    }
+                  button svg {
+                    fill: var(--player-icon);
                   }
                 `}
               >
@@ -229,12 +263,8 @@ const Player = () => {
               </div>
               <div
                 className={css`
-                  @media (prefers-color-scheme: dark) {
-                    button {
-                      svg {
-                        fill: lightgrey;
-                      }
-                    }
+                  button svg {
+                    fill: var(--player-icon);
                   }
                 `}
               >
@@ -246,6 +276,8 @@ const Player = () => {
         {!currentTrack && isLoading && <Spinner size="small" />}
       </div>
     </div>
+    </div>,
+    document.body
   );
 };
 

--- a/client/src/components/TrackGroup/PurchaseAlbumModal.tsx
+++ b/client/src/components/TrackGroup/PurchaseAlbumModal.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/css";
 import { useQuery } from "@tanstack/react-query";
 import { ArtistButton } from "components/Artist/ArtistButtons";
 import CurrencyCoinIcon from "components/common/CurrencyCoinIcon";
+import { FixedButton } from "components/common/FixedButton";
 import Modal from "components/common/Modal";
 import BuyTrackGroup from "components/TrackGroup/BuyTrackGroup";
 import { queryArtist } from "queries";
@@ -64,14 +65,13 @@ const PurchaseAlbumModal: React.FC<{
     : "buyingTrackGroup";
 
   const button = fixed ? (
-    <ArtistButton
+    <FixedButton
       onClick={() => setIsPurchasingAlbum(true)}
       rounded
-      variant="pill"
       size="compact"
     >
       {t(preOrderOrBuyText)}
-    </ArtistButton>
+    </FixedButton>
   ) : (
     <ArtistButton
       type="button"

--- a/client/src/components/TrackGroup/Wishlist.tsx
+++ b/client/src/components/TrackGroup/Wishlist.tsx
@@ -40,7 +40,6 @@ const Wishlist: React.FC<{
         className="wishlist"
         title={buttonLabel}
         rounded
-        variant="pill"
         size="compact"
         endIcon={isInWishlist ? <IoIosHeart /> : <IoIosHeartEmpty />}
       />

--- a/client/src/components/Widget/TrackTitleContent.tsx
+++ b/client/src/components/Widget/TrackTitleContent.tsx
@@ -76,10 +76,10 @@ export const TrackTitleContent: React.FC<{
   return (
     <>
       <div
-        className={`font-bold leading-tight truncate break-normal ${
+        className={`leading-tight truncate break-normal ${
           compactTitle
-            ? "text-base max-sm:text-sm max-xs:text-xs"
-            : "text-lg max-sm:text-base max-xs:text-sm"
+            ? "text-base max-sm:text-sm max-xs:text-xs font-semibold"
+            : "text-lg max-sm:text-base max-xs:text-sm font-bold"
         }`}
       >
         {titleNode}

--- a/client/src/components/Widget/TrackTitleContent.tsx
+++ b/client/src/components/Widget/TrackTitleContent.tsx
@@ -1,6 +1,7 @@
 import { TrackArtistLinks } from "components/Player/PlayingTrackDetails";
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import { getArtistUrl, getReleaseUrl } from "utils/artist";
 
 import { WidgetLink } from "./utils";
@@ -10,7 +11,20 @@ export const TrackTitleContent: React.FC<{
   embeddedInMirlo: boolean;
   combineFromAndBy?: boolean;
   byLineEnd?: React.ReactNode;
-}> = ({ track, embeddedInMirlo, combineFromAndBy, byLineEnd }) => {
+  titleLinkTo?: string;
+  useTrackArtistLinks?: boolean;
+  foldByLineAtSm?: boolean;
+  compactTitle?: boolean;
+}> = ({
+  track,
+  embeddedInMirlo,
+  combineFromAndBy,
+  byLineEnd,
+  titleLinkTo,
+  useTrackArtistLinks,
+  foldByLineAtSm,
+  compactTitle,
+}) => {
   const { t } = useTranslation("translation", { keyPrefix: "trackDetails" });
   const { t: tTrackGroup } = useTranslation("translation", {
     keyPrefix: "trackGroupDetails",
@@ -32,6 +46,8 @@ export const TrackTitleContent: React.FC<{
   const artistLink = track.trackGroup.artist ? (
     embeddedInMirlo ? (
       <TrackArtistLinks track={track} target="_blank" fullLink />
+    ) : useTrackArtistLinks ? (
+      <TrackArtistLinks track={track} />
     ) : (
       <WidgetLink
         to={getArtistUrl(track.trackGroup.artist)}
@@ -42,17 +58,35 @@ export const TrackTitleContent: React.FC<{
     )
   ) : null;
 
-  const byLineWrapperClass =
-    "text-sm leading-normal break-normal max-sm:text-xs max-xs:text-[0.65rem] [&_a:hover]:underline! flex items-center justify-between gap-2 max-xs:flex-col max-xs:items-start max-xs:gap-0";
+  const titleNode = titleLinkTo ? (
+    <Link to={titleLinkTo}>{track.title ?? ""}</Link>
+  ) : (
+    (track.title ?? "")
+  );
+
+  const byLineWrapperBase =
+    "text-sm leading-normal break-normal max-sm:text-xs max-xs:text-[0.65rem] [&_a:hover]:underline! flex items-center justify-between gap-2";
+  const byLineFoldClasses = foldByLineAtSm
+    ? "max-sm:flex-col max-sm:items-start max-sm:gap-0"
+    : "max-xs:flex-col max-xs:items-start max-xs:gap-0";
+  const byLineWrapperClass = `${byLineWrapperBase} ${byLineFoldClasses}`;
+
+  const byLineTruncateClass = `flex-1 min-w-0 truncate ${foldByLineAtSm ? "max-sm:w-full" : "max-xs:w-full"}`;
 
   return (
     <>
-      <div className="text-lg font-bold leading-tight truncate break-normal max-sm:text-base max-xs:text-sm">
-        {track.title ?? ""}
+      <div
+        className={`font-bold leading-tight truncate break-normal ${
+          compactTitle
+            ? "text-base max-sm:text-sm max-xs:text-xs"
+            : "text-lg max-sm:text-base max-xs:text-sm"
+        }`}
+      >
+        {titleNode}
       </div>
       {combineFromAndBy ? (
         <div className={byLineWrapperClass}>
-          <span className="flex-1 min-w-0 truncate">
+          <span className={byLineTruncateClass}>
             <span className="opacity-60">{t("from")}</span> {trackGroupLink}
             {artistLink && (
               <>
@@ -62,7 +96,7 @@ export const TrackTitleContent: React.FC<{
             )}
           </span>
           {byLineEnd && (
-            <div className="hidden max-sm:flex shrink-0 items-center gap-1 ">
+            <div className="hidden max-sm:flex shrink-0 items-center gap-1">
               {byLineEnd}
             </div>
           )}
@@ -73,7 +107,7 @@ export const TrackTitleContent: React.FC<{
             <span className="opacity-60">{t("from")}</span> {trackGroupLink}
           </div>
           <div className={byLineWrapperClass}>
-            <span className="flex-1 min-w-0 truncate">
+            <span className={byLineTruncateClass}>
               <span className="opacity-60">{t("by")}</span> {artistLink}
             </span>
             {byLineEnd && (

--- a/client/src/components/common/ArtistHeaderSection.tsx
+++ b/client/src/components/common/ArtistHeaderSection.tsx
@@ -197,7 +197,9 @@ const ArtistHeaderSection: React.FC<{
                           <span className="max-md:hidden text-(--mi-button-color)">
                             {artist.properties?.titles?.groupName ?? t("label")}
                           </span>
-                          <span className="max-md:hidden opacity-50">-</span>
+                          {artist.properties?.titles?.groupName && (
+                            <span className="max-md:hidden opacity-50">-</span>
+                          )}
                         </>
                       )}
                       <ArtistFormLocation
@@ -256,7 +258,7 @@ const ArtistHeaderSection: React.FC<{
             `}
           />
         )}
-        <div className="w-full flex flex-row items-center justify-end py-2 max-md:border-t max-md:border-(--mi-button-color)/50">
+        <div className="w-full flex flex-row items-center justify-end py-2 max-md:py-1 max-md:border-t max-md:border-(--mi-button-color)/50">
           <ArtistHeaderActionsStrip
             artist={artist}
             isManage={!!isManage}

--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -45,25 +45,10 @@ const CustomButton = styled.button<Sizable>(
       width: 2rem;
 
       @media screen and (max-width: ${bp.medium}px) {
-      
-      ${props.smallIcon ? "height: 1.2rem !important; width: 1.2rem !important; svg { width: 0.6rem; }; padding: .6rem !important;" : ""}
-      
-      }      
-
-      @media screen and (max-width: ${bp.small}px) {
-      
-
-        ${
-          size === "compact"
-            ? `
-            height: 1.7rem; 
-            padding: .9rem .5rem;
-            svg {
-              font-size: 1.2rem !important;
-            }
-            `
-            : ""
-        };
+        width: var(--mi-touch-target-min);
+        height: var(--mi-touch-target-min);
+        padding: 0;
+        ${props.smallIcon ? "svg { width: 0.6rem; };" : ""}
       }
     `
       : "";
@@ -93,9 +78,10 @@ const CustomButton = styled.button<Sizable>(
       ? `
         @media screen and (max-width: ${bp.medium}px) {
           border-radius: 100%;
-          height: auto;
+          width: var(--mi-touch-target-min);
+          height: var(--mi-touch-target-min);
           min-width: auto;
-          padding: .7rem !important;
+          padding: 0 !important;
 
           > p,
           .children {
@@ -253,7 +239,9 @@ const CustomButton = styled.button<Sizable>(
     display: flex;
     border-radius: ${props.onlyIcon ? "100%" : "var(--mi-border-radius)"};
     justify-content: center;
-  
+    min-width: var(--mi-touch-target-min);
+    min-height: var(--mi-touch-target-min);
+
     &[disabled] {
       opacity: 0.6;
     }
@@ -261,7 +249,7 @@ const CustomButton = styled.button<Sizable>(
     .startIcon,
     .endIcon {
       display: flex;
-      align-content: center;
+      align-items: center;
       justify-content: center;
       margin-top: ${props.onlyIcon ? "0px" : "0.1rem"};
       margin-right: ${props.onlyIcon ? "0px" : "0.5rem"};

--- a/client/src/components/common/FixedButton.tsx
+++ b/client/src/components/common/FixedButton.tsx
@@ -3,24 +3,26 @@ import Button, { ButtonLink } from "./Button";
 import { bp } from "../../constants";
 
 export const FixedButton = styled(Button)`
-  box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
-  background-color: rgba(255, 255, 255, 0.9) !important;
-  color: black !important;
+  box-shadow: 1px 1px 0.15rem rgba(0, 0, 0, 0.15);
+  background-color: var(--mi-fixed-bg-color) !important;
+  color: var(--mi-fixed-fg-color) !important;
+  border: 1px solid
+    color-mix(in srgb, var(--mi-fixed-fg-color) 40%, transparent) !important;
   height: auto;
   width: auto;
 
   justify-content: space-between;
 
   svg {
-    fill: black;
+    fill: var(--mi-fixed-fg-color);
   }
 
   :hover {
-    background-color: rgba(0, 0, 0, 0.7) !important;
-    color: white !important;
+    background-color: var(--mi-fixed-fg-color) !important;
+    color: var(--mi-fixed-bg-color) !important;
 
     svg {
-      fill: white !important;
+      fill: var(--mi-fixed-bg-color) !important;
     }
   }
 
@@ -34,17 +36,19 @@ export const FixedButton = styled(Button)`
 `;
 
 const FixedButtonLink = styled(ButtonLink)`
-  box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
-  background-color: rgba(255, 255, 255, 0.9) !important;
-  color: black !important;
+  box-shadow: 1px 1px 0.15rem rgba(0, 0, 0, 0.15);
+  background-color: var(--mi-fixed-bg-color) !important;
+  color: var(--mi-fixed-fg-color) !important;
+  border: 1px solid
+    color-mix(in srgb, var(--mi-fixed-fg-color) 40%, transparent) !important;
   height: auto;
   width: auto;
 
   justify-content: space-between;
 
   :hover {
-    background-color: rgba(0, 0, 0, 0.7) !important;
-    color: white !important;
+    background-color: var(--mi-fixed-fg-color) !important;
+    color: var(--mi-fixed-bg-color) !important;
   }
 
   @media screen and (min-width: ${bp.medium}px) {

--- a/client/src/components/common/NextButton.tsx
+++ b/client/src/components/common/NextButton.tsx
@@ -16,7 +16,7 @@ export const NextButton: React.FC<{ compact?: boolean }> = ({ compact }) => {
 
   return (
     <Button
-      startIcon={<MdSkipNext />}
+      startIcon={<MdSkipNext size={compact ? undefined : 22} />}
       variant="transparent"
       onlyIcon={compact}
       className={compact ? "!h-6 !w-6 !p-1" : undefined}

--- a/client/src/components/common/PreviousButton.tsx
+++ b/client/src/components/common/PreviousButton.tsx
@@ -13,7 +13,7 @@ export const PreviousButton: React.FC = () => {
 
   return (
     <Button
-      startIcon={<MdSkipPrevious />}
+      startIcon={<MdSkipPrevious size={22} />}
       variant="transparent"
       aria-label="Play previous track"
       onClick={onClickPrevious}

--- a/client/src/components/common/Tooltip.tsx
+++ b/client/src/components/common/Tooltip.tsx
@@ -58,15 +58,16 @@ const TooltipText = styled.span<{
     } else {
       return `
         top: 100%;
-        left: 0%;
+        left: 50%;
+        transform: translateX(-50%);
         margin-top: ${props.compact ? "0.25rem" : "0.75rem"};
 
         &:after {
           content: " ";
           position: absolute;
           bottom: 100%;
-          left: ${props.compact ? "10%" : "50%"};
-          margin-left: ${props.compact ? "0px" : "-5px"};
+          left: 50%;
+          margin-left: -5px;
           border-width: 5px;
           border-style: solid;
           border-color: transparent transparent black transparent;

--- a/client/src/components/common/TrackTable/PublicTrackGroupListing.tsx
+++ b/client/src/components/common/TrackTable/PublicTrackGroupListing.tsx
@@ -38,15 +38,14 @@ export const PublicTrackGroupListing: React.FC<{
 
   const addTracksToQueue = React.useCallback(
     (id: number) => {
-      const idx = tracks.findIndex((track) => track.id === id);
+      const playableIds = tracks
+        .filter((track) => isTrackOwnedOrPreview(track, user, trackGroup))
+        .map((track) => track.id);
+      const startingIndex = playableIds.indexOf(id);
       dispatch({
         type: "startPlayingIds",
-        playerQueueIds: tracks
-          .slice(idx, tracks.length)
-          .filter((track) => {
-            return isTrackOwnedOrPreview(track, user, trackGroup);
-          })
-          .map((track) => track.id),
+        playerQueueIds: playableIds,
+        startingIndex: startingIndex >= 0 ? startingIndex : 0,
       });
     },
     [dispatch, trackGroup, tracks, user]

--- a/client/src/state/GlobalState.tsx
+++ b/client/src/state/GlobalState.tsx
@@ -79,6 +79,7 @@ type SetShuffle = {
 type StartPlayingIds = {
   type: "startPlayingIds";
   playerQueueIds: number[];
+  startingIndex?: number;
 };
 
 type IncrementCurrentlyPlayingIndex = {
@@ -129,11 +130,14 @@ export const stateReducer = produce((draft: GlobalState, action: Actions) => {
     case "startPlayingIds":
       draft.playing = true;
       draft.playerQueueIds = clone(action.playerQueueIds);
+      const startingIndex = action.startingIndex ?? 0;
       if (draft.shuffle) {
-        const firstId = pullAt(draft.playerQueueIds, 0);
+        const firstId = pullAt(draft.playerQueueIds, startingIndex);
         draft.playerQueueIds = [...firstId, ...shuffle(draft.playerQueueIds)];
+        draft.currentlyPlayingIndex = 0;
+      } else {
+        draft.currentlyPlayingIndex = startingIndex;
       }
-      draft.currentlyPlayingIndex = 0;
       break;
     case "setLooping":
       draft.looping = action.looping;
@@ -156,7 +160,10 @@ export const stateReducer = produce((draft: GlobalState, action: Actions) => {
       draft.currentlyPlayingIndex = newIndex;
       break;
     case "decrementCurrentlyPlayingIndex":
-      draft.currentlyPlayingIndex = (draft.currentlyPlayingIndex ?? 0) - 1;
+      draft.currentlyPlayingIndex = Math.max(
+        0,
+        (draft.currentlyPlayingIndex ?? 0) - 1
+      );
       break;
     case "addTrackIdsToBackOfQueue":
       const newTracks = draft.shuffle

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -23,6 +23,8 @@ html {
   --mi-border-radius-x: 15px;
   --mi-border-radius-focus: 8px;
 
+  --mi-touch-target-min: 30px;
+
   --header-cover-sticky-height: 55px;
 
   --mi-font-family-stack:

--- a/client/src/styles/theme.css
+++ b/client/src/styles/theme.css
@@ -27,6 +27,9 @@ html {
   --mi-button-tint-x-color: var(--mi-tint-x-color);
   --mi-contrast-color: var(--mi-button-color);
 
+  --mi-fixed-bg-color: var(--mi-background-color);
+  --mi-fixed-fg-color: var(--mi-text-color);
+
   --mi-text-color: var(--mi-instance-text-color, var(--mi-black));
   --mi-light-foreground-color: #454545; /* FIXME: remove */
   --mi-lighter-foreground-color: #515151; /* FIXME: remove */

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -631,7 +631,9 @@
     "thisIsYourLastPlay": "This is your last free play — purchase this release to continue listening.",
     "trackLimitExplanation": "You have reached the play limit for this track. Purchase it to continue listening.",
     "playsRemaining_one": "{{count}} free play left — buy this release to keep listening.",
-    "playsRemaining_other": "{{count}} free plays left — buy this release to keep listening."
+    "playsRemaining_other": "{{count}} free plays left — buy this release to keep listening.",
+    "playsRemainingShort_one": "{{count}} free play left",
+    "playsRemainingShort_other": "{{count}} free plays left"
   },
   "post": {
     "postByArtist": "by <link></link>",


### PR DESCRIPTION
Player was using old stylings (merged to common component logic with Embeds now), that would most often extend its height and take up lots of screen real estate while also making track titles illegible in a lot of cases. Similarly, buttons over the player didn't display correctly, and had incoherent non matching styles. The "x plays left" indicator was also clashing with the progress bar and overflowing on those buttons. The player now also uses the same system as the header bar to adjust to the artist theme (very simple flip/flop between light or dark depending on artist's background color). This also fixes a bug where the player wouldn't play when hit for the first time on Mirlo for someone that had never been on the website before, and another bug where clicking "previous" would make the player disappear despite being on an album page. 

Also added a cypress test to make sure the player doesn't remount upon browsing the website and continuity is always garanteed.