### PR TITLE
chore: bump timeout for mocha

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -7,7 +7,7 @@ module.exports = {
   spec: "test/**/*.spec.ts",
   require: "ts-node/register",
   forbidOnly: inCI,
-  // watch: !inCI,
+  timeout: 3000,
   "watch-files": ["test/**/*.ts", "src/**/*.ts"],
   "watch-ignore": ["node_modules"],
 };

--- a/test/routers/artists/{id}.spec.ts
+++ b/test/routers/artists/{id}.spec.ts
@@ -23,14 +23,6 @@ describe("artists", () => {
   });
 
   describe("/{id}", () => {
-    beforeEach(async () => {
-      try {
-        await clearTables();
-      } catch (e) {
-        console.error(e);
-      }
-    });
-
     it("should GET /{id} with artist slug", async () => {
       const artistSlug = "test-artist";
       const user = await prisma.user.create({


### PR DESCRIPTION
close #2094

I think the clearTable on like 40+ tables probably just took too long depending on how resourced the action was.