### PR TITLE
Post side tracklist rework

### DIFF
--- a/client/src/components/ManageArtist/ManageArtistButtons.tsx
+++ b/client/src/components/ManageArtist/ManageArtistButtons.tsx
@@ -77,19 +77,21 @@ const ManageArtistButtons: React.FC = () => {
         <div
           className={css`
             z-index: 999999;
-            bottom: ${isUp ? "90px" : "20px"};
+            bottom: ${isUp ? "80px" : "20px"};
             left: 1rem;
             position: fixed;
             display: flex;
             flex-direction: column;
-
-            a,
-            button {
-              margin-bottom: 0.5rem;
-            }
+            gap: 0.5rem;
             transition: all 0.3s ease;
 
             @media screen and (max-width: ${bp.medium}px) {
+              bottom: var(
+                --fixed-actions-bottom-offset-mobile,
+                var(--fixed-actions-bottom-offset, ${isUp ? "80px" : "20px"})
+              );
+              left: 0.5rem;
+
               .children {
                 display: none;
               }

--- a/client/src/components/Player/PlayerActions.tsx
+++ b/client/src/components/Player/PlayerActions.tsx
@@ -23,11 +23,19 @@ const PlayerActions: React.FC = () => {
     <div
       className={css`
         z-index: 999999;
-        bottom: 80px;
+        bottom: var(--player-actions-bottom-offset, 80px);
         right: 1rem;
         position: fixed;
         display: flex;
         gap: 0.5rem;
+
+        @media (max-width: 768px) {
+          bottom: var(
+            --player-actions-bottom-offset-mobile,
+            var(--player-actions-bottom-offset, 80px)
+          );
+          right: 0.5rem;
+        }
       `}
     >
       <Wishlist trackGroup={{ id: currentTrack.trackGroupId }} fixed />

--- a/client/src/components/Post/PostTracksDock.tsx
+++ b/client/src/components/Post/PostTracksDock.tsx
@@ -1,0 +1,181 @@
+import { css } from "@emotion/css";
+import TrackRow from "components/common/TrackList/TrackRow";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { FaChevronDown, FaChevronUp } from "react-icons/fa";
+import { useAuthContext } from "state/AuthContext";
+import { useGlobalStateContext } from "state/GlobalState";
+import { safeLocalStorage } from "utils/safeLocalStorage";
+import { isTrackOwnedOrPreview } from "utils/tracks";
+
+const COLLAPSED_KEY = (postId: number, isMobile: boolean) =>
+  `post-tracks-dock:collapsed:${isMobile ? "mobile" : "desktop"}:${postId}`;
+
+const readBool = (key: string, fallback: boolean) => {
+  const raw = safeLocalStorage.read(key);
+  if (raw === null) return fallback;
+  return raw === "1";
+};
+
+const asideBase = css`
+  position: fixed;
+  right: 1rem;
+  bottom: 5rem;
+  z-index: 9;
+  width: 20rem;
+  max-width: calc(100vw - 2rem);
+  display: flex;
+  flex-direction: column;
+  background-color: var(--mi-background-color);
+  color: var(--mi-text-color);
+  border: 1px solid var(--mi-tint-x-color);
+  border-radius: 0.5rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  overflow: hidden;
+
+  @media (max-width: 768px) {
+    right: 0;
+    left: 0;
+    bottom: 4rem;
+    width: auto;
+    max-width: none;
+    border-radius: 0;
+    border-bottom: 0;
+    box-shadow: 0 -6px 16px var(--mi-tint-x-color);
+  }
+`;
+
+const expandedHeight = css`
+  height: min(12rem, calc(100vh - 7rem));
+  @media (max-width: 768px) {
+    height: calc(100vh - 8rem - var(--header-cover-sticky-height, 0px));
+  }
+`;
+
+const PostTracksDock: React.FC<{
+  postId: number;
+  tracks: Track[];
+}> = ({ postId, tracks }) => {
+  const { t } = useTranslation("translation", { keyPrefix: "postTracksDock" });
+  const { dispatch } = useGlobalStateContext();
+  const { user } = useAuthContext();
+
+  const trackGroup = tracks[0]?.trackGroup;
+
+  const [isMobile, setIsMobile] = React.useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 768px)").matches
+  );
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia("(max-width: 768px)");
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const [collapsed, setCollapsed] = React.useState(() =>
+    readBool(COLLAPSED_KEY(postId, isMobile), isMobile)
+  );
+
+  React.useEffect(() => {
+    setCollapsed(readBool(COLLAPSED_KEY(postId, isMobile), isMobile));
+  }, [isMobile, postId]);
+
+  React.useEffect(() => {
+    safeLocalStorage.write(
+      COLLAPSED_KEY(postId, isMobile),
+      collapsed ? "1" : "0"
+    );
+  }, [collapsed, postId, isMobile]);
+
+  // Coordinates floating buttons positions with PlayerActions and
+  // ManageArtistButtons via global CSS vars on <html>. Single-mount invariant:
+  // mounting two PostTracksDocks simultaneously would race on these vars.
+  React.useEffect(() => {
+    const playerActionsDesktop = collapsed ? "8rem" : "17.5rem";
+    const playerActionsMobile = collapsed
+      ? "7.5rem"
+      : "calc(100vh - var(--header-cover-sticky-height, 0px) - 3.5rem)";
+    const root = document.documentElement.style;
+    root.setProperty("--player-actions-bottom-offset", playerActionsDesktop);
+    root.setProperty(
+      "--player-actions-bottom-offset-mobile",
+      playerActionsMobile
+    );
+    root.setProperty("--fixed-actions-bottom-offset", "8rem");
+    root.setProperty("--fixed-actions-bottom-offset-mobile", "7.5rem");
+    return () => {
+      root.removeProperty("--player-actions-bottom-offset");
+      root.removeProperty("--player-actions-bottom-offset-mobile");
+      root.removeProperty("--fixed-actions-bottom-offset");
+      root.removeProperty("--fixed-actions-bottom-offset-mobile");
+    };
+  }, [collapsed]);
+
+  const addTracksToQueue = React.useCallback(
+    (id: number) => {
+      const playableIds = tracks
+        .filter((track) => isTrackOwnedOrPreview(track, user, trackGroup))
+        .map((track) => track.id);
+      const startingIndex = playableIds.indexOf(id);
+      dispatch({
+        type: "startPlayingIds",
+        playerQueueIds: playableIds,
+        startingIndex: startingIndex >= 0 ? startingIndex : 0,
+      });
+    },
+    [dispatch, trackGroup, tracks, user]
+  );
+
+  if (tracks.length === 0 || !trackGroup) return null;
+
+  const labelId = `post-tracks-dock-label-${postId}`;
+  const listId = `post-tracks-dock-list-${postId}`;
+
+  return (
+    <aside
+      aria-labelledby={labelId}
+      className={`${asideBase} ${collapsed ? "" : expandedHeight}`}
+    >
+      <button
+        type="button"
+        onClick={() => setCollapsed((c) => !c)}
+        aria-expanded={!collapsed}
+        aria-controls={listId}
+        className="flex items-center justify-between gap-2 px-3 py-2 max-md:py-3.5 bg-(--mi-tint-color) border-0 border-b border-(--mi-tint-x-color) text-inherit text-left cursor-pointer [font:inherit]"
+      >
+        <span
+          id={labelId}
+          className="flex-1 min-w-0 truncate text-xs font-semibold uppercase tracking-wider opacity-75"
+        >
+          {t("label")}
+        </span>
+        {collapsed ? (
+          <FaChevronUp aria-hidden className="shrink-0 opacity-60" />
+        ) : (
+          <FaChevronDown aria-hidden className="shrink-0 opacity-60" />
+        )}
+      </button>
+      <ul
+        id={listId}
+        hidden={collapsed}
+        className="list-none m-0 py-1 overflow-y-auto overscroll-contain flex-1 min-h-0 divide-y divide-(--mi-tint-color)"
+      >
+        {tracks.map((track) => (
+          <TrackRow
+            key={track.id}
+            track={track}
+            trackGroup={track.trackGroup ?? trackGroup}
+            addTracksToQueue={addTracksToQueue}
+            size="dock"
+          />
+        ))}
+      </ul>
+    </aside>
+  );
+};
+
+export default PostTracksDock;

--- a/client/src/components/Post/index.tsx
+++ b/client/src/components/Post/index.tsx
@@ -12,8 +12,10 @@ import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link, useParams } from "react-router-dom";
 import useArtistQuery from "utils/useArtistQuery";
+import { useTracksQuery } from "utils/useTracksQuery";
 
 import PostHeader from "./PostHeader";
+import PostTracksDock from "./PostTracksDock";
 
 export const PageMarkdownWrapper = styled.div`
   width: 100%;
@@ -72,6 +74,15 @@ const Post: React.FC = () => {
   const { data: post, isLoading } = useQuery(
     queryPost({ postId: postId ?? "", artistId: artistId ?? "" })
   );
+
+  const trackIds = React.useMemo(
+    () =>
+      post && !post.isContentHidden
+        ? (post.tracks?.map((pt) => pt.trackId) ?? [])
+        : [],
+    [post]
+  );
+  const { data: tracksData } = useTracksQuery(trackIds);
 
   if (!post) {
     if (!isLoading) {
@@ -146,6 +157,9 @@ const Post: React.FC = () => {
           artist={post.artist}
           prefaceText={t("likedThisPost")}
         />
+      )}
+      {!post.isContentHidden && tracksData && tracksData.length > 0 && (
+        <PostTracksDock postId={post.id} tracks={tracksData} />
       )}
     </div>
   );

--- a/client/src/components/Widget/TrackTitleContent.tsx
+++ b/client/src/components/Widget/TrackTitleContent.tsx
@@ -64,8 +64,11 @@ export const TrackTitleContent: React.FC<{
     (track.title ?? "")
   );
 
-  const byLineWrapperBase =
-    "text-sm leading-normal break-normal max-sm:text-xs max-xs:text-[0.65rem] [&_a:hover]:underline! flex items-center justify-between gap-2";
+  const byLineWrapperBase = `text-sm leading-normal break-normal ${
+    foldByLineAtSm
+      ? "max-sm:text-[0.65rem]"
+      : "max-sm:text-xs max-xs:text-[0.65rem]"
+  } [&_a:hover]:underline! flex items-center justify-between gap-2`;
   const byLineFoldClasses = foldByLineAtSm
     ? "max-sm:flex-col max-sm:items-start max-sm:gap-0"
     : "max-xs:flex-col max-xs:items-start max-xs:gap-0";
@@ -78,7 +81,7 @@ export const TrackTitleContent: React.FC<{
       <div
         className={`leading-tight truncate break-normal ${
           compactTitle
-            ? "text-base max-sm:text-sm max-xs:text-xs font-semibold"
+            ? "text-base max-sm:text-xs font-semibold"
             : "text-lg max-sm:text-base max-xs:text-sm font-bold"
         }`}
       >

--- a/client/src/components/common/ClickToPlay.tsx
+++ b/client/src/components/common/ClickToPlay.tsx
@@ -317,12 +317,7 @@ const ClickToPlay: React.FC<
           <p aria-hidden>{t(linkLabelKey)}</p>
         </PlayWrapper>
 
-        {currentlyPlaying && (
-          <PlayingMusicBars
-            width={image?.width ?? 0}
-            height={image?.height ?? 0}
-          />
-        )}
+        {currentlyPlaying && <PlayingMusicBars />}
         {image && (
           <ImageWithPlaceholder
             src={image.url}

--- a/client/src/components/common/PlayingMusicBars.tsx
+++ b/client/src/components/common/PlayingMusicBars.tsx
@@ -1,107 +1,138 @@
 import styled from "@emotion/styled";
+
 import { bp } from "../../constants";
 
-type WrapperProps = {
-  width: number;
-  height: number;
-};
-
-const Wrapper = styled.div<WrapperProps>`
-  bottom: 0;
-  right: 0;
-  left: 0;
-  top: 0;
+const CoverWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
   height: 100%;
+  inset: 0;
 
-  div {
-    justify-content: space-between;
-    height: 50px;
-    width: 50px;
-    display: flex;
-    filter: drop-shadow(0 0 1rem rgba(55, 55, 55, 0.5));
+  & > div {
     position: absolute;
-    z-index: 0;
     top: 40%;
+    z-index: 0;
+    display: flex;
+    justify-content: space-between;
+    width: 50px;
+    height: 50px;
+    filter: drop-shadow(0 0 1rem rgba(55, 55, 55, 0.5));
+
+    & > span {
+      width: 5px;
+      height: 80%;
+      background: white;
+      transform-origin: bottom;
+      animation: coverBounce 1.4s ease-in-out infinite;
+
+      &:nth-of-type(2) {
+        animation-delay: -0.2s;
+      }
+      &:nth-of-type(3) {
+        animation-delay: -0.4s;
+      }
+      &:nth-of-type(4) {
+        animation-delay: -0.6s;
+      }
+      &:nth-of-type(5) {
+        animation-delay: -0.8s;
+      }
+      &:nth-of-type(6) {
+        animation-delay: -1s;
+      }
+      &:nth-of-type(7) {
+        animation-delay: -1.2s;
+      }
+    }
   }
 
-  @keyframes bounce {
-    10% {
-      transform: scaleY(0.3); /* start by scaling to 30% */
-    }
-
-    30% {
-      transform: scaleY(1); /* scale up to 100% */
-    }
-
-    60% {
-      transform: scaleY(0.5); /* scale down to 50% */
-    }
-
-    70% {
-      transform: scaleY(0.4); /* scale down to 40% */
-    }
-
-    80% {
-      transform: scaleY(0.75); /* scale up to 75% */
-    }
-
-    100% {
-      transform: scaleY(0.6); /* scale down to 60% */
-    }
-  }
-
-  span {
-    width: 5px;
-    height: 80%;
-    background-color: white;
-    border-radius: 0px;
-    transform-origin: bottom;
-    animation: bounce 3.3s ease infinite alternate;
-    content: "";
-  }
-
-  span {
-    &:nth-of-type(2) {
-      animation-delay: -2.2s; /* Start at the end of animation */
-    }
-
-    &:nth-of-type(3) {
-      animation-delay: -3.7s; /* Start mid-way of return of animation */
-    }
-    &:nth-of-type(4) {
-      animation-delay: -4.6s; /* Start mid-way of return of animation */
-    }
-    &:nth-of-type(5) {
-      animation-delay: -5.7s; /* Start mid-way of return of animation */
-    }
-    &:nth-of-type(6) {
-      animation-delay: -6.8s; /* Start mid-way of return of animation */
-    }
-  }
   @media (max-width: ${bp.large}px) {
-    div {
-      height: 40px;
-      width: 40px;
-      filter: drop-shadow(10px 10px 4rem crimson);
+    & > div {
       top: 38%;
+      width: 40px;
+      height: 40px;
+      filter: drop-shadow(10px 10px 4rem crimson);
     }
-
-    span {
+    & > div > span {
       width: 3px;
+    }
+  }
+
+  @keyframes coverBounce {
+    0%,
+    100% {
+      transform: scaleY(0.4);
+    }
+    50% {
+      transform: scaleY(1);
     }
   }
 `;
 
-export const PlayingMusicBars: React.FC<{ width: number; height: number }> = ({
-  width,
-  height,
-}) => {
+const InlineWrapper = styled.span`
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 0.75rem;
+  margin-right: 0.375rem;
+  vertical-align: -0.0625rem;
+
+  & > span {
+    display: block;
+    width: 2px;
+    background: currentColor;
+    border-radius: 1px;
+    transform-origin: bottom center;
+    animation: inlineBounce 0.9s ease-in-out infinite;
+
+    &:nth-of-type(1) {
+      animation-delay: 0s;
+      height: 60%;
+    }
+    &:nth-of-type(2) {
+      animation-delay: 0.15s;
+      height: 100%;
+    }
+    &:nth-of-type(3) {
+      animation-delay: 0.3s;
+      height: 75%;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    & > span {
+      animation: none;
+      transform: scaleY(0.8);
+    }
+  }
+
+  @keyframes inlineBounce {
+    0%,
+    100% {
+      transform: scaleY(0.4);
+    }
+    50% {
+      transform: scaleY(1);
+    }
+  }
+`;
+
+export const PlayingMusicBars: React.FC<{
+  variant?: "cover" | "inline";
+}> = ({ variant = "cover" }) => {
+  if (variant === "inline") {
+    return (
+      <InlineWrapper aria-hidden="true">
+        <span />
+        <span />
+        <span />
+      </InlineWrapper>
+    );
+  }
   return (
-    <Wrapper width={width} height={height}>
+    <CoverWrapper>
       <div>
         <span />
         <span />
@@ -111,6 +142,6 @@ export const PlayingMusicBars: React.FC<{ width: number; height: number }> = ({
         <span />
         <span />
       </div>
-    </Wrapper>
+    </CoverWrapper>
   );
 };

--- a/client/src/components/common/TrackList/TrackRow.tsx
+++ b/client/src/components/common/TrackList/TrackRow.tsx
@@ -1,11 +1,16 @@
 import styled from "@emotion/styled";
 import DownloadAlbumButton from "components/common/DownloadAlbumButton";
+import { PlayingMusicBars } from "components/common/PlayingMusicBars";
 import WishlistTrack from "components/TrackGroup/WishlistTrack";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { FaExternalLinkAlt } from "react-icons/fa";
+import { TfiControlPause } from "react-icons/tfi";
+import { VscPlay } from "react-icons/vsc";
+import { Link } from "react-router-dom";
 import { useAuthContext } from "state/AuthContext";
 import { useGlobalStateContext } from "state/GlobalState";
+import { getArtistUrl } from "utils/artist";
 import { usePlayerSyncRequest } from "utils/playerSync";
 import { fmtMSS, isTrackOwnedOrPreview } from "utils/tracks";
 import { isEmbeddedInMirlo } from "utils/widgetContext";
@@ -20,7 +25,7 @@ import LyricsModal from "./LyricsModal";
 import TrackAuthors from "./TrackAuthors";
 import TrackRowPlayControl from "./TrackRowPlayControl";
 
-type Variant = "default" | "compact" | "widget";
+type Variant = "default" | "compact" | "widget" | "dock";
 
 const LI = styled.li<{
   canPlayTrack: boolean;
@@ -30,7 +35,12 @@ const LI = styled.li<{
   --track-row-lh: ${(p) => (p.variant === "default" ? "2rem" : "1.5rem")};
 
   @media (max-width: 768px) {
-    --track-row-lh: ${(p) => (p.variant === "default" ? "1.75rem" : "1.5rem")};
+    --track-row-lh: ${(p) =>
+      p.variant === "default"
+        ? "1.75rem"
+        : p.variant === "dock"
+          ? "1.75rem"
+          : "1.5rem"};
   }
 
   display: flex;
@@ -41,27 +51,42 @@ const LI = styled.li<{
   padding: ${(p) =>
     p.variant === "widget"
       ? "0.125rem 1rem 0.125rem 1rem"
-      : p.variant === "compact"
-        ? "0.125rem 0"
-        : "0.25rem 0"};
+      : p.variant === "dock"
+        ? "0.25rem 0.5rem 0.5rem"
+        : p.variant === "compact"
+          ? "0.125rem 0"
+          : "0.25rem 0"};
+
+  @media (max-width: 768px) {
+    ${(p) => (p.variant === "dock" ? "padding: 0.5rem 0.5rem 0.75rem;" : "")}
+  }
 
   & * {
     line-height: inherit;
   }
 
-  & > :first-child {
-    flex-shrink: 0;
-    width: var(--track-row-lh);
-    height: var(--track-row-lh);
-    display: flex;
-    align-items: center;
-    justify-content: ${(p) =>
-      p.variant === "widget" ? "flex-start" : "center"};
-  }
+  ${(p) =>
+    p.variant !== "dock"
+      ? `
+    & > :first-child {
+      flex-shrink: 0;
+      width: var(--track-row-lh);
+      height: var(--track-row-lh);
+      display: flex;
+      align-items: center;
+      justify-content: ${p.variant === "widget" ? "flex-start" : "center"};
+    }
+  `
+      : ""}
 
   &:hover {
     background-color: var(--mi-tint-x-color);
   }
+
+  ${(p) =>
+    p.variant === "dock" && p.isPlaying
+      ? `background-color: var(--mi-tint-x-color);`
+      : ""}
 
   ${(p) =>
     !p.canPlayTrack ? `color: var(--mi-contrast-color); opacity: .6;` : ""}
@@ -160,7 +185,7 @@ const TrackRow: React.FC<{
   track: Track;
   trackGroup: TrackGroup;
   addTracksToQueue: (id: number) => void;
-  size?: "small" | "compact";
+  size?: "small" | "compact" | "dock";
   inWidget?: boolean;
 }> = ({
   track,
@@ -183,13 +208,16 @@ const TrackRow: React.FC<{
   const embeddedInMirlo = isEmbeddedInMirlo();
   const sendPlayerRequest = usePlayerSyncRequest();
   const showDropdownCell =
-    size !== "small" && size !== "compact" && showDropdown;
+    size !== "small" && size !== "compact" && size !== "dock" && showDropdown;
   const isCompact = size === "compact";
+  const isDock = size === "dock";
   const variant: Variant = inWidget
     ? "widget"
-    : isCompact
-      ? "compact"
-      : "default";
+    : isDock
+      ? "dock"
+      : isCompact
+        ? "compact"
+        : "default";
   const currentPlayingTrackId =
     currentlyPlayingIndex !== undefined
       ? playerQueueIds[currentlyPlayingIndex]
@@ -231,44 +259,87 @@ const TrackRow: React.FC<{
           : ""
       }`}
     >
-      <div onClick={onTrackPlay}>
-        <TrackRowPlayControl
-          trackId={track.id}
-          canPlayTrack={canPlayTrack}
-          trackNumber={track.order}
-          onTrackPlayCallback={addTracksToQueue}
-          inWidget={inWidget}
-          compact={isCompact}
-        />
-      </div>
+      {!isDock && (
+        <div onClick={onTrackPlay}>
+          <TrackRowPlayControl
+            trackId={track.id}
+            canPlayTrack={canPlayTrack}
+            trackNumber={track.order}
+            onTrackPlayCallback={addTracksToQueue}
+            inWidget={inWidget}
+            compact={isCompact}
+          />
+        </div>
+      )}
+
+      {isDock && canPlayTrack && (
+        <button
+          type="button"
+          onClick={onTrackPlay}
+          aria-label={t(isThisTrackPlaying ? "pauseTrack" : "playTrack", {
+            title: track.title ?? t("untitled"),
+          })}
+          className="sr-only focus-visible:not-sr-only focus-visible:flex focus-visible:items-center focus-visible:justify-center focus-visible:w-7 focus-visible:h-7 focus-visible:bg-(--mi-tint-x-color) focus-visible:rounded"
+        >
+          {isThisTrackPlaying ? <TfiControlPause /> : <VscPlay />}
+        </button>
+      )}
 
       <div
         onClick={onTrackPlay}
         className="flex-1 min-w-0 flex items-start justify-between gap-2"
       >
-        <div
-          className={`overflow-hidden text-ellipsis grow [&_i]:opacity-80 ${
-            inWidget
-              ? "whitespace-nowrap break-normal min-w-0 text-xs"
-              : isCompact
-                ? "text-sm"
-                : "max-md:text-sm"
-          }`}
-        >
-          {track.title ?? <i>{t("untitled")}</i>}
-          <TrackAuthors
-            track={track}
-            trackGroupArtistId={trackGroup.artistId}
-          />
-        </div>
+        {isDock ? (
+          <div className="grow flex flex-col min-w-0 [&_i]:opacity-80">
+            <span className="truncate text-xs max-md:text-sm leading-tight!">
+              {isThisTrackPlaying && (
+                <>
+                  <PlayingMusicBars variant="inline" />
+                  <span className="sr-only">{t("nowPlaying")} </span>
+                </>
+              )}
+              {track.title ?? <i>{t("untitled")}</i>}
+            </span>
+            {trackGroup.artist?.name && (
+              <span className="truncate text-[0.65rem] max-md:text-xs leading-tight! mt-1">
+                {t("by")}{" "}
+                <Link
+                  to={getArtistUrl(trackGroup.artist)}
+                  onClick={(e) => e.stopPropagation()}
+                  className="font-bold text-(--mi-text-color)!"
+                >
+                  {trackGroup.artist.name}
+                </Link>
+              </span>
+            )}
+          </div>
+        ) : (
+          <div
+            className={`overflow-hidden text-ellipsis grow [&_i]:opacity-80 ${
+              inWidget
+                ? "whitespace-nowrap break-normal min-w-0 text-xs"
+                : isCompact
+                  ? "text-sm"
+                  : "max-md:text-sm"
+            }`}
+          >
+            {track.title ?? <i>{t("untitled")}</i>}
+            <TrackAuthors
+              track={track}
+              trackGroupArtistId={trackGroup.artistId}
+            />
+          </div>
+        )}
 
         <div
           className={`shrink-0 ${
             inWidget
               ? "text-xs"
-              : isCompact
-                ? "text-sm"
-                : "text-sm max-md:text-xs max-md:font-bold"
+              : isDock
+                ? "text-xs max-md:text-sm"
+                : isCompact
+                  ? "text-sm"
+                  : "text-sm max-md:text-xs max-md:font-bold"
           }`}
         >
           {track.audio?.duration && fmtMSS(track.audio.duration)}

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -661,6 +661,9 @@
     "publishedAt": "Published {{ date }}",
     "likedThisPost": "Liked this post?"
   },
+  "postTracksDock": {
+    "label": "Playing in this post"
+  },
   "manage": {
     "manageArtists": "Manage artist pages",
     "managePayment": "Manage payment processor",
@@ -1440,6 +1443,9 @@
   "trackGroupDetails": {
     "trackgroup": "Release:",
     "untitled": "Untitled",
+    "nowPlaying": "Now playing:",
+    "playTrack": "Play {{title}}",
+    "pauseTrack": "Pause {{title}}",
     "allOrNothingFullyFunded": "This project is fully funded! Backing it now means you'll contribute to its future success.",
     "by": "by",
     "trackCount_one": "{{count}} track",

--- a/src/jobs/send-post-notification.ts
+++ b/src/jobs/send-post-notification.ts
@@ -175,14 +175,19 @@ export default async function sendPostNotification(job: {
         continue;
       }
 
-      const postForEmail = serializePost({
-        id: post.id,
-        title: post.title,
-        urlSlug: post.urlSlug,
-        featuredImage: post.featuredImage,
-        content: post.content,
-        isPublic: post.isPublic,
-      });
+      const postForEmail = serializePost(
+        {
+          id: post.id,
+          title: post.title,
+          urlSlug: post.urlSlug,
+          featuredImage: post.featuredImage,
+          content: post.content,
+          isPublic: post.isPublic,
+        },
+        undefined,
+        undefined,
+        true
+      );
 
       await sendMailQueue.add(
         "send-mail",

--- a/src/routers/v1/manage/posts/index.ts
+++ b/src/routers/v1/manage/posts/index.ts
@@ -143,7 +143,9 @@ export default function () {
     });
 
     res.json({
-      results: posts.map((post) => serializePost(post)),
+      results: posts.map((post) =>
+        serializePost(post, undefined, undefined, true)
+      ),
     });
   }
 

--- a/src/utils/serialize/post.ts
+++ b/src/utils/serialize/post.ts
@@ -72,43 +72,47 @@ export const serializePost = (
   userTrackGroupPurchases?: Array<{ userId: number; trackGroupId: number }>,
   userTrackPurchases?: Array<{ userId: number; trackId: number }>,
   isUserSubscriber?: boolean
-) => ({
-  ...post,
-  tracks: post.tracks?.map((pt) => {
-    // Use provided purchase arrays if available, otherwise extract from nested structure
-    const tgPurchases = userTrackGroupPurchases ?? [];
-    const trackPurchases = userTrackPurchases ?? [];
+) => {
+  const canSeeContent = !!(isUserSubscriber || post.isPublic);
+  return {
+    ...post,
+    tracks: canSeeContent
+      ? post.tracks?.map((pt) => {
+          const tgPurchases = userTrackGroupPurchases ?? [];
+          const trackPurchases = userTrackPurchases ?? [];
 
-    return {
-      isPlayable: isTrackPlayable({
-        isPreview: pt.track?.isPreview,
-        trackGroupId: pt.track?.trackGroupId,
-        trackId: pt.trackId,
-        trackGroupPurchases: tgPurchases,
-        trackPurchases: trackPurchases,
-        isUserSubscriber,
-      }),
-      title: pt.track?.title ?? undefined,
-      audioDuration: pt.track?.audio?.duration ?? undefined,
-      ...pt,
-    };
-  }),
-  artist: {
-    ...post.artist,
-    avatar: post.artist
-      ? addSizesToImage(finalArtistAvatarBucket, post.artist?.avatar)
-      : null,
-  },
-  featuredImage: post.featuredImage && {
-    ...post.featuredImage,
-    src: generateFullStaticImageUrl(
-      post.featuredImage.id,
-      finalPostImageBucket,
-      post.featuredImage.extension
-    ),
-  },
-  isContentHidden: !(isUserSubscriber || post.isPublic),
-  content: !(isUserSubscriber || post.isPublic)
-    ? extractFirstParagraph(post.content ?? "")
-    : post.content,
-});
+          return {
+            isPlayable: isTrackPlayable({
+              isPreview: pt.track?.isPreview,
+              trackGroupId: pt.track?.trackGroupId,
+              trackId: pt.trackId,
+              trackGroupPurchases: tgPurchases,
+              trackPurchases: trackPurchases,
+              isUserSubscriber,
+            }),
+            title: pt.track?.title ?? undefined,
+            audioDuration: pt.track?.audio?.duration ?? undefined,
+            ...pt,
+          };
+        })
+      : undefined,
+    artist: {
+      ...post.artist,
+      avatar: post.artist
+        ? addSizesToImage(finalArtistAvatarBucket, post.artist?.avatar)
+        : null,
+    },
+    featuredImage: post.featuredImage && {
+      ...post.featuredImage,
+      src: generateFullStaticImageUrl(
+        post.featuredImage.id,
+        finalPostImageBucket,
+        post.featuredImage.extension
+      ),
+    },
+    isContentHidden: !canSeeContent,
+    content: !canSeeContent
+      ? extractFirstParagraph(post.content ?? "")
+      : post.content,
+  };
+};


### PR DESCRIPTION
This is a follow up to #2041 which added a tracklist for long blogposts so people can quickly brows all the songs in the post without leaving the space they're in in the post, which needed a visual refresh. The post songs list now lives in a bottom right corner expandable dock, which appears open by default on desktop, closed by default on mobile. I tried to limit how invasive it was in both cases to preserve the blogpost page layout.

<img width="75" height="133" alt="Screenshot_Dock_01" src="https://github.com/user-attachments/assets/7fcef717-42a1-4e7c-bf4c-40c737e55a23" />
<img width="75" height="133" alt="Screenshot_Dock_02" src="https://github.com/user-attachments/assets/7fe9838d-a53f-47d0-88cd-5d8cc8b97b83" />
<img width="216" height="144" alt="Screenshot_Dock_03" src="https://github.com/user-attachments/assets/3d6563c1-e7bc-4fa1-84f5-86963d811d49" />
