### PR TITLE
chore: break up cors and apiKey

### DIFF
--- a/src/activityPub/utils.ts
+++ b/src/activityPub/utils.ts
@@ -123,3 +123,11 @@ export const headersAreForActivityPub = (
 
   return isActivityPubMimeType(accept);
 };
+
+export const isValidActivityPubEndpoint = (path: string) => {
+  return (
+    /^\/v1\/ap\/artists\/[\w-]+(?:\/(?:outbox|followers|following|inbox|activities|posts|releases)(?:\/[\w-]+)?)?$/.test(
+      path
+    ) || /^\/.well-known\/(webfinger|nodeinfo)/.test(path)
+  );
+};

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,19 +1,21 @@
 import express from "express";
 import { initialize } from "express-openapi";
+import slowDown from "express-slow-down";
+import qs from "qs";
 
+import { apiKeyCheck } from "./auth/apiKey";
+import logger from "./logger";
+import rateLimiter from "./rateLimiter";
 import apiDoc from "./routers/v1/api-doc";
 import "./auth/passport";
 
+import routes from "./routes";
 import errorHandler from "./utils/error";
 
-import logger from "./logger";
-import rateLimiter from "./rateLimiter";
-import slowDown from "express-slow-down";
-import routes from "./routes";
-import qs from "qs";
-import { corsCheck } from "./auth/cors";
 import cookieParser from "cookie-parser";
+
 import crypto from "crypto";
