### PR TITLE
fix: newsletter embed styling issues

### DIFF
--- a/src/jobs/parse-out-iframes.ts
+++ b/src/jobs/parse-out-iframes.ts
@@ -2,6 +2,17 @@ import prisma from "@mirlo/prisma";
 
 import logger from "../logger";
 import { getClient } from "../utils/getClient";
+import { convertURLArrayToSizes } from "../utils/images";
+import { finalCoversBucket } from "../utils/minio";
+
+const coverUrl = (cover?: { url: string[] } | null): string | null => {
+  if (!cover || cover.url.length === 0) return null;
+  const sizes = convertURLArrayToSizes(cover.url, finalCoversBucket) as Record<
+    string,
+    string
+  >;
+  return sizes["120"] || sizes["60"] || sizes["original"] || null;
+};
 
 /**
  * A trackGroup is unreachable to the public (and therefore to a post-email
@@ -60,13 +71,15 @@ export const parseOutIframes = async (
       trackGroupIds.length
         ? prisma.trackGroup.findMany({
             where: { id: { in: trackGroupIds } },
-            include: { artist: true, tracks: true },
+            include: { artist: true, tracks: true, cover: true },
           })
         : Promise.resolve([]),
       trackIds.length
         ? prisma.track.findMany({
             where: { id: { in: trackIds }, deletedAt: null },
-            include: { trackGroup: { include: { artist: true } } },
+            include: {
+              trackGroup: { include: { artist: true, cover: true } },
+            },
           })
         : Promise.resolve([]),
     ]);
@@ -87,7 +100,6 @@ export const parseOutIframes = async (
           const button = tg.artist.properties?.colors?.button || "#be3455";
           const background =
             tg.artist.properties?.colors?.background || "#f5f0f0";
-          const buttonText = tg.artist.properties?.colors?.buttonText || "#111";
           const text = tg.artist.properties?.colors?.text || "#111";
           // If the trackGroup is unreachable (draft/private/deleted/unreleased),
           // fall back to the post URL so the recipient lands somewhere that
@@ -96,34 +108,47 @@ export const parseOutIframes = async (
             fallbackUrl && isTrackGroupUnreachable(tg)
               ? fallbackUrl
               : `${applicationUrl}/${tg.artist.urlSlug}/release/${tg.urlSlug}`;
-          return `<div data-type="trackGroup" data-id="${id}" style="display:flex;flex-direction:row;gap:8px;background-color:${background};border-radius:8px;padding:16px;">
-                    <div>
-                      <a href="${trackGroupUrl}" style="
-                      display:inline-block;
-                      text-decoration:none;
-                      background:${button};
-                      color:${text};
-                      width: 32px;
-                      height: 32px;
-                      text-align: center;
-                      padding-top: 3px;
-                      vertical-align: middle;
-                      display: flex;
-                      align-items: center;
-                      justify-content: center;
-                      border-radius: 24px;
-                      font-weight: bold;">
-                        &#9658;
-                      </a>
+          const cover = coverUrl(tg.cover);
+          return `<div data-type="trackGroup" data-id="${id}" style="
+                    display: flex;
+                    flex-direction: row;
+                    gap: 16px;
+                    align-items: center;
+                    background-color: ${background};
+                    color: ${text};
+                    border-radius: 8px;
+                    padding: 16px;
+                  ">
+                    ${cover ? `<img src="${cover}" alt="" width="60" height="60" style="display:block;width:60px;height:60px;border-radius:4px;object-fit:cover;flex-shrink:0;"/>` : ""}
+                    <div style="flex: 1; min-width: 0; overflow: hidden;">
+                      <strong style="
+                        display: block;
+                        color: ${button};
+                        white-space: nowrap;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      ">${tg.title}</strong>
+                      <span style="
+                        display: block;
+                        white-space: nowrap;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      ">by <a href="${applicationUrl}/${tg.artist.urlSlug}" target="_blank" rel="noopener noreferrer" style="color: ${button}; text-decoration: none;">${tg.artist?.name || "Unknown"}</a> &middot; ${tg.tracks.length} track${tg.tracks.length === 1 ? "" : "s"} album</span>
                     </div>
-                    <div>
-                      <strong>${tg.title}</strong><br/>
-                      <a href="${applicationUrl}/${tg.artist.urlSlug}" style="color:${button};text-decoration:none;">
-                        ${tg.artist?.name || "Unknown"}
-                      </a><br/>
-                      <ol>
-                        ${tg.tracks.map((track) => `<li>${track.title}</li>`).join("")}
-                      </ol>
+                    <div style="flex-shrink: 0;">
+                      <a href="${trackGroupUrl}" target="_blank" rel="noopener noreferrer" style="
+                        display: inline-block;
+                        text-decoration: none;
+                        background: ${text};
+                        color: ${background};
+                        width: 48px;
+                        height: 48px;
+                        line-height: 48px;
+                        text-align: center;
+                        border-radius: 50%;
+                        font-size: 18px;
+                        font-weight: bold;
+                      ">&#9654;</a>
                     </div>
                   </div>`;
         } else if (type === "track" && trackMap[id]) {
@@ -132,8 +157,6 @@ export const parseOutIframes = async (
             t.trackGroup.artist.properties?.colors?.button || "#be3455";
           const background =
             t.trackGroup.artist.properties?.colors?.background || "#f5f0f0";
-          const buttonText =
-            t.trackGroup.artist.properties?.colors?.buttonText || "#111";
           const text = t.trackGroup.artist.properties?.colors?.text || "#111";
           // Same fallback as the trackGroup branch: when a track's parent
           // album is unreachable to the public, link to the post that embeds
@@ -142,32 +165,49 @@ export const parseOutIframes = async (
             fallbackUrl && isTrackGroupUnreachable(t.trackGroup)
               ? fallbackUrl
               : `${applicationUrl}/${t.trackGroup.artist.urlSlug}/release/${t.trackGroup.urlSlug}/track/${t.urlSlug}`;
-          return `<div data-type="track" data-id="${id}" style="display:flex;flex-direction:column;gap:8px;background-color:${background};border-radius:8px;padding:16px;">
-                  <div>
-                    <a href="${trackUrl}" style="display:inline-block;
-                      text-decoration:none;
-                      background:${button};
-                      color:${text};
-                      width: 32px;
-                      height: 32px;
-                      text-align: center;
-                      padding-top: 3px;
-                      vertical-align: middle;
-                      display: flex;
-                      align-items: center;
-                      justify-content: center;
-                      border-radius: 24px;
-                      font-weight: bold;">
-                      &#9658;
-                    </a>
-                  </div>
-                  <div>
-                    <strong>${t.title}</strong><br/>
-                    <a href="${applicationUrl}/${t.trackGroup.artist.urlSlug}" style="color:${text}; text-decoration:none;">
-                      ${t.trackGroup.artist?.name || "Unknown"}
-                    </a>
-                  </div>
-                </div>`;
+          const cover = coverUrl(t.trackGroup.cover);
+          return `<div data-type="track" data-id="${id}" style="
+                    display: flex;
+                    flex-direction: row;
+                    gap: 16px;
+                    align-items: center;
+                    background-color: ${background};
+                    color: ${text};
+                    border-radius: 8px;
+                    padding: 16px;
+                  ">
+                    ${cover ? `<img src="${cover}" alt="" width="60" height="60" style="display:block;width:60px;height:60px;border-radius:4px;object-fit:cover;flex-shrink:0;"/>` : ""}
+                    <div style="flex: 1; min-width: 0; overflow: hidden;">
+                      <strong style="
+                        display: block;
+                        color: ${button};
+                        white-space: nowrap;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      ">${t.title}</strong>
+                      <span style="
+                        display: block;
+                        white-space: nowrap;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                      ">by <a href="${applicationUrl}/${t.trackGroup.artist.urlSlug}" target="_blank" rel="noopener noreferrer" style="color: ${button}; text-decoration: none;">${t.trackGroup.artist?.name || "Unknown"}</a></span>
+                    </div>
+                    <div style="flex-shrink: 0;">
+                      <a href="${trackUrl}" target="_blank" rel="noopener noreferrer" style="
+                        display: inline-block;
+                        text-decoration: none;
+                        background: ${text};
+                        color: ${background};
+                        width: 48px;
+                        height: 48px;
+                        line-height: 48px;
+                        text-align: center;
+                        border-radius: 50%;
+                        font-size: 18px;
+                        font-weight: bold;
+                      ">&#9654;</a>
+                    </div>
+                  </div>`;
         }
         // If not found, fallback to a placeholder
         return `<div data-type="${type}" data-id="${id}"></div>`;


### PR DESCRIPTION
When parsing iframes for newsletters, we were rendering a completely broken look (play button looked squashed, text didn't use artist color, full tracklisting was fetched and displayed), this streamlines how we handle it and makes it simple looking enough to fit in a newsletter format.

<img width="1259" height="169" alt="2026-05-20_011443" src="https://github.com/user-attachments/assets/21188cca-3b42-44d3-895c-0e62c8f93010" />
