### PR TITLE
chore: move to a simplified bucket system for those of us not already…

### DIFF
--- a/client/src/pages/admin/settings/Index.tsx
+++ b/client/src/pages/admin/settings/Index.tsx
@@ -30,10 +30,12 @@ interface FormSettings {
   s3?: SettingsFromAPI["settings"]["s3"];
   cloudflareTurnstileSecret?: string;
   defconLevel?: number;
+  bucketPrefix?: string;
 }
 
 interface SettingsFromAPI {
   cdnUrl?: string;
+  bucketNames?: { prefix: string } | null;
   settings: {
     platformPercent: number;
     instanceArtistId: number;
@@ -136,6 +138,7 @@ const Index = () => {
         s3: {
           ...response.result.settings?.s3,
         },
+        bucketPrefix: response.result.bucketNames?.prefix ?? "",
         cloudflareTurnstileSecret:
           response.result.settings?.cloudflareTurnstileSecret,
         terms: response.result.terms,
@@ -172,6 +175,10 @@ const Index = () => {
             featuredArtistIds: featuredArtists.map((a) => a.id),
           },
           cdnUrl: data.cdnUrl,
+          bucketNames:
+            data.bucketPrefix !== undefined
+              ? { prefix: data.bucketPrefix }
+              : undefined,
           terms: data.terms,
           showQueueDashboard: data.showQueueDashboard,
           isClosedToPublicArtistSignup: data.isClosedToPublicArtistSignup,
@@ -508,6 +515,26 @@ const Index = () => {
             <td>
               <InputEl
                 {...register("s3.region")}
+                className={css`
+                  text-align: right;
+                `}
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Bucket prefix
+              <br />
+              <small>
+                Leave empty for legacy mode (separate per-type buckets). Set to
+                any string (e.g. "") to use consolidated 3-bucket mode:
+                mirlo-audio, mirlo-images, mirlo-downloads.
+              </small>
+            </td>
+            <td>
+              <InputEl
+                {...register("bucketPrefix")}
+                placeholder="(empty = legacy mode)"
                 className={css`
                   text-align: right;
                 `}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -68,6 +68,12 @@ export default defineConfig({
       {
         text: "Hosting Mirlo",
         link: "/hosting",
+        items: [
+          {
+            text: "Object storage & buckets",
+            link: "/hosting/object-storage",
+          },
+        ],
       },
       {
         text: "For Mirlo Maintainers",

--- a/docs/hosting/object-storage.md
+++ b/docs/hosting/object-storage.md
@@ -1,0 +1,102 @@
+# Object storage & bucket structure
+
+Mirlo stores all media (audio, images, downloadable files) in S3-compatible
+object storage: MinIO in local development, Backblaze B2 (or any S3-compatible
+provider) in production.
+
+All storage access goes through [`src/utils/minio.ts`](https://github.com/funmusicplace/mirlo/blob/main/src/utils/minio.ts),
+which is a backend-agnostic abstraction over both MinIO and S3 clients (the
+filename is historical). Call sites express intent (`uploadIncomingAudio`,
+`getCoverBuffer`, `uploadZip`, …) and that module decides which bucket and
+object key to use.
+
+## Two bucket layouts
+
+There are two supported bucket layouts, controlled by the `bucketNames` value
+in the `Settings` table (editable in the admin settings UI):
+
+| `bucketNames` value        | Mode                                                                                                 |
+| -------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `null`                     | **Legacy**: one bucket per media type (~14 buckets). Existing installs stay on this — nothing moves. |
+| `{ "prefix": "<string>" }` | **Consolidated**: 3 buckets with path prefixes. New installs default to `{ "prefix": "" }`.          |
+
+The `prefix` is prepended to the three consolidated bucket names, so an
+instance configured with `{ "prefix": "myinstance-" }` uses the buckets
+`myinstance-mirlo-audio`, `myinstance-mirlo-images` and
+`myinstance-mirlo-downloads`. This matters for providers like Backblaze where
+bucket names are globally unique.
+
+## Consolidated layout
+
+### `mirlo-audio`
+
+| Key                                                 | Contents                                     |
+| --------------------------------------------------- | -------------------------------------------- |
+| `incoming/<audioId>`                                | Raw uploaded audio, before FFmpeg processing |
+| `<audioId>/original.<ext>`                          | The original file, kept after processing     |
+| `<audioId>/playlist.m3u8`, `<audioId>/segment-*.ts` | HLS stream segments                          |
+
+### `mirlo-images`
+
+Image keys are prefixed with the media type they belong to. The prefixes
+deliberately reuse the **legacy final bucket names**, so migrating an existing
+install is a straight copy of each legacy bucket into a same-named folder:
+
+| Key prefix                                   | Contents                                                         |
+| -------------------------------------------- | ---------------------------------------------------------------- |
+| `incoming/<type>/<imageId>`                  | Uploaded images awaiting optimization                            |
+| `trackgroup-covers/`                         | Album/release covers                                             |
+| `artist-avatars/`, `artist-banners/`         | Artist profile images                                            |
+| `mirlo-user-avatars/`, `mirlo-user-banners/` | User profile images                                              |
+| `merch-images/`                              | Merch photos                                                     |
+| `post-images/`                               | Images embedded in posts                                         |
+| _(bucket root)_                              | Generic images (the `image` type, e.g. subscription tier images) |
+
+Optimized images are stored in multiple sizes as `<imageId>-x<width>.webp`
+(plus `.jpg` for covers).
+
+The full routing table (incoming bucket, final bucket, path prefix, and
+whether the type goes through the optimize-image queue) is `imageTypeBuckets`
+in `src/utils/minio.ts` — that is the single source of truth if this document
+drifts.
+
+### `mirlo-downloads`
+
+| Key                            | Contents                                                     |
+| ------------------------------ | ------------------------------------------------------------ |
+| `content/<id>`                 | Downloadable content attached to releases/merch (PDFs, etc.) |
+| `trackgroup/<id>/<format>.zip` | Cached album download zips, per audio format                 |
+| `track/<id>/<format>.zip`      | Cached single-track download zips                            |
+
+## Legacy layout
+
+One bucket per media type, with bare object keys. Most types have a separate
+`incoming-*` bucket for uploads awaiting processing:
+
+| Media                | Incoming bucket           | Final bucket                 |
+| -------------------- | ------------------------- | ---------------------------- |
+| Track audio          | `incoming-track-audio`    | `track-audio`                |
+| Release covers       | `incoming-covers`         | `trackgroup-covers`          |
+| Artist avatars       | `incoming-artist-avatars` | `artist-avatars`             |
+| Artist banners       | `incoming-artist-banners` | `artist-banners`             |
+| User avatars         | `incoming-artist-avatars` | `mirlo-user-avatars`         |
+| User banners         | `incoming-user-banners`   | `mirlo-user-banners`         |
+| Merch images         | `incoming-merch-images`   | `merch-images`               |
+| Post images          | —                         | `post-images`                |
+| Generic images       | `incoming-mirlo-images`   | `mirlo-images`               |
+| Downloadable content | —                         | `mirlo-downloadable-content` |
+| Album zips           | —                         | `trackgroup-format`          |
+| Track zips           | —                         | `track-format`               |
+
+## How images are served
+
+In development (MinIO), the API proxies images at
+`/images/<bucket>/<key>` — note that in consolidated mode the key contains
+slashes (e.g. `/images/mirlo-images/trackgroup-covers/<id>-x600.webp`).
+
+In production (S3/Backblaze), URLs point either at a CDN (`cdnUrl` in site
+settings) or directly at the provider's public bucket URL. URL construction
+lives in `generateFullStaticImageUrl` in `src/utils/images.ts`, which derives
+the bucket and key prefix from the same routing table used for uploads.
+
+Buckets are created automatically on first use; MinIO needs no manual setup.

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,10 @@ if (!isDev) {
 
 app.use(express.static("public", { maxAge: "1y", immutable: true }));
 
-app.use("/images/:bucket/:filename", serveStatic);
+// Note: only the bucket is a route param — in consolidated bucket mode the
+// object key contains slashes (e.g. trackgroup-covers/<id>-x600.webp), so
+// serveStatic reads the rest of the path itself.
+app.use("/images/:bucket", serveStatic);
 
 app.use("/admin/queues", async (req, res) => {
   const settings = await getSiteSettings();

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import auth from "./routers/auth";
 import { serveStatic } from "./static";
 import errorHandler from "./utils/error";
 import { setCdnUrl } from "./utils/images";
+import { setBucketConfig, BucketConfig } from "./utils/minio";
 import { sanitizeHeadersForLogs } from "./utils/requestLogging";
 import { getSiteSettings } from "./utils/settings";
 import { refreshStripeClient } from "./utils/stripe";
@@ -283,6 +284,7 @@ app.listen(process.env.PORT, async () => {
   const settings = await getSiteSettings();
   setCdnUrl(settings.cdnUrl ?? undefined);
   await refreshStripeClient();
+  setBucketConfig((settings.bucketNames as BucketConfig | null) ?? null);
   console.info(`
 🚀 Server ready at: ${process.env.API_DOMAIN}`);
 });

--- a/src/jobs/generate-album.ts
+++ b/src/jobs/generate-album.ts
@@ -15,15 +15,10 @@ import { Job } from "bullmq";
 import filenamify from "filenamify";
 
 import {
-  createBucketIfNotExists,
-  downloadableContentBucket,
-  finalAudioBucket,
-  finalCoversBucket,
-  getBufferFromStorage,
-  getFile,
-  trackFormatBucket,
-  trackGroupFormatBucket,
-  uploadWrapper,
+  downloadOriginalAudio,
+  getDownloadableContentBuffer,
+  getCoverBuffer,
+  uploadZip,
 } from "../utils/minio";
 import { convertAudioToFormat } from "../utils/tracks";
 
@@ -94,15 +89,17 @@ const downloadTracks = async ({
       );
       continue;
     }
-    const originalTrackLocation = `${track.audio.id}/original.${track.audio.fileExtension}`;
-    logger.info(`audioId ${track.audio.id}: Fetching ${originalTrackLocation}`);
     const tempTrackPath = `${tempFolder}/${track.audio.id}-original.${track.audio.fileExtension}`;
     logger.info(`audioId ${track.audio.id}: Downloading to ${tempTrackPath}`);
     try {
-      await getFile(finalAudioBucket, originalTrackLocation, tempTrackPath);
+      await downloadOriginalAudio(
+        track.audio.id,
+        track.audio.fileExtension ?? "mp3",
+        tempTrackPath
+      );
     } catch (e) {
       logger.error(
-        `Error fetching original track: ${e}: ${originalTrackLocation}`
+        `Error fetching original track: ${e}: ${track.audio.id}/original.${track.audio.fileExtension}`
       );
       await fsPromises.rm(tempTrackPath, { force: true });
 
@@ -112,7 +109,7 @@ const downloadTracks = async ({
     i += 1;
     await job.updateProgress(progress);
     logger.info(
-      `audioId ${track.audio.id}: going to convert audio ${originalTrackLocation} to format ${format.format}${format.audioBitrate ? `@${format.audioBitrate}` : ""}`
+      `audioId ${track.audio.id}: going to convert audio to format ${format.format}${format.audioBitrate ? `@${format.audioBitrate}` : ""}`
     );
 
     await new Promise((resolve, reject) => {
@@ -150,12 +147,14 @@ const downloadTracks = async ({
 
 const zipFilesInFolder = async ({
   tempFolder,
-  zipFileName,
-  destinationBucket,
+  type,
+  id,
+  format,
 }: {
   tempFolder: string;
-  zipFileName: string;
-  destinationBucket: string;
+  type: "track" | "trackGroup";
+  id: number;
+  format: string;
 }) => {
   const profiler = logger.startTimer();
 
@@ -163,7 +162,7 @@ const zipFilesInFolder = async ({
     const finalFilesInFolder = await fsPromises.readdir(tempFolder);
 
     logger.info(
-      `zipFilesInFolder: ${tempFolder}: Zipping files to ${zipFileName} in bucket ${destinationBucket}: ${finalFilesInFolder.join(", ")}`
+      `zipFilesInFolder: ${tempFolder}: Zipping ${id}/${format}.zip: ${finalFilesInFolder.join(", ")}`
     );
 
     const archive = archiver("zip", {
@@ -201,12 +200,9 @@ const zipFilesInFolder = async ({
 
     archive.pipe(pass);
     archive.finalize();
-
-    // Resolve only after the upload completes. Resolving on archive's "finish"
-    // event was too early: the archive signals it has finished writing to the
-    // PassThrough, but MinIO may not have finished receiving the upload yet.
     try {
-      await uploadWrapper(destinationBucket, zipFileName, pass);
+      await uploadZip(type, id, format, pass);
+
       logger.info(
         `zipFilesInFolder: ${tempFolder}: Cleaned up incoming bucket`
       );
@@ -250,10 +246,7 @@ const downloadTrackGroupContent = async ({
         logger.info(
           `downloadTrackGroupContent: ${trackGroupId}: Fetching content ${item.id}`
         );
-        const { buffer } = await getBufferFromStorage(
-          downloadableContentBucket,
-          item.id
-        );
+        const { buffer } = await getDownloadableContentBuffer(item.id);
 
         if (buffer) {
           logger.info(
@@ -284,10 +277,7 @@ const downloadCover = async ({
     logger.info(`downloadCover: ${coverId}: Adding cover`);
 
     try {
-      const { buffer } = await getBufferFromStorage(
-        finalCoversBucket,
-        `${coverId}-x1500.webp`
-      );
+      const { buffer } = await getCoverBuffer(coverId, "webp");
       if (buffer) {
         await fsPromises.writeFile(coverDestination, buffer);
         chosenCoverLocation = coverDestination;
@@ -299,10 +289,7 @@ const downloadCover = async ({
     }
 
     try {
-      const { buffer: buffer2 } = await getBufferFromStorage(
-        finalCoversBucket,
-        `${coverId}-x1500.jpg`
-      );
+      const { buffer: buffer2 } = await getCoverBuffer(coverId, "jpg");
       if (buffer2) {
         const jpgDestination = coverDestination.replace(".webp", ".jpg");
         await fsPromises.writeFile(jpgDestination, buffer2);
@@ -326,7 +313,7 @@ const downloadAndZipTracks = async ({
   trackGroup,
   job,
   artist,
-  destinationBucket,
+  destinationType,
 }: {
   formatString: string;
   tempFolder: string;
@@ -339,7 +326,7 @@ const downloadAndZipTracks = async ({
   };
   job: Job;
   artist: Artist;
-  destinationBucket: DestinationBucket;
+  destinationType: "track" | "trackGroup";
 }) => {
   try {
     const format = parseFormat(formatString);
@@ -347,8 +334,6 @@ const downloadAndZipTracks = async ({
 
     let progress = 10;
     const coverDestination = `${tempFolder}/cover.webp`;
-
-    await createBucketIfNotExists(destinationBucket, logger);
 
     logger.info(`Checking if folder exists, if not creating it ${tempFolder}`);
     try {
@@ -387,10 +372,12 @@ const downloadAndZipTracks = async ({
 
     logger.info(`trackGroupId ${trackGroup.id}: Building zip`);
 
+    const zipId = destinationType === "track" ? tracks[0].id : trackGroup.id;
     await zipFilesInFolder({
       tempFolder,
-      zipFileName: `${destinationBucket === trackFormatBucket ? tracks[0].id : trackGroup.id}/${formatString}.zip`,
-      destinationBucket,
+      type: destinationType,
+      id: zipId,
+      format: formatString,
     });
 
     await job.updateProgress(90);
@@ -400,16 +387,12 @@ const downloadAndZipTracks = async ({
   }
 };
 
-type DestinationBucket =
-  | typeof trackFormatBucket
-  | typeof trackGroupFormatBucket;
-
 export default async (job: Job) => {
   const {
     trackGroup,
     format: formatString,
     tracks,
-    destinationBucket,
+    destinationType = "trackGroup",
   } = job.data as {
     tracks: (Track & {
       audio: TrackAudio;
@@ -419,11 +402,11 @@ export default async (job: Job) => {
       cover: TrackGroupCover;
     };
     format: string;
-    destinationBucket: DestinationBucket;
+    destinationType: "track" | "trackGroup";
   };
   let tempFolder = `${TEMP_LOCATION}trackGroup/${trackGroup.id}/${formatString}`;
 
-  if (destinationBucket === "track-format") {
+  if (destinationType === "track") {
     tempFolder = `${TEMP_LOCATION}track/${tracks[0].id}/${formatString}`;
   }
 
@@ -443,7 +426,7 @@ export default async (job: Job) => {
       trackGroup,
       job,
       artist,
-      destinationBucket,
+      destinationType,
     });
   } catch (e) {
     logger.error(`Error creating zip of tracks folder: ${tempFolder}`);

--- a/src/jobs/optimize-image.ts
+++ b/src/jobs/optimize-image.ts
@@ -7,10 +7,11 @@ import ico from "sharp-ico";
 import tempSharpConfig from "../config/sharp";
 import { generateFullStaticImageUrl } from "../utils/images";
 import {
-  createBucketIfNotExists,
-  getBufferFromStorage,
-  removeObjectFromStorage,
-  uploadWrapper,
+  ImageType,
+  downloadIncomingImageByType,
+  uploadOptimizedImageByType,
+  removeIncomingImageByType,
+  getImageFinalBucket,
 } from "../utils/minio";
 
 import { logger } from "./queue-worker";
@@ -34,27 +35,27 @@ const optimizeImage = async (job: Job) => {
     config = sharpConfig.artwork,
     destinationId,
     model,
-    incomingMinioBucket,
-    finalMinioBucket,
-  } = job.data;
+    imageType,
+  } = job.data as {
+    config: typeof sharpConfig.artwork;
+    destinationId: string;
+    model: string;
+    imageType: ImageType;
+  };
 
   try {
     const profiler = logger.startTimer();
 
     logger.info(`Starting to optimize images ${model}/${destinationId}`);
-    const { buffer } = await getBufferFromStorage(
-      incomingMinioBucket,
+    const { buffer } = await downloadIncomingImageByType(
+      imageType,
       destinationId
     );
 
     if (!buffer) {
-      logger.error(
-        `No buffer found for ${incomingMinioBucket}/${destinationId}`
-      );
+      logger.error(`No buffer found for incoming image ${destinationId}`);
       return { error: "No buffer found" };
     }
-
-    await createBucketIfNotExists(finalMinioBucket, logger);
 
     // logger.info(`Got object of size ${size}`);
     const promises = Object.entries(config)
@@ -116,8 +117,8 @@ const optimizeImage = async (job: Job) => {
               const originalSize =
                 await originalPipeline[outputType](outputOptions).toBuffer();
 
-              await uploadWrapper(
-                finalMinioBucket,
+              await uploadOptimizedImageByType(
+                imageType,
                 `${destinationId}-original${ext}`,
                 originalSize,
                 {
@@ -192,8 +193,8 @@ const optimizeImage = async (job: Job) => {
                 );
 
                 logger.info("Uploading image to bucket");
-                await uploadWrapper(
-                  finalMinioBucket,
+                await uploadOptimizedImageByType(
+                  imageType,
                   finalFileName,
                   newBuffer,
                   {
@@ -263,14 +264,19 @@ const optimizeImage = async (job: Job) => {
       });
     } else if (model === "userAvatar") {
       try {
-        const faviconFinalName = `${destinationId}_user_avatar_favicon.ico`;
         const sharpBuffer = await sharp(buffer).png().toBuffer();
         const faviconBuffer = ico.encode([sharpBuffer]);
         logger.info("Uploading user avatar favicon to bucket");
-        await uploadWrapper(finalMinioBucket, faviconFinalName, faviconBuffer, {
-          contentType: "image/x-icon",
-          cacheControl: "public, max-age=604800, stale-while-revalidate=604800",
-        });
+        await uploadOptimizedImageByType(
+          imageType,
+          `${destinationId}_user_avatar_favicon.ico`,
+          faviconBuffer,
+          {
+            contentType: "image/x-icon",
+            cacheControl:
+              "public, max-age=604800, stale-while-revalidate=604800",
+          }
+        );
         logger.info("User avatar favicon uploaded successfully");
       } catch (e) {
         const errorMessage = e instanceof Error ? e.message : String(e);
@@ -288,14 +294,19 @@ const optimizeImage = async (job: Job) => {
       });
     } else if (model === "artistAvatar") {
       try {
-        const faviconFinalName = `${destinationId}_artist_avatar_favicon.ico`;
         const sharpBuffer = await sharp(buffer).png().toBuffer();
         const faviconBuffer = ico.encode([sharpBuffer]);
         logger.info("Uploading artist avatar favicon to bucket");
-        await uploadWrapper(finalMinioBucket, faviconFinalName, faviconBuffer, {
-          contentType: "image/x-icon",
-          cacheControl: "public, max-age=604800, stale-while-revalidate=604800",
-        });
+        await uploadOptimizedImageByType(
+          imageType,
+          `${destinationId}_artist_avatar_favicon.ico`,
+          faviconBuffer,
+          {
+            contentType: "image/x-icon",
+            cacheControl:
+              "public, max-age=604800, stale-while-revalidate=604800",
+          }
+        );
         logger.info("Artist avatar favicon uploaded successfully");
       } catch (e) {
         const errorMessage = e instanceof Error ? e.message : String(e);
@@ -314,9 +325,9 @@ const optimizeImage = async (job: Job) => {
     }
 
     profiler.done({ message: "Done optimizing image" });
-    logger.info(`Removing from Bucket ${incomingMinioBucket}`);
+    logger.info(`Removing incoming image ${destinationId}`);
 
-    await removeObjectFromStorage(incomingMinioBucket, destinationId);
+    await removeIncomingImageByType(imageType, destinationId);
 
     if (urls.length === 0) {
       logger.warn(
@@ -330,7 +341,7 @@ const optimizeImage = async (job: Job) => {
       const searchParams = new URLSearchParams();
       searchParams.append(
         "url",
-        generateFullStaticImageUrl(urls[0], finalMinioBucket)
+        generateFullStaticImageUrl(urls[0], getImageFinalBucket(imageType))
       );
       searchParams.append("models", "nudity-2.1");
       searchParams.append("api_user", SIGHTENGINE_USER);

--- a/src/jobs/queue-worker.ts
+++ b/src/jobs/queue-worker.ts
@@ -3,24 +3,32 @@
 import * as dotenv from "dotenv";
 dotenv.config();
 
-import yargs from "yargs";
 import { Job, Worker } from "bullmq";
 import winston from "winston";
-import uploadAudioJob from "./upload-audio";
-import verifyAudioJob from "./verify-audio";
+import yargs from "yargs";
+
+import { REDIS_CONFIG } from "../config/redis";
+import { autoPurchaseNewAlbumsProcessor } from "../queues/auto-purchase-new-albums-queue";
+import { setBucketConfig, BucketConfig } from "../utils/minio";
+import { getSiteSettings } from "../utils/settings";
+
+import cleanUpOldFilesJob from "./clean-up-old-files";
 import generateAlbumJob from "./generate-album";
 import optimizeImage from "./optimize-image";
-import cleanUpOldFilesJob from "./clean-up-old-files";
-import sendPostNotification from "./send-post-notification";
-import { autoPurchaseNewAlbumsProcessor } from "../queues/auto-purchase-new-albums-queue";
-
 import sendMail from "./send-mail";
+import sendPostNotification from "./send-post-notification";
 
 import "../queues/send-mail-queue";
 import "../queues/send-post-notification-queue";
 import "../queues/auto-purchase-new-albums-queue";
 
-import { REDIS_CONFIG } from "../config/redis";
+import uploadAudioJob from "./upload-audio";
+import verifyAudioJob from "./verify-audio";
+
+// Initialize storage config from DB so job processors use the correct bucket names.
+getSiteSettings().then((settings) => {
+  setBucketConfig((settings.bucketNames as BucketConfig | null) ?? null);
+});
 
 export const logger = winston.createLogger({
   level: "info",
@@ -86,7 +94,7 @@ function createWorkerWithLogging(
   return worker;
 }
 
-yargs // eslint-disable-line
+yargs
   .command("run", "starts file processing queue", (argv: any) => {
     logger.info("STARTING WORKER QUEUE");
     audioQueue();

--- a/src/jobs/queue-worker.ts
+++ b/src/jobs/queue-worker.ts
@@ -25,11 +25,6 @@ import "../queues/auto-purchase-new-albums-queue";
 import uploadAudioJob from "./upload-audio";
 import verifyAudioJob from "./verify-audio";
 
-// Initialize storage config from DB so job processors use the correct bucket names.
-getSiteSettings().then((settings) => {
-  setBucketConfig((settings.bucketNames as BucketConfig | null) ?? null);
-});
-
 export const logger = winston.createLogger({
   level: "info",
   format: winston.format.json(),
@@ -95,7 +90,9 @@ function createWorkerWithLogging(
 }
 
 yargs
-  .command("run", "starts file processing queue", (argv: any) => {
+  .command("run", "starts file processing queue", async (argv: any) => {
+    const settings = await getSiteSettings();
+    setBucketConfig((settings.bucketNames as BucketConfig | null) ?? null);
     logger.info("STARTING WORKER QUEUE");
     audioQueue();
     // audioDurationQueue();

--- a/src/jobs/tasks/clean-up-files.ts
+++ b/src/jobs/tasks/clean-up-files.ts
@@ -5,11 +5,13 @@ import { startCleaningUpOldFiles } from "../../queues/clean-up-old-files-queue";
 import {
   removeObjectsFromBucket,
   trackGroupFormatBucket,
+  getDownloadsBucket,
 } from "../../utils/minio";
 
 const cleanUpFiles = async (incomingFolder: string) => {
   logger.info("cleanUpFiles");
-  if (incomingFolder.startsWith(trackGroupFormatBucket)) {
+  const effectiveTrackGroupBucket = getDownloadsBucket(trackGroupFormatBucket);
+  if (incomingFolder.startsWith(effectiveTrackGroupBucket)) {
     const split = incomingFolder.split(/\/(.*)/);
     const bucket = split[0];
     const albumId = split[1];

--- a/src/jobs/upload-audio.ts
+++ b/src/jobs/upload-audio.ts
@@ -4,12 +4,9 @@ import { Job } from "bullmq";
 import ffmpeg from "fluent-ffmpeg";
 
 import {
-  createBucketIfNotExists,
-  finalAudioBucket,
-  getFile,
-  incomingAudioBucket,
-  removeObjectFromStorage,
-  uploadWrapper,
+  downloadIncomingAudio,
+  uploadAudioHlsFile,
+  removeIncomingAudio,
 } from "../utils/minio";
 
 import { logger } from "./queue-worker";
@@ -26,7 +23,6 @@ export default async (job: Job) => {
       `upload-audio: checking if folder exists, if not creating it ${destinationFolder}`
     );
 
-    await createBucketIfNotExists(finalAudioBucket, logger);
     try {
       await fsPromises.stat(destinationFolder);
     } catch (e) {
@@ -37,7 +33,7 @@ export default async (job: Job) => {
     logger.info(`upload-audio: getting file and storing it at ${originalPath}`);
     // FIXME: can this be converted to a stream.
     // It looks like ffmpeg has issues with streams
-    await getFile(incomingAudioBucket, audioId, originalPath);
+    await downloadIncomingAudio(audioId, originalPath);
     logger.info(`upload-audio: got file and put it at ${originalPath}`);
 
     // Capture the original file size
@@ -98,14 +94,14 @@ export default async (job: Job) => {
       const uploadStream = await createReadStream(
         `${destinationFolder}/${file}`
       );
-      await uploadWrapper(finalAudioBucket, `${audioId}/${file}`, uploadStream);
+      await uploadAudioHlsFile(audioId, file, uploadStream);
     }
 
     profiler.done({ message: "Done converting to audio" });
 
     logger.info(`audioId ${audioId}: Done processing streams`);
 
-    await removeObjectFromStorage(incomingAudioBucket, audioId);
+    await removeIncomingAudio(audioId);
     logger.info(`audioId ${audioId}: Cleaned up incoming bucket`);
     await fsPromises.rm(destinationFolder, { recursive: true });
     logger.info(`Cleaned up ${destinationFolder}`);

--- a/src/jobs/verify-audio.ts
+++ b/src/jobs/verify-audio.ts
@@ -2,7 +2,7 @@ import { promises as fsPromises } from "fs";
 
 import { Job } from "bullmq";
 
-import { finalAudioBucket, getFile } from "../utils/minio";
+import { downloadOriginalAudio } from "../utils/minio";
 
 import { logger } from "./queue-worker";
 const TEMP_LOCATION = process.env.TEMP_LOCATION;
@@ -26,10 +26,9 @@ export default async (job: Job) => {
       await fsPromises.mkdir(tempFolder, { recursive: true });
     }
 
-    const remoteTrackLocation = `${audioId}/original.${fileExtension}`;
     const localTrackPath = `${tempFolder}/original.${fileExtension}`;
 
-    await getFile(finalAudioBucket, remoteTrackLocation, localTrackPath);
+    await downloadOriginalAudio(audioId, fileExtension, localTrackPath);
 
     logger.info(`audioId: ${audioId} \t got the track audio`);
 

--- a/src/queues/album-queue.ts
+++ b/src/queues/album-queue.ts
@@ -1,8 +1,8 @@
+import { Track, TrackAudio, TrackGroup } from "@mirlo/prisma/client";
 import { Queue, QueueEvents } from "bullmq";
+
 import { REDIS_CONFIG } from "../config/redis";
 import { logger } from "../logger";
-import { Track, TrackAudio, TrackGroup } from "@mirlo/prisma/client";
-import { trackFormatBucket, trackGroupFormatBucket } from "../utils/minio";
 
 const queueOptions = {
   prefix: "mirlo",
@@ -66,9 +66,7 @@ export const startGeneratingZip = async (
   trackGroup: TrackGroup & { tracks: Track[] },
   tracks: (Track & { audio: TrackAudio | null })[],
   format: string,
-  destinationBucket:
-    | typeof trackFormatBucket
-    | typeof trackGroupFormatBucket = trackGroupFormatBucket
+  destinationType: "track" | "trackGroup" = "trackGroup"
 ) => {
   const jobKey = `${trackGroup.id}-${format}`;
 
@@ -99,7 +97,7 @@ export const startGeneratingZip = async (
       trackGroup,
       tracks,
       format,
-      destinationBucket,
+      destinationType,
     },
     { deduplication: { id: jobKey, ttl: 5000 } }
   );

--- a/src/queues/processImages.ts
+++ b/src/queues/processImages.ts
@@ -8,18 +8,9 @@ import { logger } from "../jobs/queue-worker";
 import { AppError, HttpCode } from "../utils/error";
 import { APIContext } from "../utils/file";
 import {
-  createBucketIfNotExists,
-  finalArtistAvatarBucket,
-  finalArtistBackgroundBucket,
-  finalMerchImageBucket,
-  finalPostImageBucket,
-  finalUserAvatarBucket,
-  finalUserBannerBucket,
-  incomingArtistAvatarBucket,
-  incomingArtistBackgroundBucket,
-  incomingMerchImageBucket,
-  incomingUserBannerBucket,
-  uploadWrapper,
+  ImageType,
+  imageTypeUsesQueue,
+  uploadIncomingImageByType,
 } from "../utils/minio";
 
 const queueOptions = {
@@ -98,7 +89,7 @@ const isUnsupportedImageCodecError = (error: unknown) => {
 
 export const uploadAndSendToImageQueue = async (
   ctx: APIContext,
-  incomingBucket: string,
+  imageType: ImageType,
   model: string,
   sharpConfigKey: "artwork" | "avatar" | "background" | "banner" | "inFormData",
   createDatabaseEntry: (
@@ -111,7 +102,6 @@ export const uploadAndSendToImageQueue = async (
     },
     details: { dimensions: "square" | "background" | "banner" }
   ) => Promise<{ id: string } | void>,
-  finalBucket?: string, // If this is not supplied, we this basically just uploads to the first bucket,0
   storeWithExtension?: boolean
 ) => {
   logger.info(`Uploading ${sharpConfigKey} to object storage`);
@@ -141,9 +131,6 @@ export const uploadAndSendToImageQueue = async (
     ctx.req.busboy.on("error", reject);
     ctx.req.busboy.on("file", async (_fieldname, fileStream, fileInfo) => {
       try {
-        await createBucketIfNotExists(incomingBucket, logger);
-        logger.info("Made bucket");
-
         if (sharpConfigKey === "inFormData" && !fromBody.dimensions) {
           reject("Must provide dimensions field in form data");
           return;
@@ -190,9 +177,12 @@ export const uploadAndSendToImageQueue = async (
           const fileName = storeWithExtension
             ? `${image.id}.${[filenameArray[filenameArray.length - 1]]}`
             : image.id;
-          await uploadWrapper(incomingBucket, `${fileName}`, optimizedStream, {
-            contentType: fileInfo.mimeType || "application/octet-stream",
-          });
+          await uploadIncomingImageByType(
+            imageType,
+            fileName,
+            optimizedStream,
+            { contentType: fileInfo.mimeType || "application/octet-stream" }
+          );
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e);
 
@@ -217,14 +207,13 @@ export const uploadAndSendToImageQueue = async (
           return;
         }
 
-        if (finalBucket) {
+        if (imageTypeUsesQueue(imageType)) {
           logger.info("Adding image to queue");
 
           const job = await imageQueue.add("optimize-image", {
             destinationId: image.id,
             model,
-            incomingMinioBucket: incomingBucket,
-            finalMinioBucket: finalBucket,
+            imageType,
             config: sharpConfig.config[config],
           });
           resolve({ jobId: job.id, imageId: image.id });
@@ -247,7 +236,7 @@ export const processUserAvatar = (ctx: APIContext) => {
   return async (userId: number) => {
     return uploadAndSendToImageQueue(
       ctx,
-      incomingArtistAvatarBucket,
+      "userAvatar",
       "userAvatar",
       "avatar",
       async (fileInfo: { filename: string }) => {
@@ -265,8 +254,7 @@ export const processUserAvatar = (ctx: APIContext) => {
             userId,
           },
         });
-      },
-      finalUserAvatarBucket
+      }
     );
   };
 };
@@ -275,7 +263,7 @@ export const processUserBanner = (ctx: APIContext) => {
   return async (userId: number) => {
     return uploadAndSendToImageQueue(
       ctx,
-      incomingUserBannerBucket,
+      "userBanner",
       "userBanner",
       "banner",
       async (fileInfo: { filename: string }) => {
@@ -293,8 +281,7 @@ export const processUserBanner = (ctx: APIContext) => {
             userId,
           },
         });
-      },
-      finalUserBannerBucket
+      }
     );
   };
 };
@@ -303,7 +290,7 @@ export const processArtistAvatar = (ctx: APIContext) => {
   return async (artistId: number) => {
     return uploadAndSendToImageQueue(
       ctx,
-      incomingArtistAvatarBucket,
+      "artistAvatar",
       "artistAvatar",
       "avatar",
       async (fileInfo: { filename: string }) => {
@@ -321,8 +308,7 @@ export const processArtistAvatar = (ctx: APIContext) => {
             artistId,
           },
         });
-      },
-      finalArtistAvatarBucket
+      }
     );
   };
 };
@@ -331,7 +317,7 @@ export const processArtistBackground = (ctx: APIContext) => {
   return async (artistId: number) => {
     return uploadAndSendToImageQueue(
       ctx,
-      incomingArtistBackgroundBucket,
+      "artistBackground",
       "artistBackground",
       "background",
       async (fileInfo: { filename: string }) => {
@@ -348,8 +334,7 @@ export const processArtistBackground = (ctx: APIContext) => {
             artistId,
           },
         });
-      },
-      finalArtistBackgroundBucket
+      }
     );
   };
 };
@@ -358,7 +343,7 @@ export const processMerchImage = (ctx: APIContext) => {
   return async (merchId: string) => {
     return uploadAndSendToImageQueue(
       ctx,
-      incomingMerchImageBucket,
+      "merch",
       "merchImage",
       "artwork",
       async (_fileInfo: { filename: string }) => {
@@ -375,8 +360,7 @@ export const processMerchImage = (ctx: APIContext) => {
             merchId,
           },
         });
-      },
-      finalMerchImageBucket
+      }
     );
   };
 };
@@ -385,7 +369,7 @@ export const processPostImage = (ctx: APIContext) => {
   return async (postId: number) => {
     return uploadAndSendToImageQueue(
       ctx,
-      finalPostImageBucket,
+      "postImage",
       "postImage",
       "artwork",
       async (fileInfo: { filename: string; mimeType: string }) => {
@@ -399,7 +383,6 @@ export const processPostImage = (ctx: APIContext) => {
           },
         });
       },
-      undefined,
       true
     );
   };

--- a/src/queues/processTrackAudio.ts
+++ b/src/queues/processTrackAudio.ts
@@ -1,15 +1,11 @@
-import { Request, Response } from "express";
+import prisma from "@mirlo/prisma";
 import { Queue, QueueEvents } from "bullmq";
+import { Request, Response } from "express";
 
 import { REDIS_CONFIG } from "../config/redis";
-
-import prisma from "@mirlo/prisma";
 import { logger } from "../logger";
-import {
-  createBucketIfNotExists,
-  incomingAudioBucket,
-  uploadWrapper,
-} from "../utils/minio";
+import { uploadIncomingAudio } from "../utils/minio";
+
 import { verifyAudioQueue } from "./verify-audio-queue";
 
 export const buildTrackStreamURL = (trackId: number) => {
@@ -159,8 +155,6 @@ export const processTrackAudio = (ctx: { req: Request; res: Response }) => {
   return async (trackId: number) => {
     logger.info("Uploading trackAudio to temporary storage");
 
-    await createBucketIfNotExists(incomingAudioBucket, logger);
-
     ctx.req.pipe(ctx.req.busboy);
 
     const jobId = await new Promise((resolve, reject) => {
@@ -186,10 +180,8 @@ export const processTrackAudio = (ctx: { req: Request; res: Response }) => {
           },
         });
 
-        logger.info(
-          `Going to put a file on ${incomingAudioBucket}/${audio.id}: ${fileInfo.filename}`
-        );
-        await uploadWrapper(incomingAudioBucket, audio.id, fileStream);
+        logger.info(`Going to upload audio ${audio.id}: ${fileInfo.filename}`);
+        await uploadIncomingAudio(audio.id, fileStream);
 
         logger.info("Adding audio to upload-audio queue");
         const job = await audioQueue.add("upload-audio", {

--- a/src/routers/v1/admin/settings.ts
+++ b/src/routers/v1/admin/settings.ts
@@ -3,6 +3,7 @@ import { NextFunction, Request, Response } from "express";
 
 import { userAuthenticated, userHasPermission } from "../../../auth/passport";
 import { setCdnUrl } from "../../../utils/images";
+import { setBucketConfig, BucketConfig } from "../../../utils/minio";
 import { getSiteSettings } from "../../../utils/settings";
 import { refreshStripeClient } from "../../../utils/stripe";
 
@@ -32,6 +33,7 @@ export default function () {
       isClosedToPublicArtistSignup,
       showQueueDashboard,
       cdnUrl,
+      bucketNames,
     } = req.body;
     try {
       let existingSettings = await prisma.settings.findFirst();
@@ -67,6 +69,7 @@ export default function () {
           defconLevel: Number(defconLevel),
           showQueueDashboard,
           cdnUrl,
+          ...(bucketNames !== undefined && { bucketNames }),
         },
         where: {
           id: existingSettings.id,
@@ -74,8 +77,11 @@ export default function () {
       });
       setCdnUrl(cdnUrl ?? undefined);
       await refreshStripeClient();
+      if (bucketNames !== undefined) {
+        setBucketConfig((bucketNames as BucketConfig | null) ?? null);
+      }
       const refreshedSettings = await getSiteSettings();
-      return res.status(200).json({ result: maskStripeKey(refreshedSettings) });
+      return res.status(200).json({ result: refreshedSettings });
     } catch (e) {
       next(e);
     }

--- a/src/routers/v1/admin/settings.ts
+++ b/src/routers/v1/admin/settings.ts
@@ -81,7 +81,7 @@ export default function () {
         setBucketConfig((bucketNames as BucketConfig | null) ?? null);
       }
       const refreshedSettings = await getSiteSettings();
-      return res.status(200).json({ result: refreshedSettings });
+      return res.status(200).json({ result: maskStripeKey(refreshedSettings) });
     } catch (e) {
       next(e);
     }

--- a/src/routers/v1/downloadableContent/{id}.ts
+++ b/src/routers/v1/downloadableContent/{id}.ts
@@ -5,8 +5,8 @@ import { assertLoggedIn } from "../../../auth/getLoggedInUser";
 import { userAuthenticated } from "../../../auth/passport";
 import { AppError } from "../../../utils/error";
 import {
-  statDownloadableContent,
-  getDownloadableContentBufferFromStat,
+  getDownloadableContentMeta,
+  getDownloadableContentBuffer,
 } from "../../../utils/minio";
 
 type Params = {
@@ -43,10 +43,9 @@ export default function () {
           description: "You do not have access to this content",
         });
       }
-      // FIXME: Remove knowledge of BackBlaze from this location.
-      const { backblazeStat } = await statDownloadableContent(contentId);
+      const meta = await getDownloadableContentMeta(contentId);
 
-      if (!backblazeStat) {
+      if (!meta) {
         throw new AppError({
           httpCode: 404,
           description: "Content not found",
@@ -55,20 +54,17 @@ export default function () {
 
       res.setHeader(
         "Content-Type",
-        backblazeStat?.ContentType || "application/octet-stream"
+        meta.contentType || "application/octet-stream"
       );
-      res.setHeader("Content-Length", backblazeStat?.ContentLength || 0);
+      res.setHeader("Content-Length", meta.contentLength || 0);
       res.setHeader(
         "Last-Modified",
-        backblazeStat?.LastModified?.toUTCString() || new Date().toUTCString()
+        meta.lastModified?.toUTCString() || new Date().toUTCString()
       );
-      res.setHeader("ETag", `"${backblazeStat.ETag}"`);
+      res.setHeader("ETag", `"${meta.etag}"`);
 
       try {
-        const buffer = await getDownloadableContentBufferFromStat(
-          contentId,
-          backblazeStat
-        );
+        const { buffer } = await getDownloadableContentBuffer(contentId);
 
         res.end(buffer, "binary");
 

--- a/src/routers/v1/downloadableContent/{id}.ts
+++ b/src/routers/v1/downloadableContent/{id}.ts
@@ -1,13 +1,12 @@
-import { NextFunction, Request, Response } from "express";
-import { userAuthenticated } from "../../../auth/passport";
-import { assertLoggedIn } from "../../../auth/getLoggedInUser";
 import prisma from "@mirlo/prisma";
+import { NextFunction, Request, Response } from "express";
 
+import { assertLoggedIn } from "../../../auth/getLoggedInUser";
+import { userAuthenticated } from "../../../auth/passport";
 import { AppError } from "../../../utils/error";
 import {
-  downloadableContentBucket,
-  getBufferBasedOnStat,
-  statFile,
+  statDownloadableContent,
+  getDownloadableContentBufferFromStat,
 } from "../../../utils/minio";
 
 type Params = {
@@ -44,11 +43,8 @@ export default function () {
           description: "You do not have access to this content",
         });
       }
-
-      const { backblazeStat } = await statFile(
-        downloadableContentBucket,
-        contentId
-      );
+      // FIXME: Remove knowledge of BackBlaze from this location.
+      const { backblazeStat } = await statDownloadableContent(contentId);
 
       if (!backblazeStat) {
         throw new AppError({
@@ -69,8 +65,7 @@ export default function () {
       res.setHeader("ETag", `"${backblazeStat.ETag}"`);
 
       try {
-        const buffer = await getBufferBasedOnStat(
-          downloadableContentBucket,
+        const buffer = await getDownloadableContentBufferFromStat(
           contentId,
           backblazeStat
         );

--- a/src/routers/v1/manage/artists/{artistId}/images/index.ts
+++ b/src/routers/v1/manage/artists/{artistId}/images/index.ts
@@ -34,6 +34,9 @@ export default function () {
     try {
       const { jobId, imageId } = await uploadAndSendToImageQueue(
         { req, res },
+        // imageType "image" = the generic type stored at the root of the
+        // images bucket; model "image" = update the Image table after
+        // optimization (other callers pass e.g. "trackGroupCover").
         "image",
         "image",
         "inFormData",

--- a/src/routers/v1/manage/artists/{artistId}/images/index.ts
+++ b/src/routers/v1/manage/artists/{artistId}/images/index.ts
@@ -1,19 +1,16 @@
+import prisma from "@mirlo/prisma";
+import busboy from "connect-busboy";
 import { NextFunction, Request, Response } from "express";
+
+import { assertLoggedIn } from "../../../../../../auth/getLoggedInUser";
 import {
   artistBelongsToLoggedInUser,
   userAuthenticated,
 } from "../../../../../../auth/passport";
-import { assertLoggedIn } from "../../../../../../auth/getLoggedInUser";
+import { logger } from "../../../../../../logger";
 import { uploadAndSendToImageQueue } from "../../../../../../queues/processImages";
-import busboy from "connect-busboy";
-import prisma from "@mirlo/prisma";
 import { deleteArtistAvatar } from "../../../../../../utils/artist";
 import { busboyOptions } from "../../../../../../utils/images";
-import {
-  finalImageBucket,
-  incomingImageBucket,
-} from "../../../../../../utils/minio";
-import { logger } from "../../../../../../logger";
 
 type Params = {
   artistId: string;
@@ -37,7 +34,7 @@ export default function () {
     try {
       const { jobId, imageId } = await uploadAndSendToImageQueue(
         { req, res },
-        incomingImageBucket,
+        "image",
         "image",
         "inFormData",
         async (
@@ -68,8 +65,7 @@ export default function () {
           }
           logger.info("Done upserting image, id: " + image.id);
           return image;
-        },
-        finalImageBucket
+        }
       );
 
       res.json({ result: { jobId, imageId } });

--- a/src/routers/v1/manage/downloadableContent/index.ts
+++ b/src/routers/v1/manage/downloadableContent/index.ts
@@ -4,10 +4,7 @@ import { NextFunction, Request, Response } from "express";
 import { assertLoggedIn } from "../../../../auth/getLoggedInUser";
 import { userAuthenticated } from "../../../../auth/passport";
 import { AppError } from "../../../../utils/error";
-import {
-  downloadableContentBucket,
-  getPresignedUploadUrl,
-} from "../../../../utils/minio";
+import { getDownloadableContentUploadUrl } from "../../../../utils/minio";
 import {
   doesMerchBelongToUser,
   doesTrackGroupBelongToUser,
@@ -103,11 +100,8 @@ export default function () {
 
       let uploadUrl = null;
       if (downloadableContent) {
-        uploadUrl = await getPresignedUploadUrl(
-          downloadableContentBucket,
-          downloadableContent.id,
-          undefined,
-          size
+        uploadUrl = await getDownloadableContentUploadUrl(
+          downloadableContent.id
         );
       }
       res.json({ result: refreshedContent, uploadUrl });

--- a/src/routers/v1/manage/tracks/index.ts
+++ b/src/routers/v1/manage/tracks/index.ts
@@ -4,10 +4,7 @@ import { NextFunction, Request, Response } from "express";
 import { assertLoggedIn } from "../../../../auth/getLoggedInUser";
 import { userAuthenticated } from "../../../../auth/passport";
 import { buildTrackStreamURL } from "../../../../queues/processTrackAudio";
-import {
-  getPresignedUploadUrl,
-  incomingAudioBucket,
-} from "../../../../utils/minio";
+import { getAudioUploadUrl } from "../../../../utils/minio";
 import { doesTrackGroupBelongToUser } from "../../../../utils/ownership";
 
 export default function () {
@@ -141,7 +138,7 @@ export default function () {
             trackId: Number(track.id),
           },
         });
-        uploadUrl = await getPresignedUploadUrl(incomingAudioBucket, audio.id);
+        uploadUrl = await getAudioUploadUrl(audio.id);
       }
       res.json({ result: track, uploadUrl });
     } catch (e) {

--- a/src/routers/v1/manage/tracks/{trackId}/downloadOriginal.ts
+++ b/src/routers/v1/manage/tracks/{trackId}/downloadOriginal.ts
@@ -1,20 +1,16 @@
+import prisma from "@mirlo/prisma";
 import { NextFunction, Request, Response } from "express";
-import { logger } from "../../../../../logger";
+import filenamify from "filenamify";
+
 import {
-  artistBelongsToLoggedInUser,
   trackBelongsToLoggedInUser,
   userAuthenticated,
 } from "../../../../../auth/passport";
-import prisma from "@mirlo/prisma";
-
-import {
-  FormatOptions,
-  basicTrackGroupInclude,
-} from "../../../../../utils/trackGroup";
-import { finalAudioBucket, getReadStream } from "../../../../../utils/minio";
-import filenamify from "filenamify";
-import { cleanHeaderValue } from "../../../../../utils/validate-http-headers";
+import { logger } from "../../../../../logger";
 import { AppError } from "../../../../../utils/error";
+import { streamOriginalAudio } from "../../../../../utils/minio";
+import { basicTrackGroupInclude } from "../../../../../utils/trackGroup";
+import { cleanHeaderValue } from "../../../../../utils/validate-http-headers";
 
 export default function () {
   const operations = {
@@ -59,9 +55,9 @@ export default function () {
         res.set("Content-Transfer-Encoding", "binary");
         res.set("Accept-Ranges", "bytes");
 
-        const stream = await getReadStream(
-          finalAudioBucket,
-          `${track.audio.id}/original.${track.audio.fileExtension}`
+        const stream = await streamOriginalAudio(
+          track.audio.id,
+          track.audio.fileExtension ?? ""
         );
 
         if (stream) {
@@ -69,7 +65,7 @@ export default function () {
         } else {
           throw new AppError({
             httpCode: 500,
-            description: `Remote file not found for ${finalAudioBucket}/${track.audio.id}/original.${track.audio.fileExtension}`,
+            description: `Remote file not found for audio ${track.audio.id}`,
           });
         }
       } catch (e) {

--- a/src/routers/v1/trackGroups/{id}/download.ts
+++ b/src/routers/v1/trackGroups/{id}/download.ts
@@ -7,12 +7,7 @@ import { userLoggedInWithoutRedirect } from "../../../../auth/passport";
 import { logger } from "../../../../logger";
 import { startGeneratingZip } from "../../../../queues/album-queue";
 import { AppError } from "../../../../utils/error";
-import {
-  getPresignedDownloadUrl,
-  getReadStream,
-  statFile,
-  trackGroupFormatBucket,
-} from "../../../../utils/minio";
+import { presignZip, statZip, streamZip } from "../../../../utils/minio";
 import {
   FormatOptions,
   basicTrackGroupInclude,
@@ -89,13 +84,13 @@ export default function () {
         `trackGroupId: ${trackGroupId} Found a trackgroup, preparing download`
       );
 
-      const zipName = `${trackGroup.id}/${format}.zip`;
-
       try {
         logger.info("checking if trackgroup already zipped");
-        const { backblazeStat, minioStat } = await statFile(
-          trackGroupFormatBucket,
-          zipName
+        // FIXME Our controllers shouldn't have to care about the type of stat.
+        const { backblazeStat, minioStat } = await statZip(
+          "trackGroup",
+          trackGroup.id,
+          format
         );
         if (!backblazeStat && !minioStat) {
           logger.info("trackGroup doesn't exist yet, start generating it");
@@ -130,9 +125,10 @@ export default function () {
         // the zip bytes don't flow through this server (egress costs). Falls
         // back to piping the file when presigning isn't available (e.g. local
         // MinIO without a browser-reachable endpoint).
-        const presignedUrl = await getPresignedDownloadUrl(
-          trackGroupFormatBucket,
-          zipName,
+        const presignedUrl = await presignZip(
+          "trackGroup",
+          trackGroup.id,
+          format,
           {
             downloadFilename: `${asciiTitle}.zip`,
             contentType: "application/zip",
@@ -158,7 +154,7 @@ export default function () {
           contentDisposition(`${asciiTitle}.zip`, { type: "attachment" })
         );
 
-        const stream = await getReadStream(trackGroupFormatBucket, zipName);
+        const stream = await streamZip("trackGroup", trackGroup.id, format);
 
         if (stream) {
           await prisma.trackGroupDownload.create({
@@ -171,7 +167,7 @@ export default function () {
         } else {
           throw new AppError({
             httpCode: 500,
-            description: `Remote file not found for ${trackGroupFormatBucket}/${zipName}`,
+            description: `Remote file not found for trackgroup zip ${trackGroup.id}/${format}`,
           });
         }
       } catch (e) {

--- a/src/routers/v1/trackGroups/{id}/download.ts
+++ b/src/routers/v1/trackGroups/{id}/download.ts
@@ -7,7 +7,7 @@ import { userLoggedInWithoutRedirect } from "../../../../auth/passport";
 import { logger } from "../../../../logger";
 import { startGeneratingZip } from "../../../../queues/album-queue";
 import { AppError } from "../../../../utils/error";
-import { presignZip, statZip, streamZip } from "../../../../utils/minio";
+import { presignZip, streamZip, zipExists } from "../../../../utils/minio";
 import {
   FormatOptions,
   basicTrackGroupInclude,
@@ -84,27 +84,8 @@ export default function () {
         `trackGroupId: ${trackGroupId} Found a trackgroup, preparing download`
       );
 
-      try {
-        logger.info("checking if trackgroup already zipped");
-        // FIXME Our controllers shouldn't have to care about the type of stat.
-        const { backblazeStat, minioStat } = await statZip(
-          "trackGroup",
-          trackGroup.id,
-          format
-        );
-        if (!backblazeStat && !minioStat) {
-          logger.info("trackGroup doesn't exist yet, start generating it");
-          const jobId = await startGeneratingZip(
-            trackGroup,
-            trackGroup.tracks,
-            format
-          );
-          return res.json({
-            message: "We've started generating the album",
-            result: { jobId },
-          });
-        }
-      } catch (e) {
+      logger.info("checking if trackgroup already zipped");
+      if (!(await zipExists("trackGroup", trackGroup.id, format))) {
         logger.info("trackGroup doesn't exist yet, start generating it");
         const jobId = await startGeneratingZip(
           trackGroup,

--- a/src/routers/v1/trackGroups/{id}/generate.ts
+++ b/src/routers/v1/trackGroups/{id}/generate.ts
@@ -4,7 +4,7 @@ import { NextFunction, Request, Response } from "express";
 import { userLoggedInWithoutRedirect } from "../../../../auth/passport";
 import { logger } from "../../../../logger";
 import { startGeneratingZip } from "../../../../queues/album-queue";
-import { statFile, trackGroupFormatBucket } from "../../../../utils/minio";
+import { statZip } from "../../../../utils/minio";
 import {
   basicTrackGroupInclude,
   FormatOptions,
@@ -37,14 +37,13 @@ export default function () {
 
     logger.info(`trackGroupId: ${trackGroupId} Found a trackgroup`);
 
-    const zipName = `${trackGroup.id}/${format}.zip`;
-    logger.info(`zipName: ${zipName}`);
-
     try {
       logger.info("checking if trackgroup is already zipped");
-      const { backblazeStat, minioStat } = await statFile(
-        trackGroupFormatBucket,
-        zipName
+      // FIXME: Our controller shouldn't have to know about backblaze
+      const { backblazeStat, minioStat } = await statZip(
+        "trackGroup",
+        trackGroup.id,
+        format
       );
       if (backblazeStat || minioStat) {
         logger.info("the trackgroup is already zipped");

--- a/src/routers/v1/trackGroups/{id}/generate.ts
+++ b/src/routers/v1/trackGroups/{id}/generate.ts
@@ -4,7 +4,7 @@ import { NextFunction, Request, Response } from "express";
 import { userLoggedInWithoutRedirect } from "../../../../auth/passport";
 import { logger } from "../../../../logger";
 import { startGeneratingZip } from "../../../../queues/album-queue";
-import { statZip } from "../../../../utils/minio";
+import { zipExists } from "../../../../utils/minio";
 import {
   basicTrackGroupInclude,
   FormatOptions,
@@ -37,44 +37,24 @@ export default function () {
 
     logger.info(`trackGroupId: ${trackGroupId} Found a trackgroup`);
 
-    try {
-      logger.info("checking if trackgroup is already zipped");
-      // FIXME: Our controller shouldn't have to know about backblaze
-      const { backblazeStat, minioStat } = await statZip(
-        "trackGroup",
-        trackGroup.id,
-        format
-      );
-      if (backblazeStat || minioStat) {
-        logger.info("the trackgroup is already zipped");
-        return res.json({
-          message: "The album has already been generated",
-          result: true,
-        });
-      } else {
-        logger.info("trackGroup doesn't exist yet, start generating it");
-        const jobId = await startGeneratingZip(
-          trackGroup,
-          trackGroup.tracks,
-          format
-        );
-        return res.json({
-          message: "We've started generating the album",
-          result: { jobId },
-        });
-      }
-    } catch (e) {
-      logger.info("trackGroup doesn't exist yet, start generating it");
-      const jobId = await startGeneratingZip(
-        trackGroup,
-        trackGroup.tracks,
-        format
-      );
+    logger.info("checking if trackgroup is already zipped");
+    if (await zipExists("trackGroup", trackGroup.id, format)) {
+      logger.info("the trackgroup is already zipped");
       return res.json({
-        message: "We've started generating the album",
-        result: { jobId },
+        message: "The album has already been generated",
+        result: true,
       });
     }
+    logger.info("trackGroup doesn't exist yet, start generating it");
+    const jobId = await startGeneratingZip(
+      trackGroup,
+      trackGroup.tracks,
+      format
+    );
+    return res.json({
+      message: "We've started generating the album",
+      result: { jobId },
+    });
   }
 
   GET.apiDoc = {

--- a/src/routers/v1/tracks/{id}/download.ts
+++ b/src/routers/v1/tracks/{id}/download.ts
@@ -5,7 +5,7 @@ import filenamify from "filenamify";
 import { userLoggedInWithoutRedirect } from "../../../../auth/passport";
 import { logger } from "../../../../logger";
 import { AppError } from "../../../../utils/error";
-import { presignZip, statZip, streamZip } from "../../../../utils/minio";
+import { presignZip, streamZip, zipExists } from "../../../../utils/minio";
 import {
   FormatOptions,
   basicTrackGroupInclude,
@@ -81,22 +81,9 @@ export default function () {
 
       logger.info(`trackId: ${trackId} Found a track, preparing download`);
 
-      try {
-        logger.info("checking if track already zipped");
-        // FIXME: our controller shouldn't have to know about backblaze
-        const { backblazeStat, minioStat } = await statZip(
-          "track",
-          track.id,
-          format
-        );
-        if (!backblazeStat && !minioStat) {
-          logger.info("Track not zipped");
-          throw new AppError({
-            httpCode: 400,
-            description: "Need to generate track folder first",
-          });
-        }
-      } catch (e) {
+      logger.info("checking if track already zipped");
+      if (!(await zipExists("track", track.id, format))) {
+        logger.info("Track not zipped");
         throw new AppError({
           httpCode: 400,
           description: "Need to generate track folder first",

--- a/src/routers/v1/tracks/{id}/download.ts
+++ b/src/routers/v1/tracks/{id}/download.ts
@@ -5,12 +5,7 @@ import filenamify from "filenamify";
 import { userLoggedInWithoutRedirect } from "../../../../auth/passport";
 import { logger } from "../../../../logger";
 import { AppError } from "../../../../utils/error";
-import {
-  getPresignedDownloadUrl,
-  getReadStream,
-  statFile,
-  trackFormatBucket,
-} from "../../../../utils/minio";
+import { presignZip, statZip, streamZip } from "../../../../utils/minio";
 import {
   FormatOptions,
   basicTrackGroupInclude,
@@ -86,13 +81,13 @@ export default function () {
 
       logger.info(`trackId: ${trackId} Found a track, preparing download`);
 
-      const zipName = `${track.id}/${format}.zip`;
-
       try {
         logger.info("checking if track already zipped");
-        const { backblazeStat, minioStat } = await statFile(
-          trackFormatBucket,
-          zipName
+        // FIXME: our controller shouldn't have to know about backblaze
+        const { backblazeStat, minioStat } = await statZip(
+          "track",
+          track.id,
+          format
         );
         if (!backblazeStat && !minioStat) {
           logger.info("Track not zipped");
@@ -119,14 +114,10 @@ export default function () {
         // the zip bytes don't flow through this server (egress costs). Falls
         // back to piping the file when presigning isn't available (e.g. local
         // MinIO without a browser-reachable endpoint).
-        const presignedUrl = await getPresignedDownloadUrl(
-          trackFormatBucket,
-          zipName,
-          {
-            downloadFilename: `${title}.zip`,
-            contentType: "application/zip",
-          }
-        );
+        const presignedUrl = await presignZip("track", track.id, format, {
+          downloadFilename: `${title}.zip`,
+          contentType: "application/zip",
+        });
 
         if (presignedUrl) {
           logger.info(
@@ -139,14 +130,14 @@ export default function () {
         res.attachment(`${title}.zip`);
         res.set("Content-Disposition", `attachment; filename="${title}.zip"`);
 
-        const stream = await getReadStream(trackFormatBucket, zipName);
+        const stream = await streamZip("track", track.id, format);
 
         if (stream) {
           stream.pipe(res);
         } else {
           throw new AppError({
             httpCode: 500,
-            description: `Remote file not found for ${trackFormatBucket}/${zipName}`,
+            description: `Remote file not found for track zip ${track.id}/${format}`,
           });
         }
       } catch (e) {

--- a/src/routers/v1/tracks/{id}/generate.ts
+++ b/src/routers/v1/tracks/{id}/generate.ts
@@ -1,17 +1,14 @@
-import { userLoggedInWithoutRedirect } from "../../../../auth/passport";
+import prisma from "@mirlo/prisma";
 import { NextFunction, Request, Response } from "express";
+
+import { userLoggedInWithoutRedirect } from "../../../../auth/passport";
+import { logger } from "../../../../logger";
+import { startGeneratingZip } from "../../../../queues/album-queue";
+import { statZip } from "../../../../utils/minio";
 import {
   basicTrackGroupInclude,
   FormatOptions,
 } from "../../../../utils/trackGroup";
-import { logger } from "../../../../logger";
-import {
-  statFile,
-  trackFormatBucket,
-  trackGroupFormatBucket,
-} from "../../../../utils/minio";
-import { startGeneratingZip } from "../../../../queues/album-queue";
-import prisma from "@mirlo/prisma";
 
 export default function () {
   const operations = {
@@ -46,14 +43,13 @@ export default function () {
 
     logger.info(`trackId: ${trackId} Found a track`);
 
-    const zipName = `${track.id}/${format}.zip`;
-    logger.info(`zipName: ${zipName}`);
-
     try {
       logger.info("checking if track is already zipped");
-      const { backblazeStat, minioStat } = await statFile(
-        trackFormatBucket,
-        zipName
+      // FIXME: Our controller shouldn't have to care about backblaze
+      const { backblazeStat, minioStat } = await statZip(
+        "track",
+        track.id,
+        format
       );
       if (backblazeStat || minioStat) {
         logger.info("there is already a zip for this track");
@@ -67,7 +63,7 @@ export default function () {
           track.trackGroup,
           [track],
           format,
-          trackFormatBucket
+          "track"
         );
         return res.json({
           message: "We've started generating the album",
@@ -80,7 +76,7 @@ export default function () {
         track.trackGroup,
         [track],
         format,
-        trackFormatBucket
+        "track"
       );
       return res.json({
         message: "We've started generating the folder",

--- a/src/routers/v1/tracks/{id}/generate.ts
+++ b/src/routers/v1/tracks/{id}/generate.ts
@@ -4,7 +4,7 @@ import { NextFunction, Request, Response } from "express";
 import { userLoggedInWithoutRedirect } from "../../../../auth/passport";
 import { logger } from "../../../../logger";
 import { startGeneratingZip } from "../../../../queues/album-queue";
-import { statZip } from "../../../../utils/minio";
+import { zipExists } from "../../../../utils/minio";
 import {
   basicTrackGroupInclude,
   FormatOptions,
@@ -43,46 +43,25 @@ export default function () {
 
     logger.info(`trackId: ${trackId} Found a track`);
 
-    try {
-      logger.info("checking if track is already zipped");
-      // FIXME: Our controller shouldn't have to care about backblaze
-      const { backblazeStat, minioStat } = await statZip(
-        "track",
-        track.id,
-        format
-      );
-      if (backblazeStat || minioStat) {
-        logger.info("there is already a zip for this track");
-        return res.json({
-          message: "The album has already been generated",
-          result: true,
-        });
-      } else {
-        logger.info("folder for track doesn't exist yet, start generating it");
-        const jobId = await startGeneratingZip(
-          track.trackGroup,
-          [track],
-          format,
-          "track"
-        );
-        return res.json({
-          message: "We've started generating the album",
-          result: { jobId },
-        });
-      }
-    } catch (e) {
-      logger.info("folder for track doesn't exist yet, start generating it");
-      const jobId = await startGeneratingZip(
-        track.trackGroup,
-        [track],
-        format,
-        "track"
-      );
+    logger.info("checking if track is already zipped");
+    if (await zipExists("track", track.id, format)) {
+      logger.info("there is already a zip for this track");
       return res.json({
-        message: "We've started generating the folder",
-        result: { jobId },
+        message: "The album has already been generated",
+        result: true,
       });
     }
+    logger.info("folder for track doesn't exist yet, start generating it");
+    const jobId = await startGeneratingZip(
+      track.trackGroup,
+      [track],
+      format,
+      "track"
+    );
+    return res.json({
+      message: "We've started generating the folder",
+      result: { jobId },
+    });
   }
 
   GET.apiDoc = {

--- a/src/routers/v1/tracks/{id}/stream/{segment}.ts
+++ b/src/routers/v1/tracks/{id}/stream/{segment}.ts
@@ -2,10 +2,7 @@ import prisma from "@mirlo/prisma";
 import { NextFunction, Request, Response } from "express";
 
 import { userLoggedInWithoutRedirect } from "../../../../../auth/passport";
-import {
-  statAudioSegment,
-  getAudioSegmentBuffer,
-} from "../../../../../utils/minio";
+import { getAudioSegmentBufferIfExists } from "../../../../../utils/minio";
 import { canUserListenToTrack } from "../../../../../utils/ownership";
 
 export const fetchFile = async (
@@ -13,26 +10,17 @@ export const fetchFile = async (
   filename: string,
   segment: string
 ) => {
-  const { backblazeStat, minioStat } = await statAudioSegment(
-    filename,
-    segment
-  );
-  if (!backblazeStat && !minioStat) {
-    res.send();
-  }
   try {
-    const buffer = await getAudioSegmentBuffer(
-      filename,
-      segment,
-      backblazeStat
-    );
-
+    const buffer = await getAudioSegmentBufferIfExists(filename, segment);
+    if (buffer === undefined) {
+      res.send();
+      return;
+    }
     res.end(buffer, "binary");
   } catch (e) {
     console.error("error", e);
     res.status(400);
     res.send();
-    return;
   }
 };
 

--- a/src/routers/v1/tracks/{id}/stream/{segment}.ts
+++ b/src/routers/v1/tracks/{id}/stream/{segment}.ts
@@ -3,9 +3,8 @@ import { NextFunction, Request, Response } from "express";
 
 import { userLoggedInWithoutRedirect } from "../../../../../auth/passport";
 import {
-  finalAudioBucket,
-  getBufferBasedOnStat,
-  statFile,
+  statAudioSegment,
+  getAudioSegmentBuffer,
 } from "../../../../../utils/minio";
 import { canUserListenToTrack } from "../../../../../utils/ownership";
 
@@ -14,16 +13,17 @@ export const fetchFile = async (
   filename: string,
   segment: string
 ) => {
-  const alias = `${filename}/${segment}`;
-
-  const { backblazeStat, minioStat } = await statFile(finalAudioBucket, alias);
+  const { backblazeStat, minioStat } = await statAudioSegment(
+    filename,
+    segment
+  );
   if (!backblazeStat && !minioStat) {
     res.send();
   }
   try {
-    const buffer = await getBufferBasedOnStat(
-      finalAudioBucket,
-      alias,
+    const buffer = await getAudioSegmentBuffer(
+      filename,
+      segment,
       backblazeStat
     );
 

--- a/src/static.ts
+++ b/src/static.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+
 import { getBufferBasedOnStat, statFile } from "./utils/minio";
 
 export const serveStatic = async (
@@ -6,10 +7,26 @@ export const serveStatic = async (
   res: Response,
   next: NextFunction
 ) => {
-  const { backblazeStat, minioStat } = await statFile(
-    req.params.bucket,
-    req.params.filename
-  );
+  const bucket = req.params.bucket;
+  // The object key is everything after the bucket segment. It can't be a
+  // single route param because consolidated-mode keys contain slashes
+  // (e.g. trackgroup-covers/<id>-x600.webp).
+  let filename: string;
+  try {
+    filename = decodeURIComponent(req.path.slice(1));
+  } catch {
+    res.status(404);
+    next();
+    return;
+  }
+
+  if (!filename) {
+    res.status(404);
+    next();
+    return;
+  }
+
+  const { backblazeStat, minioStat } = await statFile(bucket, filename);
   if (!backblazeStat && !minioStat) {
     res.status(404);
     next();
@@ -36,11 +53,7 @@ export const serveStatic = async (
   }
 
   try {
-    const buffer = await getBufferBasedOnStat(
-      req.params.bucket,
-      req.params.filename,
-      backblazeStat
-    );
+    const buffer = await getBufferBasedOnStat(bucket, filename, backblazeStat);
 
     res.end(buffer, "binary");
 

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,9 +1,7 @@
 import prisma from "@mirlo/prisma";
-import {
-  downloadableContentBucket,
-  removeObjectsFromBucket,
-} from "../utils/minio";
+
 import logger from "../logger";
+import { removeDownloadableContent } from "../utils/minio";
 
 export const deleteDownloadableContent = async (contentId: string) => {
   await prisma.trackGroupDownloadableContent.deleteMany({
@@ -25,7 +23,7 @@ export const deleteDownloadableContent = async (contentId: string) => {
 
   if (content) {
     try {
-      await removeObjectsFromBucket(downloadableContentBucket, content.id);
+      await removeDownloadableContent(content.id);
     } catch (e) {
       logger.error("no object found, that's all right though");
     }

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -1,4 +1,4 @@
-import { backendStorage } from "./minio";
+import { backendStorage, getImagesBucket } from "./minio";
 
 const { S3_REGION = "" } = process.env;
 
@@ -22,13 +22,18 @@ export const generateFullStaticImageUrl = (
   bucket: string,
   extension?: string
 ) => {
+  const imagesBucket = getImagesBucket(bucket);
+  const effectiveBucket = imagesBucket;
+  const effectiveKey =
+    bucket !== imagesBucket ? `${bucket}/${imageName}` : imageName;
+
   if (backendStorage === "minio") {
-    return `${process.env.STATIC_MEDIA_HOST}/images/${bucket}/${imageName}.${extension ?? "webp"}`;
+    return `${process.env.STATIC_MEDIA_HOST}/images/${effectiveBucket}/${effectiveKey}.${extension ?? "webp"}`;
   } else {
     if (_cdnUrl) {
-      return `${_cdnUrl}/file/${bucket}/${imageName}.${extension ?? "webp"}`;
+      return `${_cdnUrl}/file/${effectiveBucket}/${effectiveKey}.${extension ?? "webp"}`;
     }
-    return `https://${bucket}.s3.${S3_REGION}.backblazeb2.com/${imageName}.${extension ?? "webp"}`;
+    return `https://${effectiveBucket}.s3.${S3_REGION}.backblazeb2.com/${effectiveKey}.${extension ?? "webp"}`;
   }
 };
 

--- a/src/utils/minio.ts
+++ b/src/utils/minio.ts
@@ -59,6 +59,96 @@ export const downloadableContentBucket =
 export const incomingImageBucket = s3UniquePrefix + "incoming-mirlo-images";
 export const finalImageBucket = s3UniquePrefix + "mirlo-images";
 
+// Consolidated bucket config (Phase 1 self-hosting support).
+// null = legacy mode: use per-type bucket constants above (for existing installs).
+// Set = consolidated mode: 3 buckets with path prefixes (for new installs).
+export type BucketConfig = { prefix: string };
+
+// Per-image-type routing table.
+// incoming: legacy bucket for uploads before optimization; final: legacy bucket after.
+// prefix: path prefix within mirlo-images in consolidated mode (= final bucket name, or
+//         undefined for the generic "image" type which sits at the bucket root).
+// queue: whether to add a BullMQ optimize-image job after upload.
+const imageTypeBuckets = {
+  artistAvatar: {
+    incoming: incomingArtistAvatarBucket,
+    final: finalArtistAvatarBucket,
+    prefix: finalArtistAvatarBucket as string | undefined,
+    queue: true,
+  },
+  artistBackground: {
+    incoming: incomingArtistBackgroundBucket,
+    final: finalArtistBackgroundBucket,
+    prefix: finalArtistBackgroundBucket as string | undefined,
+    queue: true,
+  },
+  userAvatar: {
+    incoming: incomingArtistAvatarBucket,
+    final: finalUserAvatarBucket,
+    prefix: finalUserAvatarBucket as string | undefined,
+    queue: true,
+  },
+  userBanner: {
+    incoming: incomingUserBannerBucket,
+    final: finalUserBannerBucket,
+    prefix: finalUserBannerBucket as string | undefined,
+    queue: true,
+  },
+  trackGroupCover: {
+    incoming: incomingCoversBucket,
+    final: finalCoversBucket,
+    prefix: finalCoversBucket as string | undefined,
+    queue: true,
+  },
+  merch: {
+    incoming: incomingMerchImageBucket,
+    final: finalMerchImageBucket,
+    prefix: finalMerchImageBucket as string | undefined,
+    queue: true,
+  },
+  postImage: {
+    incoming: finalPostImageBucket,
+    final: finalPostImageBucket,
+    prefix: finalPostImageBucket as string | undefined,
+    queue: false,
+  },
+  image: {
+    incoming: incomingImageBucket,
+    final: finalImageBucket,
+    prefix: undefined as string | undefined,
+    queue: true,
+  },
+};
+export type ImageType = keyof typeof imageTypeBuckets;
+
+let _bucketConfig: BucketConfig | null = null;
+const _ensuredBuckets = new Set<string>();
+
+export const setBucketConfig = (config: BucketConfig | null) => {
+  _bucketConfig = config;
+  _ensuredBuckets.clear();
+};
+
+const ensureBucketCached = async (bucket: string) => {
+  if (!_ensuredBuckets.has(bucket)) {
+    await createBucketIfNotExists(bucket, logger);
+    _ensuredBuckets.add(bucket);
+  }
+};
+
+const isConsolidatedMode = (): boolean => _bucketConfig !== null;
+
+export const getImagesBucket = (legacyFallback: string): string =>
+  _bucketConfig ? `${_bucketConfig.prefix}mirlo-images` : legacyFallback;
+
+export const getAudioBucket = (
+  legacyFallback: string = finalAudioBucket
+): string =>
+  _bucketConfig ? `${_bucketConfig.prefix}mirlo-audio` : legacyFallback;
+
+export const getDownloadsBucket = (legacyFallback: string): string =>
+  _bucketConfig ? `${_bucketConfig.prefix}mirlo-downloads` : legacyFallback;
+
 const {
   MINIO_HOST = "",
   MINIO_PUBLIC_HOST = "",
@@ -654,4 +744,221 @@ export const removeObjectsFromBucket = async (
       minioObojects.map((o) => o.name!)
     );
   }
+};
+
+// ─── Domain storage operations ────────────────────────────────────────────────
+// All bucket selection and key construction lives here.
+// Call sites express intent; this layer handles the routing.
+
+// ── Audio ─────────────────────────────────────────────────────────────────────
+
+const audioIncomingKey = (audioId: string) =>
+  isConsolidatedMode() ? `incoming/${audioId}` : audioId;
+
+export const uploadIncomingAudio = async (
+  audioId: string,
+  stream: Readable
+) => {
+  const bucket = getAudioBucket(incomingAudioBucket);
+  await ensureBucketCached(bucket);
+  return uploadWrapper(bucket, audioIncomingKey(audioId), stream);
+};
+
+export const downloadIncomingAudio = (audioId: string, destPath: string) =>
+  getFile(
+    getAudioBucket(incomingAudioBucket),
+    audioIncomingKey(audioId),
+    destPath
+  );
+
+export const getAudioUploadUrl = (audioId: string) =>
+  getPresignedUploadUrl(
+    getAudioBucket(incomingAudioBucket),
+    audioIncomingKey(audioId)
+  );
+
+export const removeIncomingAudio = (audioId: string) =>
+  removeObjectFromStorage(
+    getAudioBucket(incomingAudioBucket),
+    audioIncomingKey(audioId)
+  );
+
+export const downloadOriginalAudio = (
+  audioId: string,
+  ext: string,
+  destPath: string
+) => getFile(getAudioBucket(), `${audioId}/original.${ext}`, destPath);
+
+export const streamOriginalAudio = (audioId: string, ext: string) =>
+  getReadStream(getAudioBucket(), `${audioId}/original.${ext}`);
+
+export const statAudioSegment = (audioId: string, segment: string) =>
+  statFile(getAudioBucket(), `${audioId}/${segment}`);
+
+export const getAudioSegmentBuffer = (
+  audioId: string,
+  segment: string,
+  stat?: HeadObjectCommandOutput
+) => getBufferBasedOnStat(getAudioBucket(), `${audioId}/${segment}`, stat);
+
+export const uploadAudioHlsFile = async (
+  audioId: string,
+  filename: string,
+  stream: Readable
+) => {
+  const bucket = getAudioBucket();
+  await ensureBucketCached(bucket);
+  return uploadWrapper(bucket, `${audioId}/${filename}`, stream);
+};
+
+export const removeAudioFiles = (audioId: string) =>
+  removeObjectsFromBucket(getAudioBucket(), audioId);
+
+// ── Images ────────────────────────────────────────────────────────────────────
+
+export const getImageFinalBucket = (imageType: ImageType): string =>
+  imageTypeBuckets[imageType].final;
+
+export const imageTypeUsesQueue = (imageType: ImageType): boolean =>
+  imageTypeBuckets[imageType].queue;
+
+export const uploadIncomingImageByType = async (
+  imageType: ImageType,
+  fileName: string,
+  stream: Readable,
+  options?: { contentType?: string }
+) => {
+  const { incoming, prefix } = imageTypeBuckets[imageType];
+  const bucket = getImagesBucket(incoming);
+  await ensureBucketCached(bucket);
+  const key =
+    isConsolidatedMode() && prefix
+      ? `incoming/${prefix}/${fileName}`
+      : fileName;
+  return uploadWrapper(bucket, key, stream, options);
+};
+
+export const downloadIncomingImageByType = (
+  imageType: ImageType,
+  imageId: string
+) => {
+  const { incoming, prefix } = imageTypeBuckets[imageType];
+  return getBufferFromStorage(
+    getImagesBucket(incoming),
+    isConsolidatedMode() && prefix ? `incoming/${prefix}/${imageId}` : imageId
+  );
+};
+
+export const uploadOptimizedImageByType = async (
+  imageType: ImageType,
+  fileName: string,
+  buffer: Buffer,
+  options?: { contentType?: string; cacheControl?: string }
+) => {
+  const { final, prefix } = imageTypeBuckets[imageType];
+  const bucket = getImagesBucket(final);
+  await ensureBucketCached(bucket);
+  const key =
+    isConsolidatedMode() && prefix ? `${prefix}/${fileName}` : fileName;
+  return uploadWrapper(bucket, key, buffer, options);
+};
+
+export const removeIncomingImageByType = (
+  imageType: ImageType,
+  imageId: string
+) => {
+  const { incoming, prefix } = imageTypeBuckets[imageType];
+  return removeObjectFromStorage(
+    getImagesBucket(incoming),
+    isConsolidatedMode() && prefix ? `incoming/${prefix}/${imageId}` : imageId
+  );
+};
+
+export const getCoverBuffer = (coverId: string, ext: "webp" | "jpg") =>
+  getBufferFromStorage(
+    getImagesBucket(finalCoversBucket),
+    `${isConsolidatedMode() ? `${finalCoversBucket}/` : ""}${coverId}-x1500.${ext}`
+  );
+
+export const removeCoverImages = (coverId: string) =>
+  removeObjectsFromBucket(
+    getImagesBucket(finalCoversBucket),
+    isConsolidatedMode() ? `${finalCoversBucket}/${coverId}` : coverId
+  );
+
+// ── Downloadable content ──────────────────────────────────────────────────────
+
+const contentKey = (id: string) =>
+  isConsolidatedMode() ? `content/${id}` : id;
+
+export const getDownloadableContentUploadUrl = (id: string) =>
+  getPresignedUploadUrl(
+    getDownloadsBucket(downloadableContentBucket),
+    contentKey(id)
+  );
+
+export const statDownloadableContent = (id: string) =>
+  statFile(getDownloadsBucket(downloadableContentBucket), contentKey(id));
+
+export const getDownloadableContentBufferFromStat = (
+  id: string,
+  stat?: HeadObjectCommandOutput
+) =>
+  getBufferBasedOnStat(
+    getDownloadsBucket(downloadableContentBucket),
+    contentKey(id),
+    stat
+  );
+
+export const getDownloadableContentBuffer = (id: string) =>
+  getBufferFromStorage(
+    getDownloadsBucket(downloadableContentBucket),
+    contentKey(id)
+  );
+
+export const removeDownloadableContent = (id: string) =>
+  removeObjectsFromBucket(
+    getDownloadsBucket(downloadableContentBucket),
+    contentKey(id)
+  );
+
+// ── Zips ──────────────────────────────────────────────────────────────────────
+
+const zipBucket = (type: "track" | "trackGroup") =>
+  type === "track"
+    ? getDownloadsBucket(trackFormatBucket)
+    : getDownloadsBucket(trackGroupFormatBucket);
+
+const zipKey = (type: "track" | "trackGroup", id: number, format: string) =>
+  `${isConsolidatedMode() ? `${type === "track" ? "track" : "trackgroup"}/` : ""}${id}/${format}.zip`;
+
+export const statZip = (
+  type: "track" | "trackGroup",
+  id: number,
+  format: string
+) => statFile(zipBucket(type), zipKey(type, id, format));
+
+export const streamZip = (
+  type: "track" | "trackGroup",
+  id: number,
+  format: string
+) => getReadStream(zipBucket(type), zipKey(type, id, format));
+
+export const presignZip = (
+  type: "track" | "trackGroup",
+  id: number,
+  format: string,
+  options?: Parameters<typeof getPresignedDownloadUrl>[2]
+) =>
+  getPresignedDownloadUrl(zipBucket(type), zipKey(type, id, format), options);
+
+export const uploadZip = async (
+  type: "track" | "trackGroup",
+  id: number,
+  format: string,
+  stream: Readable
+) => {
+  const bucket = zipBucket(type);
+  await ensureBucketCached(bucket);
+  return uploadWrapper(bucket, zipKey(type, id, format), stream);
 };

--- a/src/utils/minio.ts
+++ b/src/utils/minio.ts
@@ -21,6 +21,12 @@ import { Logger } from "winston";
 
 import logger from "../logger";
 
+// Backend-agnostic object storage helpers: MinIO in development, any
+// S3-compatible provider (Backblaze B2 in production) via the AWS SDK.
+// The filename is historical — nothing here is MinIO-specific from the
+// caller's point of view. Bucket layout is documented in
+// docs/hosting/object-storage.md.
+
 export const incomingArtistBackgroundBucket = "incoming-artist-banners";
 export const finalArtistBackgroundBucket = "artist-banners";
 

--- a/src/utils/minio.ts
+++ b/src/utils/minio.ts
@@ -21,43 +21,35 @@ import { Logger } from "winston";
 
 import logger from "../logger";
 
-const s3UniquePrefix = "";
+export const incomingArtistBackgroundBucket = "incoming-artist-banners";
+export const finalArtistBackgroundBucket = "artist-banners";
 
-export const incomingArtistBackgroundBucket =
-  s3UniquePrefix + "incoming-artist-banners";
-export const finalArtistBackgroundBucket = s3UniquePrefix + "artist-banners";
+export const incomingArtistAvatarBucket = "incoming-artist-avatars";
+export const finalArtistAvatarBucket = "artist-avatars";
 
-export const incomingArtistAvatarBucket =
-  s3UniquePrefix + "incoming-artist-avatars";
-export const finalArtistAvatarBucket = s3UniquePrefix + "artist-avatars";
+export const incomingUserAvatarBucket = "incoming-user-avatars";
+export const finalUserAvatarBucket = "mirlo-user-avatars";
 
-export const incomingUserAvatarBucket =
-  s3UniquePrefix + "incoming-user-avatars";
-export const finalUserAvatarBucket = s3UniquePrefix + "mirlo-user-avatars";
+export const incomingUserBannerBucket = "incoming-user-banners";
+export const finalUserBannerBucket = "mirlo-user-banners";
 
-export const incomingUserBannerBucket =
-  s3UniquePrefix + "incoming-user-banners";
-export const finalUserBannerBucket = s3UniquePrefix + "mirlo-user-banners";
+export const incomingCoversBucket = "incoming-covers";
+export const finalCoversBucket = "trackgroup-covers";
 
-export const incomingCoversBucket = s3UniquePrefix + "incoming-covers";
-export const finalCoversBucket = s3UniquePrefix + "trackgroup-covers";
+export const incomingMerchImageBucket = "incoming-merch-images";
+export const finalMerchImageBucket = "merch-images";
 
-export const incomingMerchImageBucket =
-  s3UniquePrefix + "incoming-merch-images";
-export const finalMerchImageBucket = s3UniquePrefix + "merch-images";
+export const finalPostImageBucket = "post-images";
 
-export const finalPostImageBucket = s3UniquePrefix + "post-images";
+export const incomingAudioBucket = "incoming-track-audio";
+export const finalAudioBucket = "track-audio";
 
-export const incomingAudioBucket = s3UniquePrefix + "incoming-track-audio";
-export const finalAudioBucket = s3UniquePrefix + "track-audio";
+export const trackGroupFormatBucket = "trackgroup-format";
+export const trackFormatBucket = "track-format";
 
-export const trackGroupFormatBucket = s3UniquePrefix + "trackgroup-format";
-export const trackFormatBucket = s3UniquePrefix + "track-format";
-
-export const downloadableContentBucket =
-  s3UniquePrefix + "mirlo-downloadable-content";
-export const incomingImageBucket = s3UniquePrefix + "incoming-mirlo-images";
-export const finalImageBucket = s3UniquePrefix + "mirlo-images";
+export const downloadableContentBucket = "mirlo-downloadable-content";
+export const incomingImageBucket = "incoming-mirlo-images";
+export const finalImageBucket = "mirlo-images";
 
 // Consolidated bucket config (Phase 1 self-hosting support).
 // null = legacy mode: use per-type bucket constants above (for existing installs).
@@ -296,6 +288,38 @@ export const statFile = async (bucket: string, filename: string) => {
     minioStat,
     backblazeStat,
   };
+};
+
+export interface FileMeta {
+  contentType?: string;
+  contentLength?: number;
+  lastModified?: Date;
+  etag?: string;
+}
+
+const normalizeStatToMeta = (stat: {
+  backblazeStat?: HeadObjectCommandOutput;
+  minioStat?: Awaited<ReturnType<Client["statObject"]>>;
+}): FileMeta | null => {
+  if (stat.backblazeStat) {
+    return {
+      contentType: stat.backblazeStat.ContentType,
+      contentLength: stat.backblazeStat.ContentLength,
+      lastModified: stat.backblazeStat.LastModified,
+      etag: stat.backblazeStat.ETag,
+    };
+  }
+  if (stat.minioStat) {
+    return {
+      contentType: stat.minioStat.metaData?.["content-type"] as
+        | string
+        | undefined,
+      contentLength: stat.minioStat.size,
+      lastModified: stat.minioStat.lastModified,
+      etag: stat.minioStat.etag,
+    };
+  }
+  return null;
 };
 
 export const createBucketIfNotExists = async (
@@ -801,6 +825,19 @@ export const getAudioSegmentBuffer = (
   stat?: HeadObjectCommandOutput
 ) => getBufferBasedOnStat(getAudioBucket(), `${audioId}/${segment}`, stat);
 
+export const getAudioSegmentBufferIfExists = async (
+  audioId: string,
+  segment: string
+): Promise<Buffer | undefined> => {
+  const stat = await statAudioSegment(audioId, segment);
+  if (!stat.backblazeStat && !stat.minioStat) return undefined;
+  const { buffer } = await getBufferFromStorage(
+    getAudioBucket(),
+    `${audioId}/${segment}`
+  );
+  return buffer as Buffer | undefined;
+};
+
 export const uploadAudioHlsFile = async (
   audioId: string,
   filename: string,
@@ -900,6 +937,13 @@ export const getDownloadableContentUploadUrl = (id: string) =>
 export const statDownloadableContent = (id: string) =>
   statFile(getDownloadsBucket(downloadableContentBucket), contentKey(id));
 
+export const getDownloadableContentMeta = async (
+  id: string
+): Promise<FileMeta | null> => {
+  const stat = await statDownloadableContent(id);
+  return normalizeStatToMeta(stat);
+};
+
 export const getDownloadableContentBufferFromStat = (
   id: string,
   stat?: HeadObjectCommandOutput
@@ -937,6 +981,15 @@ export const statZip = (
   id: number,
   format: string
 ) => statFile(zipBucket(type), zipKey(type, id, format));
+
+export const zipExists = async (
+  type: "track" | "trackGroup",
+  id: number,
+  format: string
+): Promise<boolean> => {
+  const { backblazeStat, minioStat } = await statZip(type, id, format);
+  return !!(backblazeStat || minioStat);
+};
 
 export const streamZip = (
   type: "track" | "trackGroup",

--- a/src/utils/processTrackGroupCover.ts
+++ b/src/utils/processTrackGroupCover.ts
@@ -1,13 +1,14 @@
-import { finalCoversBucket, incomingCoversBucket } from "./minio";
 import prisma from "@mirlo/prisma";
-import { APIContext } from "./file";
+
 import { uploadAndSendToImageQueue } from "../queues/processImages";
+
+import { APIContext } from "./file";
 
 const processTrackGroupCover = (ctx: APIContext) => {
   return async (trackGroupId: number) => {
     return uploadAndSendToImageQueue(
       ctx,
-      incomingCoversBucket,
+      "trackGroupCover",
       "trackGroupCover",
       "artwork",
       async (fileInfo: { filename: string }) => {
@@ -24,8 +25,7 @@ const processTrackGroupCover = (ctx: APIContext) => {
             trackGroupId,
           },
         });
-      },
-      finalCoversBucket
+      }
     );
   };
 };

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,9 +1,12 @@
 import prisma from "@mirlo/prisma";
 import { Settings } from "@mirlo/prisma/client";
 
+import { BucketConfig } from "./minio";
+
 interface SettingsType extends Partial<Settings> {
   platformPercent: number;
   cdnUrl?: string;
+  bucketNames?: BucketConfig | null;
 }
 
 const defaultSettings = {
@@ -12,6 +15,10 @@ const defaultSettings = {
     showHeroOnHome: true,
   },
 };
+
+// Default bucket config for fresh installs: consolidated 3-bucket structure.
+// Existing installs with null bucketNames stay in legacy mode (no change to bucket layout).
+const DEFAULT_BUCKET_CONFIG: BucketConfig = { prefix: "" };
 
 export const getSiteSettings = async (): Promise<SettingsType> => {
   let [result] = await prisma.settings.findMany();
@@ -24,6 +31,7 @@ export const getSiteSettings = async (): Promise<SettingsType> => {
             showHeroOnHome: true,
           },
         },
+        bucketNames: DEFAULT_BUCKET_CONFIG,
       },
     });
   }
@@ -33,5 +41,6 @@ export const getSiteSettings = async (): Promise<SettingsType> => {
     ...settings,
     ...result,
     cdnUrl: result.cdnUrl ?? undefined,
+    bucketNames: (result.bucketNames as BucketConfig | null) ?? null,
   };
 };

--- a/src/utils/trackGroup.ts
+++ b/src/utils/trackGroup.ts
@@ -131,7 +131,7 @@ export const deleteTrackGroupCover = async (trackGroupId: number) => {
     });
 
     try {
-      removeCoverImages(cover.id);
+      await removeCoverImages(cover.id);
     } catch (e) {
       console.error("Found no files, that's okay");
     }

--- a/src/utils/trackGroup.ts
+++ b/src/utils/trackGroup.ts
@@ -19,14 +19,11 @@ import { sendBasecampAMessage } from "./basecamp";
 import { deleteDownloadableContent } from "./content";
 import { AppError } from "./error";
 import { generateFullStaticImageUrl } from "./images";
-import {
-  finalCoversBucket,
-  finalAudioBucket,
-  removeObjectsFromBucket,
-  getReadStream,
-} from "./minio";
-export { processSingleTrackGroup } from "./serialize/trackGroup";
+import { streamOriginalAudio, removeCoverImages } from "./minio";
 import { doesTrackBelongToUser, doesTrackGroupBelongToUser } from "./ownership";
+export { processSingleTrackGroup } from "./serialize/trackGroup";
+import { processSingleTrackGroup } from "./serialize/trackGroup";
+import { deleteTrack } from "./tracks";
 
 export const notifyFollowersOfNewAlbum = async (trackGroup: {
   id: number;
@@ -96,8 +93,6 @@ export const finalizeTrackGroupPublication = async (
   return updated;
 };
 
-import { deleteTrack } from "./tracks";
-
 export const whereForPublishedTrackGroups = (opts?: {
   includePrivate?: boolean;
 }): Prisma.TrackGroupWhereInput => {
@@ -136,7 +131,7 @@ export const deleteTrackGroupCover = async (trackGroupId: number) => {
     });
 
     try {
-      removeObjectsFromBucket(finalCoversBucket, cover.id);
+      removeCoverImages(cover.id);
     } catch (e) {
       console.error("Found no files, that's okay");
     }
@@ -389,12 +384,11 @@ export async function buildZipFileForPath(
         const order = track.order ? track.order : i + 1;
         const trackTitle = `${order} - ${track.title}.${format}`;
 
-        const trackLocation = `${track.audio.id}/original.${track.audio.fileExtension}`;
-        logger.info(`${track.audio.id}: Fetching ${trackLocation}`);
+        logger.info(`${track.audio.id}: Fetching original audio`);
         try {
-          const trackStream = await getReadStream(
-            finalAudioBucket,
-            trackLocation
+          const trackStream = await streamOriginalAudio(
+            track.audio.id,
+            track.audio.fileExtension ?? ""
           );
 
           if (trackStream) {
@@ -908,13 +902,6 @@ export const processTrackGroupQueryOrder = (orderByString?: unknown) => {
   return orderByObj;
 };
 
-import { processSingleTrackGroup } from "./serialize/trackGroup";
-
-export default {
-  cover: generateFullStaticImageUrl,
-  single: processSingleTrackGroup,
-};
-
 export const createOrUpdatePledge = async ({
   userId,
   message,
@@ -973,6 +960,7 @@ export const createOrUpdatePledge = async ({
   }
 };
 
-const chargePledges = (fundraiserId: number) => {
-  // Logic to charge pledges for the given fundraiserId
+export default {
+  cover: generateFullStaticImageUrl,
+  single: processSingleTrackGroup,
 };

--- a/src/utils/tracks.ts
+++ b/src/utils/tracks.ts
@@ -7,7 +7,7 @@ import ffmpeg from "fluent-ffmpeg";
 
 import { Format } from "../jobs/generate-album";
 import logger from "../logger";
-import { finalAudioBucket, removeObjectsFromBucket } from "../utils/minio";
+import { removeAudioFiles } from "../utils/minio";
 
 export const deleteTrack = async (trackId: number) => {
   await prisma.track.delete({
@@ -23,7 +23,7 @@ export const deleteTrack = async (trackId: number) => {
   });
   if (audio) {
     try {
-      await removeObjectsFromBucket(finalAudioBucket, audio.id);
+      await removeAudioFiles(audio.id);
     } catch (e) {
       logger.error("no object found, that's all right though");
     }

--- a/test/jobs/tasks/clean-up-files.spec.ts
+++ b/test/jobs/tasks/clean-up-files.spec.ts
@@ -1,0 +1,71 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import { afterEach, beforeEach, describe, it } from "mocha";
+
+import assert from "assert";
+
+import sinon from "sinon";
+
+import { EventEmitter } from "events";
+
+import cleanUpFiles from "../../../src/jobs/tasks/clean-up-files";
+import {
+  setBucketConfig,
+  minioClient,
+  trackGroupFormatBucket,
+} from "../../../src/utils/minio";
+
+describe("clean-up-files", () => {
+  let listObjectsV2Stub: sinon.SinonStub;
+  let removeObjectsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    listObjectsV2Stub = sinon
+      .stub(minioClient!, "listObjectsV2")
+      .callsFake(() => {
+        const emitter = new EventEmitter();
+        setImmediate(() => {
+          emitter.emit("data", { name: "file1" });
+          emitter.emit("end");
+        });
+        return emitter as any;
+      });
+    removeObjectsStub = sinon.stub(minioClient!, "removeObjects").resolves();
+  });
+
+  afterEach(() => {
+    setBucketConfig(null);
+    sinon.restore();
+  });
+
+  describe("legacy mode", () => {
+    it("matches legacy trackgroup bucket path", async () => {
+      await cleanUpFiles(`${trackGroupFormatBucket}/42`);
+      assert.equal(listObjectsV2Stub.firstCall.args[0], trackGroupFormatBucket);
+      assert.equal(listObjectsV2Stub.firstCall.args[1], "42");
+    });
+
+    it("ignores consolidated path", async () => {
+      await cleanUpFiles("mirlo-downloads/42");
+      assert.equal(listObjectsV2Stub.callCount, 0);
+    });
+  });
+
+  describe("consolidated mode", () => {
+    beforeEach(() => {
+      setBucketConfig({ prefix: "" });
+    });
+
+    it("matches consolidated downloads bucket path", async () => {
+      await cleanUpFiles("mirlo-downloads/trackgroup/42");
+      assert.equal(listObjectsV2Stub.firstCall.args[0], "mirlo-downloads");
+      assert.equal(listObjectsV2Stub.firstCall.args[1], "trackgroup/42");
+    });
+
+    it("ignores legacy path", async () => {
+      await cleanUpFiles(`${trackGroupFormatBucket}/42`);
+      assert.equal(listObjectsV2Stub.callCount, 0);
+    });
+  });
+});

--- a/test/routers/admin/settings.spec.ts
+++ b/test/routers/admin/settings.spec.ts
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import * as dotenv from "dotenv";
 dotenv.config();
 
-import { describe, it } from "mocha";
+import { afterEach, describe, it } from "mocha";
 import request from "supertest";
 import prisma from "@mirlo/prisma";
 
@@ -18,6 +18,25 @@ describe("admin/settings", () => {
       await clearTables();
     } catch (e) {
       console.error(e);
+    }
+  });
+
+  // Reset server-side _bucketConfig after any test that may have changed it
+  // via POST /admin/settings. clearTables() wipes the DB but the in-memory
+  // _bucketConfig on the API server persists and would affect later test files.
+  afterEach(async () => {
+    try {
+      const { accessToken } = await createUser({
+        email: "settings-reset@test.com",
+        isAdmin: true,
+      });
+      await requestApp
+        .post("admin/settings")
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json")
+        .send({ bucketNames: null, settings: { platformPercent: 7 } });
+    } catch (e) {
+      // best-effort reset; don't fail the test suite if this errors
     }
   });
 
@@ -193,6 +212,72 @@ describe("admin/settings", () => {
       const stripe = (row?.settings as Record<string, unknown>)
         ?.stripe as Record<string, unknown>;
       assert.equal(stripe?.key, "sk_test_existing");
+    });
+
+    it("should save bucketNames: { prefix: 'foo-' } to DB and return it in response", async () => {
+      const { accessToken } = await createUser({
+        email: "admin@test.com",
+        isAdmin: true,
+      });
+
+      const response = await requestApp
+        .post("admin/settings")
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json")
+        .send({
+          bucketNames: { prefix: "foo-" },
+          settings: { platformPercent: 7 },
+        });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body.result.bucketNames.prefix, "foo-");
+
+      const row = await prisma.settings.findFirst();
+      assert.deepEqual(row?.bucketNames, { prefix: "foo-" });
+    });
+
+    it("should save bucketNames: null (legacy mode) to DB", async () => {
+      const { accessToken } = await createUser({
+        email: "admin@test.com",
+        isAdmin: true,
+      });
+
+      const response = await requestApp
+        .post("admin/settings")
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json")
+        .send({ bucketNames: null, settings: { platformPercent: 7 } });
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body.result.bucketNames, null);
+
+      const row = await prisma.settings.findFirst();
+      assert.equal(row?.bucketNames, null);
+    });
+
+    it("should not update bucketNames when omitted from request", async () => {
+      const { accessToken } = await createUser({
+        email: "admin@test.com",
+        isAdmin: true,
+      });
+
+      await requestApp
+        .post("admin/settings")
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json")
+        .send({
+          bucketNames: { prefix: "keep-" },
+          settings: { platformPercent: 7 },
+        });
+
+      await requestApp
+        .post("admin/settings")
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json")
+        .send({ settings: { platformPercent: 7 } });
+
+      const row = await prisma.settings.findFirst();
+      assert.deepEqual(row?.bucketNames, { prefix: "keep-" });
     });
   });
 });

--- a/test/routers/trackGroups/{id}.download.spec.ts
+++ b/test/routers/trackGroups/{id}.download.spec.ts
@@ -1,21 +1,32 @@
 import assert from "node:assert";
+
 import * as dotenv from "dotenv";
 dotenv.config();
-import { describe, it } from "mocha";
-import {
-  clearTables,
-  createArtist,
-  createTrackGroup,
-  createUser,
-} from "../../utils";
-import prisma from "@mirlo/prisma";
-import { randomUUID } from "crypto";
+import { afterEach, beforeEach, describe, it } from "mocha";
 
-import { requestApp } from "../utils";
 import {
   createBucketIfNotExists,
   finalAudioBucket,
+  uploadZip,
+  setBucketConfig,
 } from "../../../src/utils/minio";
+import {
+  clearTables,
+  createArtist,
+  createTrack,
+  createTrackGroup,
+  createUser,
+} from "../../utils";
+
+import prisma from "@mirlo/prisma";
+
+import { randomUUID } from "crypto";
+
+import { requestApp } from "../utils";
+
+import archiver from "archiver";
+
+import { PassThrough } from "node:stream";
 
 describe("trackGroups/{id}/download", () => {
   beforeEach(async () => {
@@ -27,6 +38,24 @@ describe("trackGroups/{id}/download", () => {
   });
 
   describe("GET", () => {
+    const generateMockArchive = async () => {
+      const pass = new PassThrough();
+
+      await new Promise(async (resolve: (value?: unknown) => void) => {
+        const archive = archiver("zip", {
+          zlib: { level: 9 },
+        });
+
+        archive.on("finish", () => {
+          resolve();
+        });
+
+        archive.pipe(pass);
+        archive.finalize();
+      });
+      return pass;
+    };
+
     it("should GET / 404", async () => {
       const response = await requestApp
         .get("trackGroups/1/download")
@@ -163,6 +192,94 @@ describe("trackGroups/{id}/download", () => {
         },
       });
       assert.equal(updatedPurchase?.singleDownloadToken, downloadToken);
+    });
+
+    it("should GET / 200 and stream zip when trackgroup is already zipped", async () => {
+      const { user } = await createUser({ email: "artist@artist.com" });
+      const artist = await createArtist(user.id);
+      const trackGroup = await createTrackGroup(artist.id);
+      const track = await createTrack(trackGroup.id);
+
+      const passthrough = await generateMockArchive();
+      await uploadZip("trackGroup", trackGroup.id, "mp3-320", passthrough);
+
+      const { user: purchaser, accessToken } = await createUser({
+        email: "purchaser@artist.com",
+      });
+      await prisma.userTrackGroupPurchase.create({
+        data: {
+          userId: purchaser.id,
+          trackGroupId: trackGroup.id,
+          singleDownloadToken: randomUUID(),
+        },
+      });
+
+      const response = await requestApp
+        .get(`trackGroups/${trackGroup.id}/download?format=mp3-320`)
+        .set("Accept", "application/json")
+        .set("Cookie", [`jwt=${accessToken}`]);
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.header["content-type"], "application/zip");
+    });
+
+    describe("consolidated mode", () => {
+      let adminToken: string;
+
+      beforeEach(async () => {
+        const { accessToken } = await createUser({
+          email: "admin@test.com",
+          isAdmin: true,
+        });
+        adminToken = accessToken;
+        await requestApp
+          .post("admin/settings")
+          .set("Cookie", [`jwt=${adminToken}`])
+          .set("Accept", "application/json")
+          .send({
+            bucketNames: { prefix: "" },
+            settings: { platformPercent: 7 },
+          });
+        setBucketConfig({ prefix: "" });
+      });
+
+      afterEach(async () => {
+        setBucketConfig(null);
+        await requestApp
+          .post("admin/settings")
+          .set("Cookie", [`jwt=${adminToken}`])
+          .set("Accept", "application/json")
+          .send({ bucketNames: null, settings: { platformPercent: 7 } });
+      });
+
+      it("serves a trackgroup zip uploaded to the consolidated bucket", async () => {
+        const { user } = await createUser({ email: "artist@artist.com" });
+        const artist = await createArtist(user.id);
+        const trackGroup = await createTrackGroup(artist.id);
+        const track = await createTrack(trackGroup.id);
+
+        const passthrough = await generateMockArchive();
+        await uploadZip("trackGroup", trackGroup.id, "mp3-320", passthrough);
+
+        const { user: purchaser, accessToken } = await createUser({
+          email: "purchaser@artist.com",
+        });
+        await prisma.userTrackGroupPurchase.create({
+          data: {
+            userId: purchaser.id,
+            trackGroupId: trackGroup.id,
+            singleDownloadToken: randomUUID(),
+          },
+        });
+
+        const response = await requestApp
+          .get(`trackGroups/${trackGroup.id}/download?format=mp3-320`)
+          .set("Accept", "application/json")
+          .set("Cookie", [`jwt=${accessToken}`]);
+
+        assert.equal(response.statusCode, 200);
+        assert.equal(response.header["content-type"], "application/zip");
+      });
     });
   });
 });

--- a/test/routers/tracks/{id}.download.spec.ts
+++ b/test/routers/tracks/{id}.download.spec.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert";
+
 import * as dotenv from "dotenv";
 dotenv.config();
 import { describe, it } from "mocha";
+
+import {
+  createBucketIfNotExists,
+  finalAudioBucket,
+  uploadZip,
+} from "../../../src/utils/minio";
 import {
   clearTables,
   createArtist,
@@ -10,17 +17,15 @@ import {
   createUser,
   createUserTrackGroupPurchase,
 } from "../../utils";
+
 import prisma from "@mirlo/prisma";
+
 import { randomUUID } from "crypto";
 
 import { requestApp } from "../utils";
-import {
-  createBucketIfNotExists,
-  finalAudioBucket,
-  trackFormatBucket,
-  uploadWrapper,
-} from "../../../src/utils/minio";
+
 import archiver from "archiver";
+
 import { PassThrough } from "node:stream";
 
 describe("tracks/{id}/download", () => {
@@ -80,14 +85,8 @@ describe("tracks/{id}/download", () => {
       const trackGroup = await createTrackGroup(artist.id);
       const track = await createTrack(trackGroup.id);
 
-      await createBucketIfNotExists(finalAudioBucket);
-      await createBucketIfNotExists(trackFormatBucket);
       const passthrough = await generateMockArchive();
-      await uploadWrapper(
-        trackFormatBucket,
-        `${track.id}/flac.zip`,
-        passthrough
-      );
+      await uploadZip("track", track.id, "flac", passthrough);
 
       const { user: purchaser } = await createUser({
         email: "purchaser@artist.com",
@@ -118,13 +117,8 @@ describe("tracks/{id}/download", () => {
       const artist = await createArtist(user.id);
       const trackGroup = await createTrackGroup(artist.id);
       const track = await createTrack(trackGroup.id);
-      await createBucketIfNotExists(trackFormatBucket);
       const passthrough = await generateMockArchive();
-      await uploadWrapper(
-        trackFormatBucket,
-        `${track.id}/flac.zip`,
-        passthrough
-      );
+      await uploadZip("track", track.id, "flac", passthrough);
 
       const { user: purchaser, accessToken } = await createUser({
         email: "purchaser@artist.com",
@@ -194,9 +188,8 @@ describe("tracks/{id}/download", () => {
       });
       const track = await createTrack(trackGroup.id, { isPreview: true });
 
-      await createBucketIfNotExists(trackFormatBucket);
       const passthrough = await generateMockArchive();
-      await uploadWrapper(trackFormatBucket, `${track.id}/flac.zip`, passthrough);
+      await uploadZip("track", track.id, "flac", passthrough);
 
       const { user: purchaser, accessToken } = await createUser({
         email: "purchaser@artist.com",

--- a/test/routers/tracks/{id}.download.spec.ts
+++ b/test/routers/tracks/{id}.download.spec.ts
@@ -2,12 +2,13 @@ import assert from "node:assert";
 
 import * as dotenv from "dotenv";
 dotenv.config();
-import { describe, it } from "mocha";
+import { afterEach, beforeEach, describe, it } from "mocha";
 
 import {
   createBucketIfNotExists,
   finalAudioBucket,
   uploadZip,
+  setBucketConfig,
 } from "../../../src/utils/minio";
 import {
   clearTables,
@@ -225,6 +226,65 @@ describe("tracks/{id}/download", () => {
         .set("Cookie", [`jwt=${accessToken}`]);
 
       assert.equal(response.statusCode, 404);
+    });
+
+    describe("consolidated mode", () => {
+      let adminToken: string;
+
+      beforeEach(async () => {
+        const { accessToken } = await createUser({
+          email: "admin@test.com",
+          isAdmin: true,
+        });
+        adminToken = accessToken;
+        await requestApp
+          .post("admin/settings")
+          .set("Cookie", [`jwt=${adminToken}`])
+          .set("Accept", "application/json")
+          .send({
+            bucketNames: { prefix: "" },
+            settings: { platformPercent: 7 },
+          });
+        setBucketConfig({ prefix: "" });
+      });
+
+      afterEach(async () => {
+        setBucketConfig(null);
+        await requestApp
+          .post("admin/settings")
+          .set("Cookie", [`jwt=${adminToken}`])
+          .set("Accept", "application/json")
+          .send({ bucketNames: null, settings: { platformPercent: 7 } });
+      });
+
+      it("serves a track zip uploaded to the consolidated bucket", async () => {
+        const { user } = await createUser({ email: "artist@artist.com" });
+        const artist = await createArtist(user.id);
+        const trackGroup = await createTrackGroup(artist.id);
+        const track = await createTrack(trackGroup.id);
+
+        const passthrough = await generateMockArchive();
+        await uploadZip("track", track.id, "flac", passthrough);
+
+        const { user: purchaser, accessToken } = await createUser({
+          email: "purchaser@artist.com",
+        });
+        await prisma.userTrackPurchase.create({
+          data: {
+            userId: purchaser.id,
+            trackId: track.id,
+            singleDownloadToken: randomUUID(),
+          },
+        });
+
+        const response = await requestApp
+          .get(`tracks/${track.id}/download`)
+          .set("Accept", "application/json")
+          .set("Cookie", [`jwt=${accessToken}`]);
+
+        assert.equal(response.statusCode, 200);
+        assert.equal(response.header["content-type"], "application/zip");
+      });
     });
 
     it("should GET / fail if not generated with logged in user", async () => {

--- a/test/static.spec.ts
+++ b/test/static.spec.ts
@@ -1,0 +1,97 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import express from "express";
+import { afterEach, beforeEach, describe, it } from "mocha";
+
+import assert from "assert";
+
+import sinon from "sinon";
+import request from "supertest";
+
+import { Readable } from "stream";
+
+import { serveStatic } from "../src/static";
+import { minioClient } from "../src/utils/minio";
+
+const fileContents = "file-bytes";
+
+// Collect the raw response body regardless of content type.
+const rawBody = (res: any, cb: (err: Error | null, body: Buffer) => void) => {
+  const chunks: Buffer[] = [];
+  res.on("data", (chunk: Buffer) => chunks.push(chunk));
+  res.on("end", () => cb(null, Buffer.concat(chunks)));
+};
+
+describe("serveStatic", () => {
+  // Mounted the same way as in src/index.ts
+  const app = express();
+  app.use("/images/:bucket", serveStatic);
+
+  let statStub: sinon.SinonStub;
+  let getObjectStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    statStub = sinon.stub(minioClient!, "statObject").resolves({
+      size: fileContents.length,
+      etag: "test-etag",
+      lastModified: new Date(),
+      metaData: {},
+    } as any);
+    getObjectStub = sinon
+      .stub(minioClient!, "getObject")
+      .callsFake(
+        () => Promise.resolve(Readable.from([Buffer.from(fileContents)])) as any
+      );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("serves a legacy flat object key", async () => {
+    const response = await request(app)
+      .get("/images/trackgroup-covers/some-image-x600.webp")
+      .buffer(true)
+      .parse(rawBody)
+      .expect(200);
+
+    assert.deepEqual(statStub.firstCall.args, [
+      "trackgroup-covers",
+      "some-image-x600.webp",
+    ]);
+    assert.equal(response.body.toString(), fileContents);
+  });
+
+  it("serves a consolidated object key containing slashes", async () => {
+    await request(app)
+      .get("/images/mirlo-images/trackgroup-covers/some-image-x600.webp")
+      .expect(200);
+
+    assert.deepEqual(statStub.firstCall.args, [
+      "mirlo-images",
+      "trackgroup-covers/some-image-x600.webp",
+    ]);
+  });
+
+  it("404s when the object does not exist", async () => {
+    statStub.rejects(new Error("not found"));
+
+    await request(app).get("/images/mirlo-images/nope.webp").expect(404);
+    assert.equal(getObjectStub.called, false);
+  });
+
+  it("404s when no object key is given", async () => {
+    await request(app).get("/images/mirlo-images").expect(404);
+    assert.equal(statStub.called, false);
+  });
+
+  it("returns 304 without a body when If-None-Match matches", async () => {
+    await request(app)
+      .get("/images/mirlo-images/trackgroup-covers/foo.webp")
+      .set("If-None-Match", '"test-etag"')
+      .expect(304);
+
+    assert.equal(getObjectStub.called, false);
+  });
+});

--- a/test/utils/minio.spec.ts
+++ b/test/utils/minio.spec.ts
@@ -8,6 +8,7 @@ import assert from "assert";
 import sinon from "sinon";
 
 import { Readable } from "stream";
+import { EventEmitter } from "events";
 
 import {
   setBucketConfig,
@@ -24,6 +25,10 @@ import {
   uploadAudioHlsFile,
   uploadZip,
   getDownloadableContentBuffer,
+  getCoverBuffer,
+  removeCoverImages,
+  removeDownloadableContent,
+  removeAudioFiles,
   minioClient,
   // Bucket name constants used in assertions
   incomingArtistAvatarBucket,
@@ -459,6 +464,139 @@ describe("minio bucket routing", () => {
       const [bucket, key] = getObjectStub.firstCall.args;
       assert.equal(bucket, "mirlo-downloads");
       assert.equal(key, "content/content-id");
+    });
+  });
+
+  describe("getCoverBuffer", () => {
+    it("legacy mode: reads from finalCoversBucket with bare key", async () => {
+      await getCoverBuffer("cover-id", "webp");
+      const [bucket, key] = getObjectStub.firstCall.args;
+      assert.equal(bucket, finalCoversBucket);
+      assert.equal(key, "cover-id-x1500.webp");
+    });
+
+    it("legacy mode: reads jpg from finalCoversBucket with bare key", async () => {
+      await getCoverBuffer("cover-id", "jpg");
+      const [bucket, key] = getObjectStub.firstCall.args;
+      assert.equal(bucket, finalCoversBucket);
+      assert.equal(key, "cover-id-x1500.jpg");
+    });
+
+    describe("consolidated mode (no prefix)", () => {
+      beforeEach(() => setBucketConfig({ prefix: "" }));
+
+      it("reads from mirlo-images with path-prefixed key", async () => {
+        await getCoverBuffer("cover-id", "webp");
+        const [bucket, key] = getObjectStub.firstCall.args;
+        assert.equal(bucket, "mirlo-images");
+        assert.equal(key, `${finalCoversBucket}/cover-id-x1500.webp`);
+      });
+    });
+
+    describe("consolidated mode (with prefix)", () => {
+      beforeEach(() => setBucketConfig({ prefix: "staging-" }));
+
+      it("reads from staging-mirlo-images with path-prefixed key", async () => {
+        await getCoverBuffer("cover-id", "webp");
+        const [bucket, key] = getObjectStub.firstCall.args;
+        assert.equal(bucket, "staging-mirlo-images");
+        assert.equal(key, `${finalCoversBucket}/cover-id-x1500.webp`);
+      });
+    });
+  });
+
+  describe("deletion operations", () => {
+    let listObjectsV2Stub: sinon.SinonStub;
+    let removeObjectsStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      listObjectsV2Stub = sinon
+        .stub(minioClient!, "listObjectsV2")
+        .callsFake(() => {
+          const emitter = new EventEmitter();
+          setImmediate(() => {
+            emitter.emit("data", { name: "file1" });
+            emitter.emit("end");
+          });
+          return emitter as any;
+        });
+      removeObjectsStub = sinon.stub(minioClient!, "removeObjects").resolves();
+    });
+
+    describe("legacy mode", () => {
+      it("removeAudioFiles uses finalAudioBucket with audioId prefix", async () => {
+        await removeAudioFiles("audio-id");
+        assert.equal(listObjectsV2Stub.firstCall.args[0], finalAudioBucket);
+        assert.equal(listObjectsV2Stub.firstCall.args[1], "audio-id");
+      });
+
+      it("removeCoverImages uses finalCoversBucket with coverId prefix", async () => {
+        await removeCoverImages("cover-id");
+        assert.equal(listObjectsV2Stub.firstCall.args[0], finalCoversBucket);
+        assert.equal(listObjectsV2Stub.firstCall.args[1], "cover-id");
+      });
+
+      it("removeDownloadableContent uses downloadableContentBucket with contentId prefix", async () => {
+        await removeDownloadableContent("content-id");
+        assert.equal(
+          listObjectsV2Stub.firstCall.args[0],
+          downloadableContentBucket
+        );
+        assert.equal(listObjectsV2Stub.firstCall.args[1], "content-id");
+      });
+    });
+
+    describe("consolidated mode", () => {
+      beforeEach(() => setBucketConfig({ prefix: "" }));
+
+      it("removeAudioFiles uses mirlo-audio with audioId prefix", async () => {
+        await removeAudioFiles("audio-id");
+        assert.equal(listObjectsV2Stub.firstCall.args[0], "mirlo-audio");
+        assert.equal(listObjectsV2Stub.firstCall.args[1], "audio-id");
+      });
+
+      it("removeCoverImages uses mirlo-images with prefixed coverId", async () => {
+        await removeCoverImages("cover-id");
+        assert.equal(listObjectsV2Stub.firstCall.args[0], "mirlo-images");
+        assert.equal(
+          listObjectsV2Stub.firstCall.args[1],
+          `${finalCoversBucket}/cover-id`
+        );
+      });
+
+      it("removeDownloadableContent uses mirlo-downloads with content/ prefix", async () => {
+        await removeDownloadableContent("content-id");
+        assert.equal(listObjectsV2Stub.firstCall.args[0], "mirlo-downloads");
+        assert.equal(listObjectsV2Stub.firstCall.args[1], "content/content-id");
+      });
+    });
+
+    describe("consolidated mode (with prefix)", () => {
+      beforeEach(() => setBucketConfig({ prefix: "staging-" }));
+
+      it("removeAudioFiles uses staging-mirlo-audio", async () => {
+        await removeAudioFiles("audio-id");
+        assert.equal(
+          listObjectsV2Stub.firstCall.args[0],
+          "staging-mirlo-audio"
+        );
+      });
+
+      it("removeCoverImages uses staging-mirlo-images", async () => {
+        await removeCoverImages("cover-id");
+        assert.equal(
+          listObjectsV2Stub.firstCall.args[0],
+          "staging-mirlo-images"
+        );
+      });
+
+      it("removeDownloadableContent uses staging-mirlo-downloads", async () => {
+        await removeDownloadableContent("content-id");
+        assert.equal(
+          listObjectsV2Stub.firstCall.args[0],
+          "staging-mirlo-downloads"
+        );
+      });
     });
   });
 });

--- a/test/utils/minio.spec.ts
+++ b/test/utils/minio.spec.ts
@@ -1,0 +1,464 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import { afterEach, beforeEach, describe, it } from "mocha";
+
+import assert from "assert";
+
+import sinon from "sinon";
+
+import { Readable } from "stream";
+
+import {
+  setBucketConfig,
+  getImagesBucket,
+  getAudioBucket,
+  getDownloadsBucket,
+  getImageFinalBucket,
+  imageTypeUsesQueue,
+  uploadIncomingImageByType,
+  downloadIncomingImageByType,
+  uploadOptimizedImageByType,
+  removeIncomingImageByType,
+  uploadIncomingAudio,
+  uploadAudioHlsFile,
+  uploadZip,
+  getDownloadableContentBuffer,
+  minioClient,
+  // Bucket name constants used in assertions
+  incomingArtistAvatarBucket,
+  finalArtistAvatarBucket,
+  finalArtistBackgroundBucket,
+  incomingUserAvatarBucket,
+  finalUserAvatarBucket,
+  incomingCoversBucket,
+  finalCoversBucket,
+  finalPostImageBucket,
+  incomingImageBucket,
+  finalImageBucket,
+  incomingAudioBucket,
+  finalAudioBucket,
+  trackGroupFormatBucket,
+  trackFormatBucket,
+  downloadableContentBucket,
+} from "../../src/utils/minio";
+
+// Returns a Readable that ends immediately — safe to use as a fake upload stream.
+function emptyReadable(): Readable {
+  return new Readable({
+    read() {
+      this.push(null);
+    },
+  });
+}
+
+describe("minio bucket routing", () => {
+  let putObjectStub: sinon.SinonStub;
+  let getObjectStub: sinon.SinonStub;
+  let removeObjectStub: sinon.SinonStub;
+  let bucketExistsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    // Reset to legacy mode and clear the ensured-bucket cache.
+    setBucketConfig(null);
+    putObjectStub = sinon.stub(minioClient!, "putObject").resolves();
+    // Each call gets a fresh stream so the 'end' event fires correctly.
+    getObjectStub = sinon
+      .stub(minioClient!, "getObject")
+      .callsFake(() => Promise.resolve(emptyReadable()) as any);
+    removeObjectStub = sinon.stub(minioClient!, "removeObject").resolves();
+    bucketExistsStub = sinon.stub(minioClient!, "bucketExists").resolves(true);
+  });
+
+  afterEach(() => {
+    setBucketConfig(null);
+    sinon.restore();
+  });
+
+  // ── Bucket selection helpers ─────────────────────────────────────────────────
+
+  describe("getImagesBucket / getAudioBucket / getDownloadsBucket", () => {
+    it("legacy mode: returns the legacy fallback bucket unchanged", () => {
+      assert.equal(getImagesBucket("artist-avatars"), "artist-avatars");
+      assert.equal(
+        getAudioBucket("incoming-track-audio"),
+        "incoming-track-audio"
+      );
+      assert.equal(getAudioBucket(), finalAudioBucket);
+      assert.equal(
+        getDownloadsBucket("trackgroup-format"),
+        "trackgroup-format"
+      );
+    });
+
+    describe("consolidated mode (no prefix)", () => {
+      beforeEach(() => setBucketConfig({ prefix: "" }));
+
+      it("routes all image traffic to mirlo-images regardless of fallback", () => {
+        assert.equal(getImagesBucket("artist-avatars"), "mirlo-images");
+        assert.equal(getImagesBucket("incoming-covers"), "mirlo-images");
+      });
+
+      it("routes all audio traffic to mirlo-audio", () => {
+        assert.equal(getAudioBucket(), "mirlo-audio");
+        assert.equal(getAudioBucket("incoming-track-audio"), "mirlo-audio");
+      });
+
+      it("routes all downloads traffic to mirlo-downloads", () => {
+        assert.equal(
+          getDownloadsBucket("trackgroup-format"),
+          "mirlo-downloads"
+        );
+        assert.equal(getDownloadsBucket("track-format"), "mirlo-downloads");
+      });
+    });
+
+    describe("consolidated mode (with prefix)", () => {
+      beforeEach(() => setBucketConfig({ prefix: "staging-" }));
+
+      it("prepends prefix to all consolidated bucket names", () => {
+        assert.equal(getImagesBucket("anything"), "staging-mirlo-images");
+        assert.equal(getAudioBucket(), "staging-mirlo-audio");
+        assert.equal(getDownloadsBucket("anything"), "staging-mirlo-downloads");
+      });
+    });
+  });
+
+  // ── Image type helpers ───────────────────────────────────────────────────────
+
+  describe("imageTypeUsesQueue", () => {
+    it("returns true for all standard image types that need optimization", () => {
+      assert.equal(imageTypeUsesQueue("artistAvatar"), true);
+      assert.equal(imageTypeUsesQueue("artistBackground"), true);
+      assert.equal(imageTypeUsesQueue("userAvatar"), true);
+      assert.equal(imageTypeUsesQueue("userBanner"), true);
+      assert.equal(imageTypeUsesQueue("trackGroupCover"), true);
+      assert.equal(imageTypeUsesQueue("merch"), true);
+      assert.equal(imageTypeUsesQueue("image"), true);
+    });
+
+    it("returns false for postImage which goes straight to final storage", () => {
+      assert.equal(imageTypeUsesQueue("postImage"), false);
+    });
+  });
+
+  describe("getImageFinalBucket", () => {
+    it("returns the correct final bucket name for each type", () => {
+      assert.equal(
+        getImageFinalBucket("artistAvatar"),
+        finalArtistAvatarBucket
+      );
+      assert.equal(
+        getImageFinalBucket("artistBackground"),
+        finalArtistBackgroundBucket
+      );
+      assert.equal(getImageFinalBucket("trackGroupCover"), finalCoversBucket);
+      assert.equal(getImageFinalBucket("image"), finalImageBucket);
+      assert.equal(getImageFinalBucket("postImage"), finalPostImageBucket);
+    });
+  });
+
+  // ── Image routing: legacy mode ───────────────────────────────────────────────
+
+  describe("image routing: legacy mode", () => {
+    it("uploadIncomingImageByType(artistAvatar) → incoming-artist-avatars with bare key", async () => {
+      await uploadIncomingImageByType(
+        "artistAvatar",
+        "abc123",
+        emptyReadable()
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, incomingArtistAvatarBucket);
+      assert.equal(key, "abc123");
+    });
+
+    it("downloadIncomingImageByType(artistAvatar) → incoming-artist-avatars with bare key", async () => {
+      await downloadIncomingImageByType("artistAvatar", "abc123");
+      const [bucket, key] = getObjectStub.firstCall.args;
+      assert.equal(bucket, incomingArtistAvatarBucket);
+      assert.equal(key, "abc123");
+    });
+
+    it("uploadOptimizedImageByType(artistAvatar) → artist-avatars with bare key", async () => {
+      await uploadOptimizedImageByType(
+        "artistAvatar",
+        "abc123-x500.webp",
+        Buffer.alloc(0)
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, finalArtistAvatarBucket);
+      assert.equal(key, "abc123-x500.webp");
+    });
+
+    it("removeIncomingImageByType(artistAvatar) → incoming-artist-avatars with bare key", async () => {
+      await removeIncomingImageByType("artistAvatar", "abc123");
+      const [bucket, key] = removeObjectStub.firstCall.args;
+      assert.equal(bucket, incomingArtistAvatarBucket);
+      assert.equal(key, "abc123");
+    });
+
+    it("uploadIncomingImageByType(trackGroupCover) → incoming-covers bucket", async () => {
+      await uploadIncomingImageByType(
+        "trackGroupCover",
+        "cover-id",
+        emptyReadable()
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, incomingCoversBucket);
+      assert.equal(key, "cover-id");
+    });
+
+    it("uploadOptimizedImageByType(trackGroupCover) → trackgroup-covers bucket", async () => {
+      await uploadOptimizedImageByType(
+        "trackGroupCover",
+        "cover-id-x1500.webp",
+        Buffer.alloc(0)
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, finalCoversBucket);
+      assert.equal(key, "cover-id-x1500.webp");
+    });
+
+    it("uploadIncomingImageByType(postImage) → post-images bucket (no separate incoming bucket)", async () => {
+      await uploadIncomingImageByType("postImage", "post-id", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, finalPostImageBucket);
+      assert.equal(key, "post-id");
+    });
+
+    it("uploadIncomingImageByType(image) → incoming-mirlo-images bucket", async () => {
+      await uploadIncomingImageByType("image", "img-id", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, incomingImageBucket);
+      assert.equal(key, "img-id");
+    });
+
+    it("downloadIncomingImageByType(userAvatar) reads from incoming-artist-avatars, not incoming-user-avatars", async () => {
+      // userAvatar shares the artist-avatars incoming bucket intentionally;
+      // this test guards against the old bug where the final bucket was used as incoming.
+      await downloadIncomingImageByType("userAvatar", "user-id");
+      const [bucket] = getObjectStub.firstCall.args;
+      assert.equal(bucket, incomingArtistAvatarBucket);
+      assert.notEqual(bucket, incomingUserAvatarBucket);
+      assert.notEqual(bucket, finalUserAvatarBucket);
+    });
+  });
+
+  // ── Image routing: consolidated mode ────────────────────────────────────────
+
+  describe("image routing: consolidated mode (no prefix)", () => {
+    beforeEach(() => setBucketConfig({ prefix: "" }));
+
+    it("uploadIncomingImageByType(artistAvatar) → mirlo-images / incoming/{prefix}/{id}", async () => {
+      await uploadIncomingImageByType(
+        "artistAvatar",
+        "abc123",
+        emptyReadable()
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-images");
+      assert.equal(key, `incoming/${finalArtistAvatarBucket}/abc123`);
+    });
+
+    it("downloadIncomingImageByType(artistAvatar) → mirlo-images / incoming/{prefix}/{id}", async () => {
+      await downloadIncomingImageByType("artistAvatar", "abc123");
+      const [bucket, key] = getObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-images");
+      assert.equal(key, `incoming/${finalArtistAvatarBucket}/abc123`);
+    });
+
+    it("uploadOptimizedImageByType(artistAvatar) → mirlo-images / {prefix}/{filename}", async () => {
+      await uploadOptimizedImageByType(
+        "artistAvatar",
+        "abc123-x500.webp",
+        Buffer.alloc(0)
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-images");
+      assert.equal(key, `${finalArtistAvatarBucket}/abc123-x500.webp`);
+    });
+
+    it("removeIncomingImageByType(artistAvatar) → mirlo-images / incoming/{prefix}/{id}", async () => {
+      await removeIncomingImageByType("artistAvatar", "abc123");
+      const [bucket, key] = removeObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-images");
+      assert.equal(key, `incoming/${finalArtistAvatarBucket}/abc123`);
+    });
+
+    it("uploadIncomingImageByType(image) → mirlo-images with NO path prefix (prefix: undefined)", async () => {
+      // The generic 'image' type has prefix: undefined — even in consolidated mode,
+      // images are stored at the bucket root without a path prefix.
+      await uploadIncomingImageByType("image", "img-id", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-images");
+      assert.equal(key, "img-id");
+    });
+
+    it("uploadOptimizedImageByType(image) → mirlo-images with NO path prefix", async () => {
+      await uploadOptimizedImageByType(
+        "image",
+        "img-id-original.webp",
+        Buffer.alloc(0)
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-images");
+      assert.equal(key, "img-id-original.webp");
+    });
+
+    it("uploadIncomingImageByType(trackGroupCover) → mirlo-images / incoming/{prefix}/{id}", async () => {
+      await uploadIncomingImageByType(
+        "trackGroupCover",
+        "cover-id",
+        emptyReadable()
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-images");
+      assert.equal(key, `incoming/${finalCoversBucket}/cover-id`);
+    });
+
+    it("uploadOptimizedImageByType(trackGroupCover) → mirlo-images / {prefix}/{filename}", async () => {
+      await uploadOptimizedImageByType(
+        "trackGroupCover",
+        "cover-id-x1500.webp",
+        Buffer.alloc(0)
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-images");
+      assert.equal(key, `${finalCoversBucket}/cover-id-x1500.webp`);
+    });
+
+    it("uploadIncomingImageByType(userAvatar) → mirlo-images / incoming/{finalUserAvatarBucket}/{id}", async () => {
+      await uploadIncomingImageByType("userAvatar", "user-id", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-images");
+      assert.equal(key, `incoming/${finalUserAvatarBucket}/user-id`);
+    });
+  });
+
+  describe("image routing: consolidated mode (with prefix)", () => {
+    beforeEach(() => setBucketConfig({ prefix: "staging-" }));
+
+    it("uploadIncomingImageByType(artistAvatar) → staging-mirlo-images with correct key", async () => {
+      await uploadIncomingImageByType(
+        "artistAvatar",
+        "abc123",
+        emptyReadable()
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "staging-mirlo-images");
+      assert.equal(key, `incoming/${finalArtistAvatarBucket}/abc123`);
+    });
+
+    it("uploadOptimizedImageByType(trackGroupCover) → staging-mirlo-images with correct key", async () => {
+      await uploadOptimizedImageByType(
+        "trackGroupCover",
+        "cover-id-x1500.webp",
+        Buffer.alloc(0)
+      );
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "staging-mirlo-images");
+      assert.equal(key, `${finalCoversBucket}/cover-id-x1500.webp`);
+    });
+
+    it("uploadIncomingImageByType(image) → staging-mirlo-images with NO path prefix", async () => {
+      await uploadIncomingImageByType("image", "img-id", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "staging-mirlo-images");
+      assert.equal(key, "img-id");
+    });
+  });
+
+  // ── Audio routing ────────────────────────────────────────────────────────────
+
+  describe("audio routing: legacy mode", () => {
+    it("uploadIncomingAudio → incoming-track-audio with bare key", async () => {
+      await uploadIncomingAudio("audio-id", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, incomingAudioBucket);
+      assert.equal(key, "audio-id");
+    });
+
+    it("uploadAudioHlsFile → track-audio with id/filename key", async () => {
+      await uploadAudioHlsFile("audio-id", "segment.ts", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, finalAudioBucket);
+      assert.equal(key, "audio-id/segment.ts");
+    });
+  });
+
+  describe("audio routing: consolidated mode", () => {
+    beforeEach(() => setBucketConfig({ prefix: "" }));
+
+    it("uploadIncomingAudio → mirlo-audio with incoming/ key prefix", async () => {
+      await uploadIncomingAudio("audio-id", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-audio");
+      assert.equal(key, "incoming/audio-id");
+    });
+
+    it("uploadAudioHlsFile → mirlo-audio with same id/filename key (no extra prefix)", async () => {
+      await uploadAudioHlsFile("audio-id", "segment.ts", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-audio");
+      assert.equal(key, "audio-id/segment.ts");
+    });
+  });
+
+  // ── Zip routing ──────────────────────────────────────────────────────────────
+
+  describe("zip routing: legacy mode", () => {
+    it("uploadZip(trackGroup) → trackgroup-format / {id}/{format}.zip", async () => {
+      await uploadZip("trackGroup", 42, "mp3-320", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, trackGroupFormatBucket);
+      assert.equal(key, "42/mp3-320.zip");
+    });
+
+    it("uploadZip(track) → track-format / {id}/{format}.zip", async () => {
+      await uploadZip("track", 7, "flac", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, trackFormatBucket);
+      assert.equal(key, "7/flac.zip");
+    });
+  });
+
+  describe("zip routing: consolidated mode", () => {
+    beforeEach(() => setBucketConfig({ prefix: "" }));
+
+    it("uploadZip(trackGroup) → mirlo-downloads / trackgroup/{id}/{format}.zip", async () => {
+      await uploadZip("trackGroup", 42, "mp3-320", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-downloads");
+      assert.equal(key, "trackgroup/42/mp3-320.zip");
+    });
+
+    it("uploadZip(track) → mirlo-downloads / track/{id}/{format}.zip", async () => {
+      await uploadZip("track", 7, "flac", emptyReadable());
+      const [bucket, key] = putObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-downloads");
+      assert.equal(key, "track/7/flac.zip");
+    });
+  });
+
+  // ── Downloadable content routing ─────────────────────────────────────────────
+
+  describe("downloadable content routing: legacy mode", () => {
+    it("getDownloadableContentBuffer → mirlo-downloadable-content with bare key", async () => {
+      await getDownloadableContentBuffer("content-id");
+      const [bucket, key] = getObjectStub.firstCall.args;
+      assert.equal(bucket, downloadableContentBucket);
+      assert.equal(key, "content-id");
+    });
+  });
+
+  describe("downloadable content routing: consolidated mode", () => {
+    beforeEach(() => setBucketConfig({ prefix: "" }));
+
+    it("getDownloadableContentBuffer → mirlo-downloads / content/{id}", async () => {
+      await getDownloadableContentBuffer("content-id");
+      const [bucket, key] = getObjectStub.firstCall.args;
+      assert.equal(bucket, "mirlo-downloads");
+      assert.equal(key, "content/content-id");
+    });
+  });
+});


### PR DESCRIPTION
… stuck in multi bucket system

Note that this is kind of a one way street (which is desired, we won't want anyone migrating _back_ to legacy after they've enabled the consolidated buckets). 

Note also that the intent is still to switch eventually to the Image table for any of the other things so that we don't have unique Image systems for every type of Image but rather something consolidated. 

Worth doing a little bit more thinking about the impact this will have on CDN caches for images. Might be worth flushing edge caches on cloudflare when this rolls out. 

* [ ] Think about how to handle `clean-up-old-files` job. 

Closes #1143

