### PR TITLE
fix(client): wrap artist About empty state without overflowing modal

### DIFF
--- a/client/src/components/Artist/ArtistHeaderDescription.tsx
+++ b/client/src/components/Artist/ArtistHeaderDescription.tsx
@@ -97,16 +97,17 @@ const ArtistHeaderDescription: React.FC<ArtistHeaderDescriptionProps> = ({
               </div>
             ) : (
               isManage && (
-                <ArtistButton
-                  wrap
-                  size="compact"
-                  variant="dashed"
-                  onClick={() => setIsEditing(true)}
-                  startIcon={<FaPen />}
-                  className="max-w-full"
-                >
-                  {t("noBioYet")}
-                </ArtistButton>
+                <div className="flex flex-col items-start gap-2">
+                  <ArtistButton
+                    size="compact"
+                    variant="dashed"
+                    onClick={() => setIsEditing(true)}
+                    startIcon={<FaPen />}
+                  >
+                    {t("editBioButton")}
+                  </ArtistButton>
+                  <p>{t("noBioYet")}</p>
+                </div>
               )
             )}
           </div>


### PR DESCRIPTION
Fixes #1481.

The empty-bio CTA renders the long `noBioYet` string as the button label, which overflows the modal in translated locales.

Following the design @simonv3 sketched in the issue, the empty state now shows a compact "Edit bio" button with the descriptive text underneath. Both i18n keys already exist in `artist.*` — no new translations.