### PR TITLE
Fix manage label roster tab

### DIFF
--- a/client/cypress/e2e/manage-label-roster.cy.ts
+++ b/client/cypress/e2e/manage-label-roster.cy.ts
@@ -1,0 +1,82 @@
+/// <reference types="cypress" />
+
+const labelUserEmail = "manage-roster-label@example.com";
+const labelUserPassword = "test1234";
+const labelArtistName = "Test Label Profile";
+const labelArtistSlug = "test-label-profile";
+
+const rosterArtistUserEmail = "manage-roster-artist@example.com";
+const rosterArtistName = "Roster Artist";
+const rosterArtistSlug = "manage-roster-artist";
+
+describe("manage label roster tab", () => {
+  let labelArtistId: number;
+
+  before(() => {
+    cy.task("clearTables");
+
+    cy.task("createUser", {
+      email: labelUserEmail,
+      password: labelUserPassword,
+      emailConfirmationToken: null,
+      name: "Label Owner",
+      currency: "usd",
+      canCreateArtists: true,
+      isLabelAccount: true,
+    })
+      .then((labelUser: any) => {
+        return cy.task("createArtist", {
+          userId: labelUser.user.id,
+          name: labelArtistName,
+          urlSlug: labelArtistSlug,
+          isLabelProfile: true,
+        });
+      })
+      .then((artist: any) => {
+        labelArtistId = artist.id;
+        return cy.task("createUser", {
+          email: rosterArtistUserEmail,
+          password: "test1234",
+          emailConfirmationToken: null,
+          name: rosterArtistName,
+          currency: "usd",
+        });
+      })
+      .then((rosterUser: any) => {
+        return cy.task("createArtist", {
+          userId: rosterUser.user.id,
+          name: rosterArtistName,
+          urlSlug: rosterArtistSlug,
+        });
+      });
+  });
+
+  beforeEach(() => {
+    cy.login({ email: labelUserEmail, password: labelUserPassword });
+  });
+
+  it("renders the new manage roster route without crashing", () => {
+    cy.visit(`/manage/artists/${labelArtistId}/roster`);
+
+    cy.contains("a", "Manage label artists").should("be.visible");
+  });
+
+  it("keeps the roster tab inside the manage section instead of jumping to /account/label", () => {
+    cy.visit(`/manage/artists/${labelArtistId}/releases`);
+
+    cy.get("nav").contains("a", "Roster").click();
+
+    cy.location("pathname").should(
+      "eq",
+      `/manage/artists/${labelArtistId}/roster`
+    );
+  });
+
+  it("redirects to /account/label when clicking the manage label artists button", () => {
+    cy.visit(`/manage/artists/${labelArtistId}/roster`);
+
+    cy.contains("a", "Manage label artists").click();
+
+    cy.location("pathname").should("eq", "/account/label");
+  });
+});

--- a/client/src/components/ManageArtist/ManageArtist.tsx
+++ b/client/src/components/ManageArtist/ManageArtist.tsx
@@ -38,7 +38,7 @@ const ManageArtist: React.FC<{}> = () => {
       id: "roster",
       label: rosterTitle,
       visible: !!artist.isLabelProfile,
-      to: "/account/label",
+      to: "roster",
     },
     {
       id: "releases",

--- a/client/src/components/ManageArtist/ManageArtistRoster.tsx
+++ b/client/src/components/ManageArtist/ManageArtistRoster.tsx
@@ -1,0 +1,58 @@
+import { useQuery } from "@tanstack/react-query";
+import { ArtistButtonLink } from "components/Artist/ArtistButtons";
+import ArtistSquare from "components/Artist/ArtistSquare";
+import LoadingBlocks from "components/Artist/LoadingBlocks";
+import SectionActionStrip from "components/common/SectionActionStrip";
+import TrackgroupGrid from "components/common/TrackgroupGrid";
+import { queryArtist } from "queries";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { FaPen } from "react-icons/fa";
+import { useParams } from "react-router-dom";
+
+import { ManageSectionWrapper } from "./ManageSectionWrapper";
+
+const ManageArtistRoster: React.FC = () => {
+  const { t } = useTranslation("translation", { keyPrefix: "manageArtist" });
+  const { artistId } = useParams();
+
+  if (!artistId) {
+    return <div>{t("doesNotExist")}</div>;
+  }
+
+  const { data: artist, isPending } = useQuery(
+    queryArtist({ artistSlug: artistId })
+  );
+
+  if (isPending) {
+    return <LoadingBlocks />;
+  }
+
+  const rosterArtists = artist?.user?.artistLabels ?? [];
+
+  return (
+    <ManageSectionWrapper>
+      <SectionActionStrip>
+        <ArtistButtonLink
+          to="/account/label"
+          size="compact"
+          variant="dashed"
+          startIcon={<FaPen />}
+        >
+          {t("manageLabelArtists")}
+        </ArtistButtonLink>
+      </SectionActionStrip>
+      {rosterArtists.length === 0 ? (
+        <div>{t("noArtistsOnRosterYet")}</div>
+      ) : (
+        <TrackgroupGrid gridNumber="4" as="ul" role="list">
+          {rosterArtists.map((al) => (
+            <ArtistSquare key={al.artist.id} artist={al.artist} />
+          ))}
+        </TrackgroupGrid>
+      )}
+    </ManageSectionWrapper>
+  );
+};
+
+export default ManageArtistRoster;

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -361,6 +361,14 @@ const routes: RouteObject[] = [
                     },
                   },
                   {
+                    path: "roster",
+                    async lazy() {
+                      const { default: Component } =
+                        await import("components/ManageArtist/ManageArtistRoster");
+                      return { Component };
+                    },
+                  },
+                  {
                     path: "releases",
                     async lazy() {
                       const { default: Component } =

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -711,6 +711,8 @@
     "labelsAndCollectives": "Label and collectives",
     "name": "Name",
     "roster": "Roster",
+    "manageLabelArtists": "Manage label artists",
+    "noArtistsOnRosterYet": "No artists on your roster yet.",
     "unpublishedReleases": "Unpublished releases",
     "publishedReleases": "Published releases",
     "setEntireCataloguePrice": "Set entire catalogue price",


### PR DESCRIPTION
the "roster/artists" tab on a label page had an odd behavior for a navbar menu, where it would take you to the "manage artist label page" outside of the label page, which meant if you were just clicking it to see your roster but wanted to remain on your label page to keep editing, you had to explicitely go "back to label page" and then re-enable manage view.

This makes going to "manage label artists" opt in with a simple button in the section action strip to uniformize pattern with all other sections. "manage label" is still accessible at any point anywhere else in the sidebar burger menu in any case so it doesn't change much to the overall flow.