### PR TITLE
Fixed buttons improvements

### DIFF
--- a/client/cypress/e2e/player-buy-wishlist-target.cy.ts
+++ b/client/cypress/e2e/player-buy-wishlist-target.cy.ts
@@ -30,7 +30,7 @@ const buildTrack = ({
   trackGroupId: featuredRelease.id,
   trackGroup: {
     ...featuredRelease,
-    tracksCount: trackCount,
+    totalTracks: trackCount,
   },
   isPreview: true,
   audio: { id: `audio-${id}`, duration: 60, uploadState: "SUCCESS" },

--- a/client/cypress/e2e/player-buy-wishlist-target.cy.ts
+++ b/client/cypress/e2e/player-buy-wishlist-target.cy.ts
@@ -1,0 +1,204 @@
+import {
+  ARTIST_EXAMPLE,
+  TRACK_GROUP_EXAMPLE,
+} from "../../../client/test/mocks";
+
+const artistSlug = "example-artist";
+const albumSlug = TRACK_GROUP_EXAMPLE.urlSlug ?? "example-album";
+
+const artist = {
+  ...ARTIST_EXAMPLE,
+  urlSlug: artistSlug,
+  user: { artistLabels: [], currency: "usd" },
+};
+
+const featuredRelease = {
+  ...TRACK_GROUP_EXAMPLE,
+  artist: { ...TRACK_GROUP_EXAMPLE.artist, urlSlug: artistSlug },
+};
+
+const buildTrack = ({
+  id,
+  trackCount,
+}: {
+  id: number;
+  trackCount: number;
+}) => ({
+  id,
+  title: `Track ${id}`,
+  order: 1,
+  trackGroupId: featuredRelease.id,
+  trackGroup: {
+    ...featuredRelease,
+    tracksCount: trackCount,
+  },
+  isPreview: true,
+  audio: { id: `audio-${id}`, duration: 60, uploadState: "SUCCESS" },
+  trackArtists: [],
+  license: null,
+});
+
+const baseUser = {
+  id: 1,
+  email: "tester@example.com",
+  name: "Tester",
+  wishlist: [],
+  trackFavorites: [],
+  userTrackGroupPurchases: [],
+  userTrackPurchases: [],
+};
+
+const stubCommonRoutes = () => {
+  cy.intercept("GET", "/v1/settings/instanceArtist", {
+    statusCode: 200,
+    body: { result: null },
+  });
+  cy.intercept("GET", "/v1/trackGroups*", {
+    statusCode: 200,
+    body: { results: [featuredRelease], total: 1 },
+  });
+  cy.intercept("GET", "/v1/trackGroups/topSold*", {
+    statusCode: 200,
+    body: { results: [], total: 0 },
+  });
+  cy.intercept("GET", "/v1/tags*", {
+    statusCode: 200,
+    body: { results: [], total: 0 },
+  });
+  cy.intercept("GET", "/v1/posts*", {
+    statusCode: 200,
+    body: { results: [], total: 0 },
+  });
+  cy.intercept("GET", `/v1/artists/${artistSlug}*`, {
+    statusCode: 200,
+    body: { result: artist },
+  });
+  cy.intercept("GET", `/v1/trackGroups/${albumSlug}*`, {
+    statusCode: 200,
+    body: { result: featuredRelease },
+  });
+};
+
+const visitWithTrack = (trackId: number) => {
+  cy.visit("/", {
+    onBeforeLoad(win) {
+      win.localStorage.setItem(
+        "nomadState",
+        JSON.stringify({
+          playerQueueIds: [trackId],
+          currentlyPlayingIndex: 0,
+          playing: true,
+        })
+      );
+    },
+  });
+};
+
+describe("player wishlist/buy target choice", () => {
+  describe("multi-track release", () => {
+    const trackId = 42;
+
+    beforeEach(() => {
+      stubCommonRoutes();
+
+      cy.intercept("GET", "/auth/profile", {
+        statusCode: 200,
+        body: { result: baseUser },
+      });
+
+      cy.intercept("GET", `/v1/tracks/${trackId}`, {
+        statusCode: 200,
+        body: { result: buildTrack({ id: trackId, trackCount: 8 }) },
+      });
+
+      cy.intercept("POST", `/v1/tracks/${trackId}/favorite`, {
+        statusCode: 200,
+        body: { result: {} },
+      }).as("favoriteTrack");
+
+      cy.intercept("POST", `/v1/trackGroups/${featuredRelease.id}/wishlist`, {
+        statusCode: 200,
+        body: { result: {} },
+      }).as("wishlistAlbum");
+    });
+
+    it("wishlist trigger opens a 2-item dropdown that targets the track", () => {
+      visitWithTrack(trackId);
+
+      cy.get('[data-cy="player-actions"] button.wishlist', {
+        timeout: 10000,
+      }).click();
+
+      cy.contains("Wishlist this track").should("be.visible");
+      cy.contains("Wishlist this album").should("be.visible");
+
+      cy.contains("Wishlist this track").click();
+
+      cy.wait("@favoriteTrack")
+        .its("request.body")
+        .should("deep.equal", { favorite: true });
+    });
+
+    it("wishlist dropdown targets the album when album item is picked", () => {
+      visitWithTrack(trackId);
+
+      cy.get('[data-cy="player-actions"] button.wishlist', {
+        timeout: 10000,
+      }).click();
+      cy.contains("Wishlist this album").click();
+
+      cy.wait("@wishlistAlbum")
+        .its("request.body")
+        .should("deep.equal", { wishlist: true });
+    });
+
+    it("buy trigger opens a 2-item dropdown with track and album options", () => {
+      visitWithTrack(trackId);
+
+      cy.get('[data-cy="player-actions"]', { timeout: 10000 })
+        .contains("button", "Name your price")
+        .click();
+
+      cy.contains("Buy this track").should("be.visible");
+      cy.contains("Buy this album").should("be.visible");
+    });
+  });
+
+  describe("single-track release", () => {
+    const trackId = 7;
+
+    beforeEach(() => {
+      stubCommonRoutes();
+
+      cy.intercept("GET", "/auth/profile", {
+        statusCode: 200,
+        body: { result: baseUser },
+      });
+
+      cy.intercept("GET", `/v1/tracks/${trackId}`, {
+        statusCode: 200,
+        body: { result: buildTrack({ id: trackId, trackCount: 1 }) },
+      });
+
+      cy.intercept("POST", `/v1/trackGroups/${featuredRelease.id}/wishlist`, {
+        statusCode: 200,
+        body: { result: {} },
+      }).as("wishlistAlbum");
+    });
+
+    it("wishlist button toggles the album directly without opening a dropdown", () => {
+      visitWithTrack(trackId);
+
+      cy.get('[data-cy="player-actions"] button.wishlist', {
+        timeout: 10000,
+      }).click();
+
+      cy.contains("Wishlist this track").should("not.exist");
+      cy.contains("Wishlist this album").should("not.exist");
+
+      cy.wait("@wishlistAlbum")
+        .its("request.body")
+        .should("deep.equal", { wishlist: true });
+    });
+  });
+});

--- a/client/src/components/Player/PlayerActions.tsx
+++ b/client/src/components/Player/PlayerActions.tsx
@@ -1,8 +1,17 @@
 import { css } from "@emotion/css";
+import DropdownMenu from "components/common/DropdownMenu";
+import { DropdownMenuItemButton } from "components/common/DropdownMenuItem";
+import { FixedButton } from "components/common/FixedButton";
+import Modal from "components/common/Modal";
 import TipArtist from "components/common/TipArtist";
+import BuyTrackGroup from "components/TrackGroup/BuyTrackGroup";
 import PurchaseOrDownloadAlbum from "components/TrackGroup/PurchaseOrDownloadAlbumModal";
 import Wishlist from "components/TrackGroup/Wishlist";
 import React from "react";
+import { useTranslation } from "react-i18next";
+import { IoIosHeart, IoIosHeartEmpty } from "react-icons/io";
+import api from "services/api";
+import { useAuthContext } from "state/AuthContext";
 import { useGlobalStateContext } from "state/GlobalState";
 
 import useCurrentTrackHook from "./useCurrentTrackHook";
@@ -18,6 +27,15 @@ const PlayerActions: React.FC = () => {
   if (!currentTrack || isLoading) {
     return null;
   }
+
+  const trackGroup = currentTrack.trackGroup;
+
+  if (!trackGroup) {
+    return null;
+  }
+
+  const tracksCount = trackGroup.tracksCount ?? trackGroup.tracks?.length ?? 1;
+  const isMultiTrack = tracksCount > 1;
 
   return (
     <div
@@ -38,14 +56,209 @@ const PlayerActions: React.FC = () => {
         }
       `}
     >
-      <Wishlist trackGroup={{ id: currentTrack.trackGroupId }} fixed />
-      {currentTrack.trackGroup.artistId && (
-        <TipArtist artistId={currentTrack.trackGroup.artistId} fixed />
+      {isMultiTrack ? (
+        <WishlistTargetMenu track={currentTrack} trackGroup={trackGroup} />
+      ) : (
+        <Wishlist trackGroup={{ id: trackGroup.id }} fixed />
       )}
-      {currentTrack.trackGroup && (
-        <PurchaseOrDownloadAlbum trackGroup={currentTrack.trackGroup} fixed />
+      {trackGroup.artistId && (
+        <TipArtist artistId={trackGroup.artistId} fixed />
+      )}
+      {isMultiTrack ? (
+        <BuyTargetMenu track={currentTrack} trackGroup={trackGroup} />
+      ) : (
+        <PurchaseOrDownloadAlbum trackGroup={trackGroup} fixed />
       )}
     </div>
+  );
+};
+
+const WishlistTargetMenu: React.FC<{
+  track: Track;
+  trackGroup: NonNullable<Track["trackGroup"]>;
+}> = ({ track, trackGroup }) => {
+  const { user } = useAuthContext();
+  const { t } = useTranslation("translation", { keyPrefix: "wishlist" });
+
+  const [albumInWishlist, setAlbumInWishlist] = React.useState(
+    !!user?.wishlist?.find((w) => w.trackGroupId === trackGroup.id)
+  );
+  const [trackInWishlist, setTrackInWishlist] = React.useState(
+    !!user?.trackFavorites?.find((w) => w.trackId === track.id)
+  );
+
+  if (!user) {
+    return null;
+  }
+
+  const toggleAlbum = async () => {
+    const next = !albumInWishlist;
+    await api.post(`trackGroups/${trackGroup.id}/wishlist`, { wishlist: next });
+    setAlbumInWishlist(next);
+  };
+
+  const toggleTrack = async () => {
+    const next = !trackInWishlist;
+    await api.post(`tracks/${track.id}/favorite`, { favorite: next });
+    setTrackInWishlist(next);
+  };
+
+  const anyInWishlist = albumInWishlist || trackInWishlist;
+  const triggerLabel = anyInWishlist
+    ? t("openWishlistMenuActive")
+    : t("openWishlistMenu");
+
+  const trigger = (
+    <FixedButton
+      aria-label={triggerLabel}
+      className="wishlist max-md:justify-center!"
+      title={triggerLabel}
+      rounded
+      size="compact"
+      endIcon={anyInWishlist ? <IoIosHeart /> : <IoIosHeartEmpty />}
+    />
+  );
+
+  return (
+    <DropdownMenu trigger={trigger}>
+      <WishlistMenuItem
+        active={trackInWishlist}
+        onToggle={toggleTrack}
+        labelAdd={t("wishlistThisTrack")}
+        labelRemove={t("removeTrackFromWishlist")}
+      />
+      <WishlistMenuItem
+        active={albumInWishlist}
+        onToggle={toggleAlbum}
+        labelAdd={t("wishlistThisAlbum")}
+        labelRemove={t("removeAlbumFromWishlist")}
+      />
+    </DropdownMenu>
+  );
+};
+
+const WishlistMenuItem: React.FC<{
+  active: boolean;
+  onToggle: () => void | Promise<void>;
+  labelAdd: string;
+  labelRemove: string;
+  setIsMenuOpen?: (open: boolean) => void;
+}> = ({ active, onToggle, labelAdd, labelRemove, setIsMenuOpen }) => {
+  const label = active ? labelRemove : labelAdd;
+  return (
+    <DropdownMenuItemButton
+      startIcon={active ? <IoIosHeart /> : <IoIosHeartEmpty />}
+      onClick={async () => {
+        await onToggle();
+        setIsMenuOpen?.(false);
+      }}
+    >
+      {label}
+    </DropdownMenuItemButton>
+  );
+};
+
+const BuyTargetMenu: React.FC<{
+  track: Track;
+  trackGroup: NonNullable<Track["trackGroup"]>;
+}> = ({ track, trackGroup }) => {
+  const { user } = useAuthContext();
+  const { t } = useTranslation("translation", { keyPrefix: "player" });
+  const { t: tCard } = useTranslation("translation", {
+    keyPrefix: "trackGroupCard",
+  });
+  const [buyTarget, setBuyTarget] = React.useState<"track" | "album" | null>(
+    null
+  );
+
+  if (!trackGroup.isGettable) {
+    return null;
+  }
+
+  const albumOwned = !!user?.userTrackGroupPurchases?.find(
+    (p) => p.trackGroupId === trackGroup.id
+  );
+  const trackOwned =
+    !!user?.userTrackPurchases?.find((p) => p.trackId === track.id) ||
+    (track.isPreview && albumOwned);
+
+  if (albumOwned && trackOwned) {
+    return null;
+  }
+
+  const payOrNameYourPrice =
+    trackGroup.minPrice === 0 ? "nameYourPriceLabel" : "buy";
+  const preOrderOrBuyText =
+    trackGroup.minPrice === null
+      ? "saveAlbum"
+      : trackGroup.fundraiser?.isAllOrNothing
+        ? "backThisProject"
+        : trackGroup.isPreorder
+          ? "preOrder"
+          : payOrNameYourPrice;
+  const purchaseTitle = trackGroup.isPreorder
+    ? "preOrderingTrackGroup"
+    : "buyingTrackGroup";
+
+  const modalTitle =
+    buyTarget === "track"
+      ? tCard(purchaseTitle, { title: track.title })
+      : tCard(purchaseTitle, { title: trackGroup.title });
+
+  const trigger = (
+    <FixedButton rounded size="compact">
+      {tCard(preOrderOrBuyText)}
+    </FixedButton>
+  );
+
+  return (
+    <>
+      <DropdownMenu trigger={trigger}>
+        <BuyMenuItem
+          show={!trackOwned}
+          label={t("buyThisTrack")}
+          onSelect={() => setBuyTarget("track")}
+        />
+        <BuyMenuItem
+          show={!albumOwned}
+          label={t("buyThisAlbum")}
+          onSelect={() => setBuyTarget("album")}
+        />
+      </DropdownMenu>
+      <Modal
+        size="small"
+        open={!!buyTarget}
+        onClose={() => setBuyTarget(null)}
+        title={modalTitle}
+        noPadding
+      >
+        <BuyTrackGroup
+          trackGroup={trackGroup}
+          track={buyTarget === "track" ? track : undefined}
+        />
+      </Modal>
+    </>
+  );
+};
+
+const BuyMenuItem: React.FC<{
+  show: boolean;
+  label: string;
+  onSelect: () => void;
+  setIsMenuOpen?: (open: boolean) => void;
+}> = ({ show, label, onSelect, setIsMenuOpen }) => {
+  if (!show) {
+    return null;
+  }
+  return (
+    <DropdownMenuItemButton
+      onClick={() => {
+        onSelect();
+        setIsMenuOpen?.(false);
+      }}
+    >
+      {label}
+    </DropdownMenuItemButton>
   );
 };
 

--- a/client/src/components/Player/PlayerActions.tsx
+++ b/client/src/components/Player/PlayerActions.tsx
@@ -34,8 +34,8 @@ const PlayerActions: React.FC = () => {
     return null;
   }
 
-  const tracksCount = trackGroup.tracksCount ?? trackGroup.tracks?.length ?? 1;
-  const isMultiTrack = tracksCount > 1;
+  const totalTracks = trackGroup.totalTracks ?? trackGroup.tracks?.length ?? 1;
+  const isMultiTrack = totalTracks > 1;
 
   return (
     <div

--- a/client/src/components/Player/PlayerActions.tsx
+++ b/client/src/components/Player/PlayerActions.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/css";
-import DropdownMenu from "components/common/DropdownMenu";
+import DropdownMenu, { useDropdownMenu } from "components/common/DropdownMenu";
 import { DropdownMenuItemButton } from "components/common/DropdownMenuItem";
 import { FixedButton } from "components/common/FixedButton";
 import Modal from "components/common/Modal";
@@ -39,6 +39,7 @@ const PlayerActions: React.FC = () => {
 
   return (
     <div
+      data-cy="player-actions"
       className={css`
         z-index: 10;
         bottom: var(--player-actions-bottom-offset, 80px);
@@ -121,18 +122,20 @@ const WishlistTargetMenu: React.FC<{
 
   return (
     <DropdownMenu trigger={trigger}>
-      <WishlistMenuItem
-        active={trackInWishlist}
-        onToggle={toggleTrack}
-        labelAdd={t("wishlistThisTrack")}
-        labelRemove={t("removeTrackFromWishlist")}
-      />
-      <WishlistMenuItem
-        active={albumInWishlist}
-        onToggle={toggleAlbum}
-        labelAdd={t("wishlistThisAlbum")}
-        labelRemove={t("removeAlbumFromWishlist")}
-      />
+      <ul>
+        <WishlistMenuItem
+          active={trackInWishlist}
+          onToggle={toggleTrack}
+          labelAdd={t("wishlistThisTrack")}
+          labelRemove={t("removeTrackFromWishlist")}
+        />
+        <WishlistMenuItem
+          active={albumInWishlist}
+          onToggle={toggleAlbum}
+          labelAdd={t("wishlistThisAlbum")}
+          labelRemove={t("removeAlbumFromWishlist")}
+        />
+      </ul>
     </DropdownMenu>
   );
 };
@@ -142,19 +145,21 @@ const WishlistMenuItem: React.FC<{
   onToggle: () => void | Promise<void>;
   labelAdd: string;
   labelRemove: string;
-  setIsMenuOpen?: (open: boolean) => void;
-}> = ({ active, onToggle, labelAdd, labelRemove, setIsMenuOpen }) => {
+}> = ({ active, onToggle, labelAdd, labelRemove }) => {
+  const menu = useDropdownMenu();
   const label = active ? labelRemove : labelAdd;
   return (
-    <DropdownMenuItemButton
-      startIcon={active ? <IoIosHeart /> : <IoIosHeartEmpty />}
-      onClick={async () => {
-        await onToggle();
-        setIsMenuOpen?.(false);
-      }}
-    >
-      {label}
-    </DropdownMenuItemButton>
+    <li>
+      <DropdownMenuItemButton
+        startIcon={active ? <IoIosHeart /> : <IoIosHeartEmpty />}
+        onClick={async () => {
+          await onToggle();
+          menu?.close();
+        }}
+      >
+        {label}
+      </DropdownMenuItemButton>
+    </li>
   );
 };
 
@@ -214,16 +219,18 @@ const BuyTargetMenu: React.FC<{
   return (
     <>
       <DropdownMenu trigger={trigger}>
-        <BuyMenuItem
-          show={!trackOwned}
-          label={t("buyThisTrack")}
-          onSelect={() => setBuyTarget("track")}
-        />
-        <BuyMenuItem
-          show={!albumOwned}
-          label={t("buyThisAlbum")}
-          onSelect={() => setBuyTarget("album")}
-        />
+        <ul>
+          <BuyMenuItem
+            show={!trackOwned}
+            label={t("buyThisTrack")}
+            onSelect={() => setBuyTarget("track")}
+          />
+          <BuyMenuItem
+            show={!albumOwned}
+            label={t("buyThisAlbum")}
+            onSelect={() => setBuyTarget("album")}
+          />
+        </ul>
       </DropdownMenu>
       <Modal
         size="small"
@@ -245,20 +252,22 @@ const BuyMenuItem: React.FC<{
   show: boolean;
   label: string;
   onSelect: () => void;
-  setIsMenuOpen?: (open: boolean) => void;
-}> = ({ show, label, onSelect, setIsMenuOpen }) => {
+}> = ({ show, label, onSelect }) => {
+  const menu = useDropdownMenu();
   if (!show) {
     return null;
   }
   return (
-    <DropdownMenuItemButton
-      onClick={() => {
-        onSelect();
-        setIsMenuOpen?.(false);
-      }}
-    >
-      {label}
-    </DropdownMenuItemButton>
+    <li>
+      <DropdownMenuItemButton
+        onClick={() => {
+          onSelect();
+          menu?.close();
+        }}
+      >
+        {label}
+      </DropdownMenuItemButton>
+    </li>
   );
 };
 

--- a/client/src/components/common/DropdownMenu.tsx
+++ b/client/src/components/common/DropdownMenu.tsx
@@ -20,6 +20,7 @@ const DropdownMenu: React.FC<{
   compact?: boolean;
   label?: string;
   triggerClassName?: string;
+  trigger?: React.ReactElement;
 }> = ({
   children,
   icon,
@@ -28,6 +29,7 @@ const DropdownMenu: React.FC<{
   label,
   smallIcon,
   triggerClassName,
+  trigger,
 }) => {
   const [buttonPosition, setButtonPosition] = React.useState<{
     x: number;
@@ -38,13 +40,63 @@ const DropdownMenu: React.FC<{
 
   const [isMenuOpen, setIsMenuOpen] = React.useState<boolean>(false);
 
-  if (!icon) {
-    icon = <FaEllipsisV />;
-  }
-
   const colors = useGetArtistColors();
-
   const LocalButton = colors ? ArtistButton : Button;
+
+  const defaultTrigger = (
+    <LocalButton
+      size={compact ? "compact" : undefined}
+      variant={dashed ? "dashed" : "transparent"}
+      className={`${css`
+        ${!triggerClassName
+          ? `
+          background: transparent !important;
+
+          &:hover {
+            background: transparent !important;
+          }
+        `
+          : ""}
+
+        @media screen and (max-width: ${bp.medium}px) {
+          ${smallIcon ? "width: 2rem !important; height: 2rem !important;" : ""}
+          svg {
+            ${smallIcon ? "width: .3rem !important; margin-left:1rem;" : ""}
+          }
+        }
+      `}${triggerClassName ? ` ${triggerClassName}` : ""}`}
+      startIcon={icon ?? <FaEllipsisV />}
+    />
+  );
+
+  const renderedTrigger = trigger ?? defaultTrigger;
+
+  const openMenu = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    const rect = e.currentTarget.getBoundingClientRect();
+    const openRightward = rect.left < window.innerWidth / 2;
+    const openUpward = rect.top > window.innerHeight / 2;
+    setButtonPosition({
+      x: openRightward ? rect.left : rect.right,
+      y: rect.top,
+      openUpward,
+      openRightward,
+    });
+    setIsMenuOpen(true);
+  };
+
+  const triggerElement = React.cloneElement(renderedTrigger, {
+    "aria-label": renderedTrigger.props["aria-label"] ?? label,
+    "aria-haspopup": "menu",
+    "aria-expanded": isMenuOpen,
+    onClick: (e: React.MouseEvent<HTMLElement>) => {
+      renderedTrigger.props.onClick?.(e);
+      if (e.defaultPrevented) {
+        return;
+      }
+      openMenu(e);
+    },
+  });
 
   return (
     <div
@@ -132,46 +184,7 @@ const DropdownMenu: React.FC<{
           document.body
         )}
 
-      <LocalButton
-        size={compact ? "compact" : undefined}
-        variant={dashed ? "dashed" : "transparent"}
-        aria-label={label}
-        role="menu"
-        className={`${css`
-          ${!triggerClassName
-            ? `
-            background: transparent !important;
-
-            &:hover {
-              background: transparent !important;
-            }
-          `
-            : ""}
-
-          @media screen and (max-width: ${bp.medium}px) {
-            ${smallIcon
-              ? "width: 2rem !important; height: 2rem !important;"
-              : ""}
-            svg {
-              ${smallIcon ? "width: .3rem !important; margin-left:1rem;" : ""}
-            }
-          }
-        `}${triggerClassName ? ` ${triggerClassName}` : ""}`}
-        onClick={(e) => {
-          e.stopPropagation();
-          const rect = e.currentTarget.getBoundingClientRect();
-          const openRightward = rect.left < window.innerWidth / 2;
-          const openUpward = rect.top > window.innerHeight / 2;
-          setButtonPosition({
-            x: openRightward ? rect.left : rect.right,
-            y: rect.top,
-            openUpward,
-            openRightward,
-          });
-          setIsMenuOpen(true);
-        }}
-        startIcon={icon}
-      />
+      {triggerElement}
     </div>
   );
 };

--- a/client/src/components/common/DropdownMenu.tsx
+++ b/client/src/components/common/DropdownMenu.tsx
@@ -12,6 +12,12 @@ import { bp } from "../../constants";
 
 import Button from "./Button";
 
+const DropdownMenuContext = React.createContext<{ close: () => void } | null>(
+  null
+);
+
+export const useDropdownMenu = () => React.useContext(DropdownMenuContext);
+
 const DropdownMenu: React.FC<{
   children: React.ReactElement | React.ReactElement[];
   dashed?: boolean;
@@ -39,6 +45,15 @@ const DropdownMenu: React.FC<{
   }>({ x: 0, y: 0, openUpward: false, openRightward: false });
 
   const [isMenuOpen, setIsMenuOpen] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    if (!isMenuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsMenuOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isMenuOpen]);
 
   const colors = useGetArtistColors();
   const LocalButton = colors ? ArtistButton : Button;
@@ -128,7 +143,7 @@ const DropdownMenu: React.FC<{
                   ? "none"
                   : "translateX(-100%)"};
                 border-radius: var(--mi-border-radius);
-                padding: 0.5rem;
+                padding: 0;
                 z-index: 999;
                 overflow: hidden;
                 min-width: 215px;
@@ -145,19 +160,19 @@ const DropdownMenu: React.FC<{
                 }
 
                 li > * {
-                  min-width: 200px;
+                  width: 100%;
+                  min-width: 0;
                   list-style-type: none;
                   text-decoration: none;
                   text-align: right;
-                  display: block;
                   white-space: normal;
                   color: var(--mi-text-color) !important;
                   background-color: var(--mi-background-color) !important;
                   word-break: break-word;
                   font-weight: normal;
                   border-radius: 0;
-                  padding: 0.5rem;
-                  margin: 0rem;
+                  padding: 0.5rem 0.75rem;
+                  margin: 0;
 
                   display: flex;
                   align-items: center;
@@ -174,11 +189,75 @@ const DropdownMenu: React.FC<{
                     border: none;
                   }
                 }
+
+                @media screen and (max-width: ${bp.medium}px) {
+                  top: 50% !important;
+                  bottom: auto !important;
+                  left: 50% !important;
+                  right: auto !important;
+                  transform: translate(-50%, -50%) !important;
+                  min-width: 0;
+                  max-width: none;
+                  width: min(90vw, 360px);
+                  border-radius: var(--mi-border-radius-x);
+                  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+
+                  ul {
+                    display: grid;
+                    grid-template-columns: auto auto;
+                    justify-content: center;
+                    column-gap: 0.75rem;
+                    padding: 0;
+                    margin: 0;
+                  }
+
+                  li {
+                    display: grid;
+                    grid-template-columns: subgrid;
+                    grid-column: 1 / -1;
+                    align-items: center;
+                    padding: 0.875rem 1rem;
+                    font-size: 0.875rem;
+                  }
+
+                  li + li {
+                    border-top: 1px solid var(--mi-darken-color);
+                  }
+
+                  li > * {
+                    display: contents !important;
+                  }
+
+                  li .startIcon {
+                    justify-self: end;
+                    grid-column: 1;
+                  }
+
+                  li .children {
+                    justify-self: start;
+                    grid-column: 2;
+                    text-align: left;
+                  }
+
+                  li:hover {
+                    background: var(--mi-text-color) !important;
+                    color: var(--mi-background-color) !important;
+                  }
+
+                  li svg {
+                    width: 1rem;
+                    height: 1rem;
+                  }
+                }
               `}
             >
-              {React.Children.map(children, (child) =>
-                React.cloneElement(child, { setIsMenuOpen })
-              )}
+              <DropdownMenuContext.Provider
+                value={{ close: () => setIsMenuOpen(false) }}
+              >
+                {React.Children.map(children, (child) =>
+                  React.cloneElement(child, { setIsMenuOpen })
+                )}
+              </DropdownMenuContext.Provider>
             </div>
           </>,
           document.body

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -249,7 +249,13 @@
   },
   "wishlist": {
     "addToWishlist": "Add to wishlist",
-    "removeFromWishlist": "Remove from wishlist"
+    "removeFromWishlist": "Remove from wishlist",
+    "openWishlistMenu": "Add to wishlist",
+    "openWishlistMenuActive": "Wishlist options",
+    "wishlistThisTrack": "Wishlist this track",
+    "removeTrackFromWishlist": "Remove this track from wishlist",
+    "wishlistThisAlbum": "Wishlist this album",
+    "removeAlbumFromWishlist": "Remove this album from wishlist"
   },
   "trackGroupCard": {
     "publishedAt": "Publish date:",
@@ -685,7 +691,9 @@
     "shuffleMusic": "Shuffle music",
     "volumeControl": "Volume control",
     "muteVolume": "Mute volume",
-    "nowPlayingAnnouncement": "Now playing: {{title}} by {{artist}}"
+    "nowPlayingAnnouncement": "Now playing: {{title}} by {{artist}}",
+    "buyThisTrack": "Buy this track",
+    "buyThisAlbum": "Buy this album"
   },
   "post": {
     "postByArtist": "by <link></link>",

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -154,7 +154,7 @@ interface TrackGroup {
   makeTracksPreviewableOnRelease: boolean;
   isPublic: boolean;
   hasNotifiedFollowers?: boolean;
-  tracksCount?: number;
+  totalTracks?: number;
 }
 
 interface Post {

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -154,6 +154,7 @@ interface TrackGroup {
   makeTracksPreviewableOnRelease: boolean;
   isPublic: boolean;
   hasNotifiedFollowers?: boolean;
+  tracksCount?: number;
 }
 
 interface Post {

--- a/src/routers/v1/tracks/{id}/index.ts
+++ b/src/routers/v1/tracks/{id}/index.ts
@@ -19,6 +19,9 @@ export default function () {
         include: {
           trackGroup: {
             include: {
+              _count: {
+                select: { tracks: true },
+              },
               artist: {
                 include: {
                   avatar: true,

--- a/src/utils/serialize/trackGroup.ts
+++ b/src/utils/serialize/trackGroup.ts
@@ -30,13 +30,16 @@ export const processSingleTrackGroup = (
       downloadableContentId: string;
     }[];
     trackGroupPurchases?: { userId: number }[];
+    _count?: { tracks?: number; userTrackGroupPurchases?: number };
   },
   options?: { loggedInUserId?: number }
 ) => {
+  const { _count, ...rest } = tg;
   const currency =
     tg.paymentToUser?.currency ?? tg.artist?.user?.currency ?? "usd";
   return {
-    ...tg,
+    ...rest,
+    tracksCount: _count?.tracks ?? tg.tracks?.length,
     currency,
     hasNotifiedFollowers: tg.notifiedFollowersAt !== null,
     tracks: tg.tracks?.map((track) => ({

--- a/src/utils/serialize/trackGroup.ts
+++ b/src/utils/serialize/trackGroup.ts
@@ -39,7 +39,7 @@ export const processSingleTrackGroup = (
     tg.paymentToUser?.currency ?? tg.artist?.user?.currency ?? "usd";
   return {
     ...rest,
-    tracksCount: _count?.tracks ?? tg.tracks?.length,
+    totalTracks: _count?.tracks ?? tg.tracks?.length,
     currency,
     hasNotifiedFollowers: tg.notifiedFollowersAt !== null,
     tracks: tg.tracks?.map((track) => ({


### PR DESCRIPTION
Because the player buttons were made before we added the capacity to wishlist or buy single tracks, if was, often counter intuitively, only possible to wishlist or buy albums through the player buttons, when if you're listening to a lot of things, tracks might be a more immediate candidate in a lot cases (reaching trackcount limit, preparing some favorite tracks, etc.).

I also made the dropdown more accessible on mobile, centered with bigger icons, up until now it could be pretty finnicky to use on smartphones, this makes it much more usable.