+
 import {
   sanitizeHeadersForLogs,
   sanitizeBodyForLogs,
@@ -33,7 +35,7 @@ apiApp.use((req, res, next) => {
   next();
 });
 
-apiApp.use(corsCheck);
+apiApp.use(apiKeyCheck);
 apiApp.use(cookieParser());
 apiApp.use(express.urlencoded({ extended: true }));
 

--- a/src/auth/apiKey.ts
+++ b/src/auth/apiKey.ts
@@ -1,0 +1,96 @@
+import prisma from "@mirlo/prisma";
+import { NextFunction, Request, Response } from "express";
+
+import { isValidActivityPubEndpoint } from "../activityPub/utils";
+import logger from "../logger";
+import { AppError } from "../utils/error";
+
+const MIRLO_API_KEY_HEADER = "mirlo-api-key";
+
+const SAFE_METHODS = ["GET", "HEAD", "OPTIONS"];
+
+const isExcludedFromKeyCheck = (path: string, query?: { format?: string }) => {
+  return (
+    path.includes("/oembed") ||
+    path.startsWith("/v1/checkout") ||
+    path.startsWith("/v1/webhooks") ||
+    path.endsWith("/stripe/connect") ||
+    path.endsWith("/stripe/connectComplete") ||
+    (path.startsWith("/v1/artists/") &&
+      path.endsWith("/feed") &&
+      query?.format === "rss") ||
+    (path.startsWith("/v1/trackGroups") && query?.format === "rss") ||
+    (path.startsWith("/v1/artists/") && path.endsWith("/confirmFollow"))
+  );
+};
+
+export const apiKeyCheck = async (
+  req: Request,
+  _res: Response,
+  next: NextFunction
+) => {
+  // @ts-ignore - req.logger added by middleware
+  const log = req.logger || logger;
+  try {
+    const isSameSite =
+      req.headers["sec-fetch-site"] === "same-site" ||
+      req.headers["sec-fetch-site"] === "same-origin";
+    const isCORSPreflight =
+      req.method === "OPTIONS" &&
+      req.headers["access-control-request-method"] &&
+      req.headers["access-control-request-headers"];
+    const isMutatingRequest =
+      req.path.startsWith("/v1") && !SAFE_METHODS.includes(req.method);
+
+    if (
+      !isMutatingRequest ||
+      isSameSite ||
+      isCORSPreflight ||
+      isValidActivityPubEndpoint(req.path) ||
+      isExcludedFromKeyCheck(req.path, req.query)
+    ) {
+      // For safe methods, still try to identify the client for attribution
+      // but don't require a key
+      const apiHeader = req.headers[MIRLO_API_KEY_HEADER];
+      if (typeof apiHeader === "string" && apiHeader) {
+        const clients = await prisma.client.findMany({
+          where: { key: apiHeader },
+        });
+        if (clients.length === 1) {
+          req.client = clients[0];
+        }
+      }
+      return next();
+    }
+
+    const apiHeader = req.headers[MIRLO_API_KEY_HEADER];
+    if (typeof apiHeader !== "string" || !apiHeader) {
+      throw new AppError({
+        httpCode: 401,
+        description: "Missing API key",
+      });
+    }
+
+    log.info(`apiKeyCheck: Looking for client with API key: ${apiHeader}`);
+    const clients = await prisma.client.findMany({
+      where: { key: apiHeader },
+    });
+    log.info(
+      `apiKeyCheck: Found ${clients.length} clients with that API key: ${clients
+        .map((c) => `${c.applicationName}: ${c.allowedCorsOrigins.join(", ")}`)
+        .join(", ")}`
+    );
+
+    if (clients.length !== 1) {
+      throw new AppError({
+        httpCode: 401,
+        description: "Invalid API key",
+      });
+    }
+
+    req.client = clients[0];
+    return next();
+  } catch (e) {
+    next(e);
+  }
+};

--- a/src/auth/cors.ts
+++ b/src/auth/cors.ts
@@ -3,126 +3,47 @@ import { Client } from "@mirlo/prisma/client";
 import cors from "cors";
 import { NextFunction, Request, Response } from "express";
 
-import logger from "../logger";
-import { AppError } from "../utils/error";
-
 const isTest = process.env.NODE_ENV === "test" || process.env.CI;
-const MIRLO_API_KEY_HEADER = "mirlo-api-key";
 
-const checkForPrivateEndpoint = (path: string, query?: { format?: string }) => {
-  return (
-    path.startsWith("/v1") &&
-    !(
-      path.includes("/oembed") ||
-      path.startsWith("/v1/checkout") ||
-      path.startsWith("/v1/webhooks") ||
-      path.endsWith("/stripe/connect") ||
-      path.endsWith("/stripe/connectComplete") ||
-      // FIXME: This needs to be improved probably.
-      // Exclude artist feed endpoints
-      (path.startsWith("/v1/artists/") &&
-        path.endsWith("/feed") &&
-        query?.format === "rss") ||
-      (path.startsWith("/v1/trackGroups") && query?.format === "rss") ||
-      // confirmFollow is public cause it comes from an email
-      (path.startsWith("/v1/artists/") && path.endsWith("/confirmFollow"))
-    )
-  );
+const CACHE_TTL_MS = 60_000; // 1 minute
+let cachedClients: Client[] = [];
+let cacheExpiry = 0;
+
+export const invalidateClientCache = () => {
+  cacheExpiry = 0;
 };
 
-export const isValidActivityPubEndpoint = (path: string) => {
-  return (
-    /^\/v1\/ap\/artists\/[\w-]+(?:\/(?:outbox|followers|following|inbox|activities|posts|releases)(?:\/[\w-]+)?)?$/.test(
-      path
-    ) || /^\/.well-known\/(webfinger|nodeinfo)/.test(path)
-  );
-};
-
-export const corsCheck = async (...args: [Request, Response, NextFunction]) => {
-  const [req, _res, next] = args;
-  // @ts-ignore - req.logger added by middleware
-  const log = req.logger || logger;
+export const corsMiddleware = async (
+  ...args: [Request, Response, NextFunction]
+) => {
+  const [req, , next] = args;
   try {
-    const isSameSite =
-      req.headers["sec-fetch-site"] === "same-site" ||
-      req.headers["sec-fetch-site"] === "same-origin";
     const isHealthCheck = req.path === "/health" && req.headers["health-check"];
-    const isRSSFormat = req.query?.format === "rss";
-
-    // Health checks, the test environment, and any RSS feed bypass both
-    // client lookup and API-key validation entirely. CORS still applies (we
-    // fall through to the cors() call below with an empty client list, so
-    // only API_DOMAIN / dev localhost are in the origin allowlist)
-    const skipsClientLookup = isHealthCheck || isTest || isRSSFormat;
 
     let clients: Client[] = [];
-    if (!skipsClientLookup) {
-      const isAPIEndpointPrivate = checkForPrivateEndpoint(req.path, req.query);
-
-      // The API key is only required for cross-site requests to private
-      // endpoints. Same-site (the SPA), public endpoints, and ActivityPub
-      // endpoints all skip the key check; in those cases we still need every
-      // registered client's allowed origins merged into the CORS allowlist,
-      // so we load them all
-
-      const isCORSPreflight =
-        req.method === "OPTIONS" &&
-        req.headers["access-control-request-method"] &&
-        req.headers["access-control-request-headers"];
-      const skipsApiKey =
-        isSameSite ||
-        !isAPIEndpointPrivate ||
-        isCORSPreflight ||
-        isValidActivityPubEndpoint(req.path);
-
-      if (skipsApiKey) {
-        clients = await prisma.client.findMany();
-      } else {
-        const apiHeader = req.headers[MIRLO_API_KEY_HEADER];
-        if (typeof apiHeader !== "string" || !apiHeader) {
-          throw new AppError({
-            httpCode: 401,
-            description: "Missing API Code",
-          });
-        }
-        log.info(`Looking for client with API key: ${apiHeader}`);
-        clients = await prisma.client.findMany({
-          where: { key: apiHeader },
-        });
-        log.info(
-          `Found ${clients.length} clients with that API key: ${clients
-            .map(
-              (c) => `${c.applicationName}: ${c.allowedCorsOrigins.join(", ")}`
-            )
-            .join(", ")}`
-        );
-        if (clients.length === 1) {
-          req.client = clients[0];
-        }
+    if (!isHealthCheck && !isTest) {
+      const now = Date.now();
+      if (now > cacheExpiry) {
+        cachedClients = await prisma.client.findMany();
+        cacheExpiry = now + CACHE_TTL_MS;
       }
+      clients = cachedClients;
     }
 
-    const allowedClientOrigins = clients.flatMap((c) =>
-      c.allowedCorsOrigins.map((origin) =>
-        origin.startsWith("regex:")
-          ? new RegExp(origin.replace("regex:", ""))
-          : origin
-      )
-    );
-
     const origin: (string | RegExp)[] = [
-      ...allowedClientOrigins,
+      ...clients.flatMap((c) =>
+        c.allowedCorsOrigins.map((o) =>
+          o.startsWith("regex:") ? new RegExp(o.replace("regex:", "")) : o
+        )
+      ),
       process.env.API_DOMAIN ?? "http://localhost:3000",
     ];
 
     if (process.env.NODE_ENV === "development") {
-      origin.push("http://localhost:8080"); // Just... for ease of coding
+      origin.push("http://localhost:8080");
     }
 
-    return cors({
-      origin,
-      credentials: true,
-    })(...args);
+    return cors({ origin, credentials: true })(...args);
   } catch (e) {
     next(e);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,10 @@ import qs from "qs";
 import swaggerUi from "swagger-ui-express";
 
 import { federation } from "./activityPub/federation";
+import { isValidActivityPubEndpoint } from "./activityPub/utils";
 import apiApp from "./api";
 import "./auth/passport";
-import { corsCheck, isValidActivityPubEndpoint } from "./auth/cors";
+import { corsMiddleware } from "./auth/cors";
 import { userLoggedInWithoutRedirect } from "./auth/passport";
 import logger from "./logger";
 import parseIndex from "./parseIndex";
@@ -45,7 +46,7 @@ app.get("/x-forwarded-for", (request, response) =>
   response.send(request.headers["x-forwarded-for"])
 );
 
-app.use(corsCheck);
+app.use(corsMiddleware);
 app.use(cookieParser());
 // @fedify/express's fromERequest builds the request URL using req.host, which
 // in Express returns the raw Host header including the port (e.g. "api:3000").


### PR DESCRIPTION
This splits up the cors and API Key checks into two different middleware, one for the entire app and one for the api. 