### PR TITLE
chore: temporary files location for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ STATIC_MEDIA_HOST=http://localhost:3000
 
 # NGINX_PORT=3001
 MEDIA_LOCATION=./data/media/
+TEMP_LOCATION=/tmp/data/media/
 
 DATABASE_URL="postgresql://nomads:nomads@pgsql:5432/nomads?schema=public"
 POSTGRES_LOCAL_MACHINE_PORT=5434

--- a/src/jobs/generate-album.ts
+++ b/src/jobs/generate-album.ts
@@ -1,8 +1,19 @@
-import { Job } from "bullmq";
-
 import { createReadStream, promises as fsPromises } from "fs";
+import { PassThrough } from "stream";
 
-import { logger } from "./queue-worker";
+import prisma from "@mirlo/prisma";
+import {
+  Artist,
+  Track,
+  TrackArtist,
+  TrackAudio,
+  TrackGroup,
+  TrackGroupCover,
+} from "@mirlo/prisma/client";
+import archiver from "archiver";
+import { Job } from "bullmq";
+import filenamify from "filenamify";
+
 import {
   createBucketIfNotExists,
   downloadableContentBucket,
@@ -15,24 +26,16 @@ import {
   uploadWrapper,
 } from "../utils/minio";
 import { convertAudioToFormat } from "../utils/tracks";
-import archiver from "archiver";
-import { PassThrough } from "stream";
-import {
-  Artist,
-  Track,
-  TrackArtist,
-  TrackAudio,
-  TrackGroup,
-  TrackGroupCover,
-} from "@mirlo/prisma/client";
-import filenamify from "filenamify";
-import prisma from "@mirlo/prisma";
+
+import { logger } from "./queue-worker";
 
 export type Format = {
   format: "mp3" | "wav" | "flac" | "opus" | "libmp3lame";
   audioCodec?: "flac" | "libmp3lame" | "opus" | "wav";
   audioBitrate?: "320" | "256" | "128";
 };
+
+const TEMP_LOCATION = process.env.TEMP_LOCATION;
 
 const parseFormat = (format: string): Format => {
   const split = format.split(".");
@@ -406,10 +409,10 @@ export default async (job: Job) => {
     format: string;
     destinationBucket: DestinationBucket;
   };
-  let tempFolder = `/data/media/trackGroup/${trackGroup.id}/${formatString}`;
+  let tempFolder = `${TEMP_LOCATION}trackGroup/${trackGroup.id}/${formatString}`;
 
   if (destinationBucket === "track-format") {
-    tempFolder = `/data/media/track/${tracks[0].id}/${formatString}`;
+    tempFolder = `${TEMP_LOCATION}track/${tracks[0].id}/${formatString}`;
   }
 
   try {

--- a/src/jobs/upload-audio.ts
+++ b/src/jobs/upload-audio.ts
@@ -13,13 +13,14 @@ import {
 } from "../utils/minio";
 
 import { logger } from "./queue-worker";
+const TEMP_LOCATION = process.env.TEMP_LOCATION;
 
 export default async (job: Job) => {
   const { audioId, fileExtension } = job.data;
   let progress = 10;
 
   try {
-    const destinationFolder = `/data/media/processing/${audioId}`;
+    const destinationFolder = `${TEMP_LOCATION}processing/${audioId}`;
 
     logger.info(
       `upload-audio: checking if folder exists, if not creating it ${destinationFolder}`

--- a/src/jobs/verify-audio.ts
+++ b/src/jobs/verify-audio.ts
@@ -1,10 +1,12 @@
-import { Job } from "bullmq";
-
 import { promises as fsPromises } from "fs";
 
-import { logger } from "./queue-worker";
-import { finalAudioBucket, getFile } from "../utils/minio";
+import { Job } from "bullmq";
 import fetch from "node-fetch";
+
+import { finalAudioBucket, getFile } from "../utils/minio";
+
+import { logger } from "./queue-worker";
+const TEMP_LOCATION = process.env.TEMP_LOCATION;
 
 export default async (job: Job) => {
   const { audioId, fileExtension } = job.data;
@@ -17,7 +19,7 @@ export default async (job: Job) => {
     }
 
     let progress = 10;
-    const tempFolder = `/data/media/verifying/${audioId}`;
+    const tempFolder = `${TEMP_LOCATION}verifying/${audioId}`;
 
     try {
       await fsPromises.stat(tempFolder);


### PR DESCRIPTION
File uploads were not working for me when running Mirlo outside docker due to the location of temporary files.
This uses a more standardised temp file location that makes it possible to run Mirlo both as a container or directly on your machine's OS.