### PR TITLE
fix: tie trackgroup cover and font size to viewport

### DIFF
--- a/client/src/components/Merch/MerchView.tsx
+++ b/client/src/components/Merch/MerchView.tsx
@@ -10,6 +10,8 @@ import SupportArtistPopUp from "components/common/SupportArtistPopUp";
 import PublicTrackGroupListing from "components/common/TrackList/PublicTrackGroupListing";
 import WidthContainer from "components/common/WidthContainer";
 import {
+  coverSizeMax,
+  coverSizeMin,
   ImageAndDetailsWrapper,
   ImageWrapper,
 } from "components/TrackGroup/TrackGroup";
@@ -73,6 +75,12 @@ function MerchView() {
       />
       <div
         className={css`
+          --cover-size: clamp(
+            ${coverSizeMin},
+            min(45vw, calc(100dvh - 320px)),
+            ${coverSizeMax}
+          );
+
           width: 100%;
           align-items: center;
 

--- a/client/src/components/TrackGroup/ArtistByLine.tsx
+++ b/client/src/components/TrackGroup/ArtistByLine.tsx
@@ -3,6 +3,8 @@ import { ArtistButtonLink } from "components/Artist/ArtistButtons";
 import { Trans, useTranslation } from "react-i18next";
 import { getArtistUrl, getReleaseUrl } from "utils/artist";
 
+import { coverSizeMax } from "./TrackGroup";
+
 const inlineLink = css`
   display: inline !important;
   white-space: normal !important;
@@ -27,7 +29,11 @@ const ArtistByLine: React.FC<{
   return (
     <div
       className={css`
-        font-size: 18px;
+        font-size: clamp(
+          0.875rem,
+          calc(var(--cover-size, ${coverSizeMax}) / 28),
+          1.125rem
+        );
         font-style: normal;
       `}
     >

--- a/client/src/components/TrackGroup/ItemViewTitle.tsx
+++ b/client/src/components/TrackGroup/ItemViewTitle.tsx
@@ -9,10 +9,11 @@ import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import { useAuthContext } from "state/AuthContext";
 
-import { bp } from "../../constants";
+import { between, bp } from "../../constants";
 import ClickToPlayTracks from "../common/ClickToPlayTracks";
 
 import ArtistByLine from "./ArtistByLine";
+import { coverSizeMax } from "./TrackGroup";
 import TrackGroupAdminMenu from "./TrackGroupAdminMenu";
 
 export const ItemViewTitle: React.FC<{
@@ -29,6 +30,11 @@ export const ItemViewTitle: React.FC<{
         align-items: center;
         justify-content: flex-start;
         max-width: 80%;
+
+        @media screen and ${between(bp.medium, bp.xlarge)} {
+          margin-top: 0.25rem;
+          margin-bottom: 0.25rem;
+        }
       `}
     >
       {showPlayButton && (
@@ -51,8 +57,13 @@ export const ItemViewTitle: React.FC<{
       <div>
         <h1
           className={css`
-            font-size: 2rem;
-            line-height: 2.2rem;
+            font-size: clamp(
+              1.25rem,
+              calc(var(--cover-size, ${coverSizeMax}) / 14),
+              2rem
+            );
+            line-height: 1.1;
+            margin: 0;
           `}
         >
           {title}

--- a/client/src/components/TrackGroup/ReleaseDate.tsx
+++ b/client/src/components/TrackGroup/ReleaseDate.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import { bp } from "../../constants";
+
 export const formatDate = ({
   date,
   options: defaultOptions,
@@ -88,13 +89,12 @@ const ReleaseDate: React.FC<{ releaseDate?: string }> = ({
     <div
       className={css`
         color: var(--mi-secondary-text-color);
-        font-size: 1rem;
         width: 100%;
         font-size: var(--mi-font-size-small);
         filter: opacity(80%);
 
-        @media screen and (max-width: ${bp.medium}px) {
-          font-size: var(--mi-font-size-small);
+        @media screen and (max-width: ${bp.xlarge}px) {
+          font-size: var(--mi-font-size-xsmall);
         }
       `}
     >

--- a/client/src/components/TrackGroup/TrackGroup.tsx
+++ b/client/src/components/TrackGroup/TrackGroup.tsx
@@ -11,10 +11,10 @@ import WidthContainer from "components/common/WidthContainer";
 import { queryArtist, queryTrackGroup } from "queries";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
-import { useAuthContext } from "state/AuthContext";
 import { isTrackGroupPublished } from "utils/artist";
+import { useMatchMedia } from "utils/useMatchMedia";
 
-import { bp } from "../../constants";
+import { between, bp } from "../../constants";
 import Box, { ArtistBox } from "../common/Box";
 import ClickToPlayTracks from "../common/ClickToPlayTracks";
 
@@ -30,23 +30,21 @@ import TrackGroupMerch from "./TrackGroupMerch";
 import TrackGroupPills from "./TrackGroupPills";
 import Wishlist from "./Wishlist";
 
-export const Container = styled.div<{ user?: LoggedInUser | null }>`
-  ${(props) =>
-    props.user!
-      ? `
-    min-height: calc(100vh - 70px);
-    margin-top: 0vh;`
-      : `
-    min-height: calc(100vh - 130px);
-    margin-top: 1rem;`}
+export const coverSizeMin = "280px";
+export const coverSizeMax = "470px";
+
+export const Container = styled.div`
+  --cover-size: clamp(
+    ${coverSizeMin},
+    min(45vw, calc(100dvh - 270px)),
+    ${coverSizeMax}
+  );
+  --content-width: calc(var(--cover-size) * 2.3 + 0.5rem);
+
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   width: 100%;
   padding: var(--mi-side-paddings-xsmall);
-
-  @media screen and (max-width: ${bp.small}px) {
-    margin-top: 0rem;
-  }
 `;
 
 export const ImageWrapper = styled.div`
@@ -64,7 +62,20 @@ export const UnderneathImage = styled.div`
 
   @media screen and (max-width: ${bp.medium}px) {
     margin-top: 0.25rem;
-    flex-wrap: wrap;
+  }
+
+  @media screen and ${between(bp.medium, bp.xlarge)} {
+    --mi-touch-target-min: 24px;
+
+    button {
+      height: 2rem;
+      padding: 0.3rem 0.6rem;
+      font-size: 0.85rem;
+    }
+    button svg {
+      width: 0.9rem;
+      height: 0.9rem;
+    }
   }
 `;
 
@@ -75,18 +86,36 @@ export const SmallScreenPlayWrapper = styled.div`
   }
 `;
 
-export const ImageAndDetailsWrapper = styled.div`
-  display: flex;
-  flex: 45%;
-  max-width: 45%;
-  flex-direction: column;
+export const ItemViewContentWrapper = styled.div`
+  width: 100%;
+  max-width: var(--content-width);
+  margin: 0 auto;
+
+  td {
+    padding: 0rem 0.4rem 0rem 0rem;
+    margin: 0.1rem 0rem;
+  }
+
+  a {
+    color: var(--mi-button-color);
+  }
 
   @media screen and (max-width: ${bp.small}px) {
-    flex: 100%;
     max-width: 100%;
+
+    td {
+      padding: 0.2rem 0.1rem 0.2rem 0rem;
+    }
+  }
+`;
+
+export const ImageAndDetailsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: var(--cover-size);
+
+  @media screen and (max-width: ${bp.small}px) {
     width: 100%;
-    min-width: 100%;
-    flex-direction: column;
   }
 `;
 
@@ -158,14 +187,12 @@ export const TrackgroupInfosWrapper = styled.div`
 `;
 
 export const TrackListingWrapper = styled.div`
-  max-width: 59%;
-  flex: 59%;
-  margin: 0 0 0 0.5rem;
+  width: calc(var(--cover-size) * 1.3);
+  min-width: 0;
+  font-size: clamp(0.8125rem, calc(var(--cover-size) / 30), 1rem);
 
   @media screen and (max-width: ${bp.small}px) {
-    max-width: 100%;
-    flex: 100%;
-    margin-left: 0;
+    width: 100%;
   }
 `;
 
@@ -173,13 +200,12 @@ function TrackGroup() {
   const { t } = useTranslation("translation", {
     keyPrefix: "trackGroupDetails",
   });
+  const isCompactLayout = useMatchMedia(between(bp.medium, bp.xlarge));
 
   const { artistId, trackGroupId } = useParams();
   const { data: artist, isPending: isLoadingArtist } = useQuery(
     queryArtist({ artistSlug: artistId ?? "" })
   );
-
-  const { user } = useAuthContext();
 
   const { data: trackGroup, isPending: isLoadingTrackGroup } = useQuery(
     queryTrackGroup({ albumSlug: trackGroupId ?? "", artistId: artistId ?? "" })
@@ -211,28 +237,8 @@ function TrackGroup() {
         description={`An album by ${trackGroup.artist?.name ?? "an artist"} on Mirlo`}
         image={trackGroup.cover?.sizes?.[600]}
       />
-      <Container user={user}>
-        <div
-          className={css`
-            width: 100%;
-            align-items: center;
-
-            td {
-              padding: 0rem 0.4rem 0rem 0rem;
-              margin: 0.1rem 0rem;
-            }
-
-            a {
-              color: var(--mi-button-color);
-            }
-
-            @media screen and (max-width: ${bp.small}px) {
-              td {
-                padding: 0.2rem 0.1rem 0.2rem 0rem;
-              }
-            }
-          `}
-        >
+      <Container>
+        <ItemViewContentWrapper>
           {!isPublished && (
             <div
               className={css`
@@ -264,11 +270,14 @@ function TrackGroup() {
             <div
               className={css`
                 display: flex;
-                justify-content: space-between;
+                justify-content: center;
+                align-items: flex-start;
                 flex-wrap: nowrap;
+                gap: 0.5rem;
 
                 @media screen and (max-width: ${bp.small}px) {
                   flex-direction: column;
+                  gap: 0;
                 }
               `}
             >
@@ -323,6 +332,9 @@ function TrackGroup() {
                   <PublicTrackGroupListing
                     tracks={trackGroup.tracks}
                     trackGroup={trackGroup}
+                    fluidText
+                    size={isCompactLayout ? "compact" : undefined}
+                    keepDropdownInCompact
                   />
                   {trackGroup.isGettable && (
                     <p
@@ -413,7 +425,7 @@ function TrackGroup() {
             <SupportArtistPopUp artist={trackGroup.artist} />
           )}
           <FlagContent trackGroupId={trackGroup.id} />
-        </div>
+        </ItemViewContentWrapper>
       </Container>
     </WidthContainer>
   );

--- a/client/src/components/TrackGroup/TrackView.tsx
+++ b/client/src/components/TrackGroup/TrackView.tsx
@@ -9,7 +9,6 @@ import WidthContainer from "components/common/WidthContainer";
 import { queryArtist, queryTrackGroup } from "queries";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
-import { useAuthContext } from "state/AuthContext";
 import { getReleaseUrl } from "utils/artist";
 
 import { bp } from "../../constants";
@@ -23,6 +22,7 @@ import {
   Container,
   ImageAndDetailsWrapper,
   ImageWrapper,
+  ItemViewContentWrapper,
   SmallScreenPlayWrapper,
   TrackListingWrapper,
   UnderneathImage,
@@ -39,8 +39,6 @@ function TrackView() {
   const { data: artist, isLoading: isLoadingArtist } = useQuery(
     queryArtist({ artistSlug: artistId ?? "" })
   );
-  const { user } = useAuthContext();
-
   const { data: trackGroup, isLoading: isLoadingTrackGroup } = useQuery(
     queryTrackGroup({ albumSlug: trackGroupId ?? "", artistId: artistId ?? "" })
   );
@@ -71,28 +69,8 @@ function TrackView() {
         description={`A track by ${trackGroup.artist?.name ?? "an artist"} on Mirlo`}
         image={trackGroup.cover?.sizes?.[600]}
       />
-      <Container user={user}>
-        <div
-          className={css`
-            width: 100%;
-            align-items: center;
-
-            td {
-              padding: 0rem 0.4rem 0rem 0rem;
-              margin: 0.1rem 0rem;
-            }
-
-            a {
-              color: var(--mi-button-color);
-            }
-
-            @media screen and (max-width: ${bp.small}px) {
-              td {
-                padding: 0.2rem 0.1rem 0.2rem 0rem;
-              }
-            }
-          `}
-        >
+      <Container>
+        <ItemViewContentWrapper>
           <div
             className={css`
               display: flex;
@@ -112,11 +90,14 @@ function TrackView() {
             <div
               className={css`
                 display: flex;
-                justify-content: space-between;
+                justify-content: center;
+                align-items: flex-start;
                 flex-wrap: nowrap;
+                gap: 0.5rem;
 
                 @media screen and (max-width: ${bp.small}px) {
                   flex-direction: column;
+                  gap: 0;
                 }
               `}
             >
@@ -166,6 +147,7 @@ function TrackView() {
                   <PublicTrackGroupListing
                     tracks={[filteredTrack]}
                     trackGroup={trackGroup}
+                    fluidText
                   />
                 </TrackListingWrapper>
                 {filteredTrack.description && (
@@ -216,7 +198,7 @@ function TrackView() {
               <SupportArtistPopUp artist={trackGroup.artist} />
             )}
           </div>
-        </div>
+        </ItemViewContentWrapper>
       </Container>
     </WidthContainer>
   );

--- a/client/src/components/common/TrackList/PublicTrackGroupListing.tsx
+++ b/client/src/components/common/TrackList/PublicTrackGroupListing.tsx
@@ -14,7 +14,17 @@ export const PublicTrackGroupListing: React.FC<{
   size?: "small" | "compact";
   showDropdown?: boolean;
   inWidget?: boolean;
-}> = ({ tracks, trackGroup, size, showDropdown = true, inWidget }) => {
+  fluidText?: boolean;
+  keepDropdownInCompact?: boolean;
+}> = ({
+  tracks,
+  trackGroup,
+  size,
+  showDropdown = true,
+  inWidget,
+  fluidText,
+  keepDropdownInCompact,
+}) => {
   const { user } = useAuthContext();
   const [isLoading, setIsLoading] = React.useState(true);
   const { dispatch } = useGlobalStateContext();
@@ -61,6 +71,8 @@ export const PublicTrackGroupListing: React.FC<{
           trackGroup={track.trackGroup ?? trackGroup}
           size={size}
           inWidget={inWidget}
+          fluidText={fluidText}
+          keepDropdownInCompact={keepDropdownInCompact}
         />
       ))}
     </ul>

--- a/client/src/components/common/TrackList/TrackRow.tsx
+++ b/client/src/components/common/TrackList/TrackRow.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/css";
 import styled from "@emotion/styled";
 import DownloadAlbumButton from "components/common/DownloadAlbumButton";
 import { PlayingMusicBars } from "components/common/PlayingMusicBars";
@@ -26,6 +27,18 @@ import TrackAuthors from "./TrackAuthors";
 import TrackRowPlayControl from "./TrackRowPlayControl";
 
 type Variant = "default" | "compact" | "widget" | "dock";
+
+const compactDropdownTrigger = css`
+  width: 1.5rem !important;
+  height: 1.5rem !important;
+  min-width: 0 !important;
+  min-height: 0 !important;
+  padding: 0 !important;
+  svg {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+`;
 
 const LI = styled.li<{
   canPlayTrack: boolean;
@@ -121,7 +134,8 @@ const TrackDropdown: React.FC<{
   track: Track;
   trackGroup: TrackGroup;
   user: LoggedInUser | null | undefined;
-}> = ({ track, trackGroup, user }) => {
+  compact?: boolean;
+}> = ({ track, trackGroup, user, compact }) => {
   const ownsTrack = !!user?.userTrackPurchases?.find(
     (p) => p.trackId === track.id
   );
@@ -134,7 +148,12 @@ const TrackDropdown: React.FC<{
   const showLicense = track.license && track.license.short !== "copyright";
 
   return (
-    <DropdownMenu smallIcon compact label="Track options">
+    <DropdownMenu
+      smallIcon
+      compact
+      label="Track options"
+      triggerClassName={compact ? compactDropdownTrigger : undefined}
+    >
       <ul>
         <li>
           <GoToTrack
@@ -187,6 +206,8 @@ const TrackRow: React.FC<{
   addTracksToQueue: (id: number) => void;
   size?: "small" | "compact" | "dock";
   inWidget?: boolean;
+  fluidText?: boolean;
+  keepDropdownInCompact?: boolean;
 }> = ({
   track,
   addTracksToQueue,
@@ -194,6 +215,8 @@ const TrackRow: React.FC<{
   size,
   showDropdown,
   inWidget,
+  fluidText,
+  keepDropdownInCompact,
 }) => {
   const { t } = useTranslation("translation", {
     keyPrefix: "trackGroupDetails",
@@ -208,7 +231,10 @@ const TrackRow: React.FC<{
   const embeddedInMirlo = isEmbeddedInMirlo();
   const sendPlayerRequest = usePlayerSyncRequest();
   const showDropdownCell =
-    size !== "small" && size !== "compact" && size !== "dock" && showDropdown;
+    size !== "small" &&
+    size !== "dock" &&
+    showDropdown &&
+    (size !== "compact" || keepDropdownInCompact);
   const isCompact = size === "compact";
   const isDock = size === "dock";
   const variant: Variant = inWidget
@@ -223,6 +249,24 @@ const TrackRow: React.FC<{
       ? playerQueueIds[currentlyPlayingIndex]
       : undefined;
   const isThisTrackPlaying = playing && currentPlayingTrackId === track.id;
+
+  const titleSizeClass = fluidText
+    ? ""
+    : inWidget
+      ? "whitespace-nowrap break-normal min-w-0 text-xs"
+      : isCompact
+        ? "text-sm"
+        : "max-md:text-sm";
+
+  const durationSizeClass = fluidText
+    ? "text-[0.875em] max-md:font-bold"
+    : inWidget
+      ? "text-xs"
+      : isDock
+        ? "text-xs max-md:text-sm"
+        : isCompact
+          ? "text-sm"
+          : "text-sm max-md:text-xs max-md:font-bold";
 
   const onTrackPlay = React.useCallback(() => {
     if (!canPlayTrack) return;
@@ -315,13 +359,7 @@ const TrackRow: React.FC<{
           </div>
         ) : (
           <div
-            className={`overflow-hidden text-ellipsis grow [&_i]:opacity-80 ${
-              inWidget
-                ? "whitespace-nowrap break-normal min-w-0 text-xs"
-                : isCompact
-                  ? "text-sm"
-                  : "max-md:text-sm"
-            }`}
+            className={`overflow-hidden text-ellipsis grow [&_i]:opacity-80 ${titleSizeClass}`}
           >
             {track.title ?? <i>{t("untitled")}</i>}
             <TrackAuthors
@@ -331,23 +369,18 @@ const TrackRow: React.FC<{
           </div>
         )}
 
-        <div
-          className={`shrink-0 ${
-            inWidget
-              ? "text-xs"
-              : isDock
-                ? "text-xs max-md:text-sm"
-                : isCompact
-                  ? "text-sm"
-                  : "text-sm max-md:text-xs max-md:font-bold"
-          }`}
-        >
+        <div className={`shrink-0 ${durationSizeClass}`}>
           {track.audio?.duration && fmtMSS(track.audio.duration)}
         </div>
       </div>
 
       {showDropdownCell && (
-        <TrackDropdown track={track} trackGroup={trackGroup} user={user} />
+        <TrackDropdown
+          track={track}
+          trackGroup={trackGroup}
+          user={user}
+          compact={isCompact}
+        />
       )}
     </LI>
   );

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -4,6 +4,9 @@ export const bp = {
   small: "576",
   medium: "768",
   large: "992",
-  xlarge: "1200",
+  xlarge: "1280",
   xxlarge: "1400",
 };
+
+export const between = (min: string, max: string) =>
+  `(min-width: ${Number(min) + 1}px) and (max-width: ${max}px)`;

--- a/client/src/utils/useMatchMedia.ts
+++ b/client/src/utils/useMatchMedia.ts
@@ -1,0 +1,17 @@
+import React from "react";
+
+export function useMatchMedia(query: string): boolean {
+  const [matches, setMatches] = React.useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia(query).matches
+  );
+
+  React.useEffect(() => {
+    const mq = window.matchMedia(query);
+    const handler = () => setMatches(mq.matches);
+    handler();
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
This became a priority when I started testing Mirlo on smaller / older FHD laptops (on Windows), where the whole layout would be swallowed by the height of the album cover on trackgroup pages which couldn't even be fully displayed. Mostly this is a rework of something I *thought* I'd already done a couple years ago. I've also been working on a similarly more scalable / responsive system for the artist pages.

This shouldn't change anything on most big screen monitor layouts, or OS/Browsers that render pages without any scaling.