### PR TITLE
fix: stripe mock pin to prevent test fail

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 services:
   stripe-test:
     container_name: blackbird-stripe-mock-test
-    image: stripe/stripe-mock
+    image: stripe/stripe-mock:v0.199.0
     networks: !reset [test-network]
     ports: !reset []
     profiles: [test]


### PR DESCRIPTION
Looks like the new stripe mock introduced something causing our tests to fail. This pins our docker image accordingly. 

https://github.com/stripe/stripe-mock/issues/1636