### PR TITLE
Blog layout overhaul

### DIFF
--- a/client/src/components/Artist/ArtistShare.tsx
+++ b/client/src/components/Artist/ArtistShare.tsx
@@ -1,9 +1,5 @@
-import { ArtistButton } from "components/Artist/ArtistButtons";
-import Modal from "components/common/Modal";
-import ShareToSocials from "components/common/ShareToSocials";
-import React from "react";
+import ShareButton from "components/common/ShareButton";
 import { useTranslation } from "react-i18next";
-import { BsShare } from "react-icons/bs";
 import { getArtistUrl } from "utils/artist";
 
 const ArtistShare: React.FC<{
@@ -12,56 +8,19 @@ const ArtistShare: React.FC<{
   size?: "compact" | "big" | "tiny";
 }> = ({ artist, buttonClassName, size }) => {
   const { t } = useTranslation("translation", { keyPrefix: "share" });
-  const [isOpen, setIsOpen] = React.useState(false);
 
   if (!artist) return null;
 
   const artistUrl = `${import.meta.env.VITE_CLIENT_DOMAIN}${getArtistUrl(artist)}`;
 
-  const handleShareClick = async () => {
-    const shareData = { title: artist.name, url: artistUrl };
-    const isTouchPrimary =
-      typeof window !== "undefined" &&
-      window.matchMedia("(pointer: coarse)").matches;
-    const canNativeShare =
-      typeof navigator !== "undefined" &&
-      typeof navigator.share === "function" &&
-      (typeof navigator.canShare !== "function" ||
-        navigator.canShare(shareData));
-
-    if (isTouchPrimary && canNativeShare) {
-      try {
-        await navigator.share(shareData);
-      } catch {}
-      return;
-    }
-    setIsOpen(true);
-  };
-
   return (
-    <>
-      <ArtistButton
-        onlyIcon
-        aria-label={t("share") ?? ""}
-        title={t("share") ?? ""}
-        onClick={handleShareClick}
-        startIcon={<BsShare />}
-        size={size}
-        className={buttonClassName}
-      />
-      <Modal
-        size="small"
-        title={t("shareArtist", { artistName: artist.name }) ?? ""}
-        open={isOpen}
-        onClose={() => setIsOpen(false)}
-      >
-        <ShareToSocials
-          url={artistUrl}
-          title={artist.name}
-          socials={["mastodon", "bluesky", "email"]}
-        />
-      </Modal>
-    </>
+    <ShareButton
+      title={artist.name}
+      url={artistUrl}
+      modalTitle={t("shareArtist", { artistName: artist.name }) ?? ""}
+      buttonClassName={buttonClassName}
+      size={size}
+    />
   );
 };
 

--- a/client/src/components/Post/PostCard.tsx
+++ b/client/src/components/Post/PostCard.tsx
@@ -1,115 +1,24 @@
 import { css } from "@emotion/css";
-import styled from "@emotion/styled";
-import { ArtistButtonLink } from "components/Artist/ArtistButtons";
-import Box from "components/common/Box";
 import { formatDate } from "components/TrackGroup/ReleaseDate";
-import { sample } from "lodash";
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { FaPlay } from "react-icons/fa";
 import { Link, useParams } from "react-router-dom";
 import { getArtistUrl, getPostURLReference } from "utils/artist";
 import { useLinkContainer } from "utils/useLinkContainer";
 
-import { bp } from "../../constants";
-
-const HalfTone: React.FC<{ color1?: string; color2?: string }> = ({
-  color1,
-  color2,
-}) => {
-  return (
-    <div
-      className={css`
-        --mask: linear-gradient(rgb(0 0 0), rgb(0 0 0 / 0.5));
-        --stop1: 3%;
-        --stop2: 90%;
-
-        aspect-ratio: 1;
-        position: relative;
-        background: ${color1 || "var(--mi-white)"};
-        filter: contrast(50);
-
-        &:after {
-          content: "";
-          position: absolute;
-          inset: 0;
-
-          background-repeat: round;
-          mask-image: var(--mask);
-
-          --bgSize: ${sample([".7rem", ".5rem"])};
-          --bgPosition: calc(var(--bgSize) / 2);
-          --stop1: 3%;
-          --stop2: 65%;
-
-          background-image:
-            radial-gradient(
-              circle at center,
-              ${color2 || "var(--mi-button-color)"} var(--stop1),
-              transparent var(--stop2)
-            ),
-            radial-gradient(
-              circle at center,
-              ${color2 || "var(--mi-button-color)"} var(--stop1),
-              transparent var(--stop2)
-            );
-          background-size: var(--bgSize) var(--bgSize);
-          background-position:
-            0 0,
-            var(--bgPosition) var(--bgPosition);
-        }
-      `}
-    ></div>
-  );
-};
-
-const PostContainer = styled.li<{
-  isOnArtistPage?: boolean;
-}>`
+const cardStyle = css`
   display: flex;
-  border-radius: 5px;
-  border: var(--mi-border);
-  background-color: var(--mi-background-color);
+  flex-direction: column;
   position: relative;
+  min-width: 0;
   width: 100%;
+  min-height: 180px;
+  max-height: 360px;
+  overflow: hidden;
   cursor: pointer;
-
-  .post-container__link {
-    text-decoration: none;
-    overflow: hidden;
-    display: inline-block;
-    text-align: left;
-    width: 100%;
-    font-weight: normal;
-    justify-content: flex-start;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-
-    .children {
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-  }
-
-  &::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: 5px;
-    z-index: 1;
-    background: var(--mi-button-tint-color);
-    transition: 0.2s background;
-    pointer-events: none;
-  }
-
-  &:hover::after {
-    background: var(--mi-button-tint-x-color);
-  }
-
-  &:hover {
-    .post-container__link {
-      text-decoration: underline;
-    }
-  }
+  background: var(--mi-button-tint-color);
+  border: 1px solid var(--mi-tint-color);
 
   &:focus-within {
     outline: 1px solid var(--mi-text-color);
@@ -124,140 +33,62 @@ const PostCard: React.FC<{
   const { t, i18n } = useTranslation("translation", { keyPrefix: "post" });
 
   const { artistId } = useParams();
-
   const isOnArtistPage = !!artistId;
 
-  const LinkToUse = isOnArtistPage ? ArtistButtonLink : Link;
+  const featuredImageSrc = post.featuredImage?.src;
+  const excerpt = post.content?.replace(/<[^>]*>/g, "").trim();
+  const trackCount = post.trackCount ?? post.tracks?.length ?? 0;
+  const hasTracks = trackCount > 0;
 
   return (
-    <PostContainer isOnArtistPage={isOnArtistPage} {...postContainerProps}>
-      <Box
-        noPadding
-        className={css`
-          height: 350px;
-          width: 100% !important;
-          border: solid 1px transparent;
-          margin-bottom: 0 !important;
-          overflow: hidden;
-          justify-content: space-between;
-          position: relative;
-
-          @media (prefers-color-scheme: dark) {
-            background-color: var(--mi-background-color);
-          }
-
-          @media screen and (max-width: ${bp.medium}px) {
-            padding: 0 !important;
-          }
-        `}
-      >
-        <div
-          className={css`
-            height: 65%;
-            z-index: 0;
-            position: relative;
-            overflow: hidden;
-          `}
-        >
-          {post.featuredImage ? (
-            <img
-              src={post.featuredImage?.src}
-              className={css`
-                object-fit: cover;
-                height: 100%;
-                width: 100%;
-              `}
-            />
-          ) : (
-            <HalfTone
-              color1="var(--mi-button-color)"
-              color2="var(--mi-background-color)"
-            />
-          )}
+    <li {...postContainerProps} className={cardStyle}>
+      {featuredImageSrc && (
+        <div className="relative w-full h-40 overflow-hidden">
+          <img
+            src={featuredImageSrc}
+            alt=""
+            className="block w-full h-full object-cover"
+          />
         </div>
-        <div
-          className={css`
-            padding: 1.5rem;
-            margin: 0;
-            z-index: 1;
-            position: relative;
-            width: 100%;
-            overflow: hidden;
-            transition: 0.2s ease-in-out;
-            ${!post.featuredImage ? "height: 100%;" : ""}
-            background-color: var(--mi-background-color);
-          `}
-        >
-          {post.artist && (
-            <div
-              className={css`
-                padding-bottom: 1.5rem;
-              `}
-            >
-              <p
-                className={css`
-                  white-space: nowrap;
-                  width: 90%;
-                  text-overflow: ellipsis;
-                  padding-right: 3rem;
-                  position: absolute;
-
-                  a {
-                    display: inline-block;
-                    width: auto;
-                    height: auto;
-                    margin-left: 0;
-                  }
-                `}
-              >
-                {t("postByPrefix")}{" "}
-                <LinkToUse variant="link" to={getArtistUrl(post.artist)}>
-                  {post.artist?.name}
-                </LinkToUse>
-              </p>
+      )}
+      <div className="flex flex-col flex-1 gap-1 py-3 px-4">
+        <h3 className="text-base font-semibold text-(--mi-text-color) line-clamp-2 leading-snug!">
+          <Link to={postUrl} className="no-underline! text-inherit!">
+            {post.title}
+          </Link>
+        </h3>
+        {hasTracks && (
+          <div
+            className={`flex items-center gap-2 px-3 py-2 rounded bg-(--mi-button-color) text-(--mi-button-text-color) text-xs ${
+              excerpt ? "mt-2" : "my-auto"
+            }`}
+          >
+            <FaPlay className="shrink-0 w-2.5 h-2.5" aria-hidden />
+            <span className="truncate">
+              {t("tracksInPost", { count: trackCount })}
+            </span>
+          </div>
+        )}
+        {excerpt && (
+          <div
+            className={`text-xs text-(--mi-text-color) leading-snug ${
+              featuredImageSrc ? "line-clamp-2" : "line-clamp-[11] mt-3"
+            }`}
+          >
+            {excerpt}
+          </div>
+        )}
+      </div>
+      <div className="px-4">
+        <div className="flex flex-col gap-1 py-2.5 border-t border-(--mi-tint-color)">
+          {post.artist && !isOnArtistPage && (
+            <div className="text-xs text-(--mi-secondary-text-color)">
+              {t("postByPrefix")}{" "}
+              <Link to={getArtistUrl(post.artist)}>{post.artist.name}</Link>
             </div>
           )}
-          <div
-            className={css`
-              width: 100%;
-              margin-bottom: 0.5rem;
-            `}
-          >
-            <h3
-              className={
-                "h4 " +
-                css`
-                  padding-bottom: 0.3rem;
-                  text-align: left;
-
-                  a {
-                    margin-left: 0;
-                  }
-                `
-              }
-            >
-              <LinkToUse
-                to={postUrl}
-                variant="link"
-                className={
-                  "post-container__link " +
-                  css`
-                    font-weight: normal;
-                    text-align: center;
-                    color: var(--mi-text-color);
-                  `
-                }
-              >
-                {post.title}
-              </LinkToUse>
-            </h3>
-            <p
-              className={css`
-                color: var(--mi-light-foreground-color);
-                text-transform: uppercase;
-                font-size: var(--mi-font-size-small);
-              `}
-            >
+          <div className="flex items-center justify-between">
+            <div className="text-xs text-(--mi-secondary-text-color) uppercase">
               {formatDate({
                 date: post.publishedAt,
                 i18n,
@@ -267,11 +98,15 @@ const PostCard: React.FC<{
                   year: "numeric",
                 },
               })}
-            </p>
+            </div>
+            <span className="text-xs font-semibold text-(--mi-text-color) opacity-70">
+              {t("readPost")} →
+            </span>
           </div>
         </div>
-      </Box>
-    </PostContainer>
+      </div>
+    </li>
   );
 };
+
 export default PostCard;

--- a/client/src/components/Post/PostGrid.tsx
+++ b/client/src/components/Post/PostGrid.tsx
@@ -8,6 +8,7 @@ const PostGridWrapper = styled.ul<{}>`
   display: grid;
   grid-template-columns: repeat(3, 31.6%);
   gap: 1rem 2.5%;
+  align-items: start;
   max-width: 100%;
   list-style-type: none;
 

--- a/client/src/components/Post/PostHeader.tsx
+++ b/client/src/components/Post/PostHeader.tsx
@@ -3,18 +3,25 @@ import styled from "@emotion/styled";
 import Avatar from "components/Artist/Avatar";
 import ClickToPlayTracks from "components/common/ClickToPlayTracks";
 import FollowArtist from "components/common/FollowArtist";
-import SpaceBetweenDiv from "components/common/SpaceBetweenDiv";
+import ShareButton from "components/common/ShareButton";
+import TipArtist from "components/common/TipArtist";
 import { formatDate } from "components/TrackGroup/ReleaseDate";
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+import { getPostURLReference } from "utils/artist";
+import useIsSubscribedToArtist from "utils/useIsSubscribedToArtist";
 
 import { bp } from "../../constants";
 
 const AvatarWrapper = styled.div`
   margin-right: 0.25rem;
   display: flex;
-  line-height: 2.2rem;
+  flex-wrap: wrap;
+  align-items: center;
+  row-gap: 0.25rem;
+  line-height: 1.5rem;
+  font-size: 0.875rem;
 
   a {
     display: inline-flex;
@@ -46,12 +53,80 @@ const AvatarLink: React.FC<{
 
 const PostHeader: React.FC<{ post: Post }> = ({ post }) => {
   const { t, i18n } = useTranslation("translation", { keyPrefix: "post" });
+  const { t: tShare } = useTranslation("translation", { keyPrefix: "share" });
+  const isSubscribed = useIsSubscribedToArtist(post.artistId);
 
   const featuredImage = post.featuredImage?.src;
 
   const trackIds = post.tracks
     ?.filter((track) => track.isPlayable)
     .map((track) => track.trackId);
+
+  const bylineInner = post.artist ? (
+    <>
+      {trackIds && trackIds.length > 0 && (
+        <ClickToPlayTracks
+          trackIds={trackIds}
+          className={css`
+            width: 50px !important;
+            margin-right: 10px;
+          `}
+        />
+      )}
+      <AvatarWrapper>
+        <Trans
+          t={t}
+          i18nKey="postByArtist"
+          components={{
+            link: (
+              <AvatarLink
+                avatar={post.artist.avatar?.sizes?.[60]}
+                to={`/${post.artist.urlSlug?.toLowerCase() ?? post.artistId}`}
+                name={post.artist.name}
+              ></AvatarLink>
+            ),
+          }}
+        />
+        <span
+          aria-hidden
+          className={css`
+            padding: 0 0.4rem;
+          `}
+        >
+          ·
+        </span>
+        <span>
+          {t("publishedAt", {
+            date: formatDate({
+              date: post.publishedAt,
+              i18n,
+              options: {
+                dateStyle: "medium",
+              },
+            }),
+          })}
+        </span>
+      </AvatarWrapper>
+    </>
+  ) : null;
+
+  const actionButtons = post.artistId ? (
+    <div
+      className={css`
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      `}
+    >
+      <TipArtist artistId={post.artistId} compact />
+      <ShareButton
+        title={post.title}
+        url={`${import.meta.env.VITE_CLIENT_DOMAIN}${getPostURLReference(post)}`}
+        modalTitle={tShare("sharePost") ?? ""}
+        size="compact"
+      />
+    </div>
+  ) : null;
 
   return (
     <div
@@ -100,9 +175,7 @@ const PostHeader: React.FC<{ post: Post }> = ({ post }) => {
       >
         <div
           className={
-            (featuredImage
-              ? "max-w-3xl px-4 flex pt-8 w-full justify-center "
-              : "max-w-3xl px-4 md:px-12 flex pt-8 w-full justify-center bg-(--mi-background-color) ") +
+            "max-w-[824px] px-4 md:px-12 flex pt-8 md:pt-12 w-full justify-center " +
             css`
               margin: 0 auto 0;
               position: relative;
@@ -114,6 +187,12 @@ const PostHeader: React.FC<{ post: Post }> = ({ post }) => {
                 font-size: 1.2rem;
                 font-weight: 100;
                 line-height: 1.5rem;
+                ${featuredImage
+                  ? `background: var(--mi-white);
+                     color: var(--mi-black) !important;
+                     a { color: var(--mi-black) !important; }
+                     border-radius: 0.5rem 0.5rem 0 0;`
+                  : ""}
               }
             `
           }
@@ -123,8 +202,14 @@ const PostHeader: React.FC<{ post: Post }> = ({ post }) => {
               flex: 100%;
               width: 100%;
               ${!featuredImage
-                ? "border-bottom: 1px solid var(--mi-tint-color); padding-bottom: 1rem;"
+                ? "border-bottom: 1px solid var(--mi-tint-color);"
                 : ""}
+
+              @media (min-width: ${bp.medium}px) {
+                ${featuredImage
+                  ? "border-bottom: 1px solid var(--mi-darken-x-background-color);"
+                  : ""}
+              }
             `}
           >
             <div
@@ -136,7 +221,7 @@ const PostHeader: React.FC<{ post: Post }> = ({ post }) => {
             >
               <h1
                 className={
-                  "mb-1 text-5xl! " +
+                  "mb-1 text-4xl! font-bold! " +
                   css`
                     @media (max-width: ${bp.medium}px) {
                       font-size: 2rem;
@@ -147,63 +232,64 @@ const PostHeader: React.FC<{ post: Post }> = ({ post }) => {
                 {post.title}
               </h1>
             </div>
-            {post.artist && (
-              <SpaceBetweenDiv
-                className={css`
-                  padding-top: 0.5rem;
-                `}
-              >
+            {post.artist &&
+              (isSubscribed ? (
                 <div
                   className={css`
                     display: flex;
-                    align-items: center;
+                    align-items: flex-end;
+                    justify-content: space-between;
+                    flex-wrap: wrap;
+                    gap: 0.5rem;
+                    min-height: 3.5rem;
+                    padding-top: 0.5rem;
+                    margin-bottom: 0.5rem;
                   `}
                 >
-                  {trackIds && trackIds.length > 0 && (
-                    <ClickToPlayTracks
-                      trackIds={trackIds}
-                      className={css`
-                        width: 50px !important;
-                        margin-right: 10px;
-                      `}
-                    />
-                  )}
-                  <div>
-                    <AvatarWrapper>
-                      <Trans
-                        t={t}
-                        i18nKey="postByArtist"
-                        components={{
-                          link: (
-                            <AvatarLink
-                              avatar={post.artist.avatar?.sizes?.[60]}
-                              to={`/${post.artist.urlSlug?.toLowerCase() ?? post.artistId}`}
-                              name={post.artist.name}
-                            ></AvatarLink>
-                          ),
-                        }}
-                      />
-                    </AvatarWrapper>
-                    <small>
-                      <em>
-                        {t("publishedAt", {
-                          date: formatDate({
-                            date: post.publishedAt,
-                            i18n,
-                            options: {
-                              dateStyle: "medium",
-                            },
-                          }),
-                        })}
-                      </em>
-                    </small>
+                  <div
+                    className={css`
+                      display: flex;
+                      align-items: center;
+                      align-self: flex-start;
+                      min-width: 0;
+                    `}
+                  >
+                    {bylineInner}
                   </div>
+                  {actionButtons}
                 </div>
-                {post.artistId && (
-                  <FollowArtist artistId={post.artistId} hideWhenSubscribed />
-                )}
-              </SpaceBetweenDiv>
-            )}
+              ) : (
+                <>
+                  <div
+                    className={css`
+                      display: flex;
+                      align-items: center;
+                      width: 100%;
+                      padding-top: 0.5rem;
+                    `}
+                  >
+                    {bylineInner}
+                  </div>
+                  {post.artistId && (
+                    <div
+                      className={css`
+                        margin-top: 1rem;
+                        margin-bottom: 0.5rem;
+                        display: flex;
+                        align-items: center;
+                        justify-content: space-between;
+                        gap: 0.5rem;
+                      `}
+                    >
+                      <FollowArtist
+                        artistId={post.artistId}
+                        hideWhenSubscribed
+                      />
+                      {actionButtons}
+                    </div>
+                  )}
+                </>
+              ))}
           </div>
         </div>
       </div>

--- a/client/src/components/Post/index.tsx
+++ b/client/src/components/Post/index.tsx
@@ -26,6 +26,10 @@ export const PageMarkdownWrapper = styled.div`
   flex-direction: column;
   gap: 1rem;
 
+  a {
+    color: #5c899c;
+  }
+
   blockquote {
     font-style: italic;
     border-left: 4px solid #d1d5db;
@@ -109,9 +113,7 @@ const Post: React.FC = () => {
   }
 
   return (
-    <div
-      className={`w-full relative ${post.featuredImage ? "" : "bg-(--mi-tint-color)"}`}
-    >
+    <div className="w-full relative bg-(--mi-darken-background-color) pb-12">
       <MetaCard
         title={`${post.title} ${t("byArtist", { artist: post.artist?.name })}`}
         description={post.content.slice(0, 500)}
@@ -120,11 +122,9 @@ const Post: React.FC = () => {
       <PostHeader post={post} />
 
       <div
-        className={
-          post.featuredImage
-            ? "max-w-3xl mx-auto px-4 pt-8"
-            : "max-w-3xl mx-auto px-4 md:px-12 pt-4 pb-8 bg-(--mi-background-color)"
-        }
+        className={`max-w-[824px] mx-auto px-4 md:px-12 pt-8 pb-8 md:pb-12 bg-(--mi-white) text-(--mi-black) ${
+          post.featuredImage ? "md:rounded-b-lg" : "md:rounded-lg"
+        }`}
       >
         <PageMarkdownWrapper>
           {post.isContentHidden && (
@@ -155,6 +155,7 @@ const Post: React.FC = () => {
         </PageMarkdownWrapper>
       </div>
       {post.artist &&
+        !post.isContentHidden &&
         !user?.artistUserSubscriptions?.some(
           (sub) => sub.artistSubscriptionTier.artistId === post.artist?.id
         ) && (

--- a/client/src/components/common/FollowArtist.test.tsx
+++ b/client/src/components/common/FollowArtist.test.tsx
@@ -173,16 +173,16 @@ describe("FollowArtist", () => {
       });
     });
 
-    test("opens modal with youCanFollowThisArtist when artist has no paid tiers", async () => {
+    test("opens modal with newsletter prompt and email form when artist has no paid tiers", async () => {
       renderFollowArtist();
 
       await waitFor(() => screen.getByRole("button", { name: /follow/i }));
       await userEvent.click(screen.getByRole("button", { name: /follow/i }));
 
-      expect(screen.getByText("youCanFollowThisArtist")).toBeInTheDocument();
       expect(
-        screen.queryByTestId("support-tiers-form")
-      ).not.toBeInTheDocument();
+        screen.getByText("enterEmailToSubscribeToNewsletter")
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("support-tiers-form")).toBeInTheDocument();
     });
 
     test("opens modal with chooseSupportLevel and tiers form when artist has paid tiers", async () => {

--- a/client/src/components/common/FollowArtist.tsx
+++ b/client/src/components/common/FollowArtist.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { FaCheck, FaMinus, FaPlus } from "react-icons/fa";
 import api from "services/api";
 import { useAuthContext } from "state/AuthContext";
+import useIsSubscribedToArtist from "utils/useIsSubscribedToArtist";
 
 import Box from "./Box";
 import Modal from "./Modal";
@@ -24,13 +25,7 @@ const FollowArtist: React.FC<{
 
   const localArtistId = artistId ?? artist?.id;
   const artistUserSubscriptions = user?.artistUserSubscriptions;
-  const [isSubscribed, setIsSubscribed] = React.useState(
-    !!user?.artistUserSubscriptions?.find(
-      (aus) =>
-        aus.artistSubscriptionTier.artistId &&
-        !aus.artistSubscriptionTier.isDefaultTier
-    )
-  );
+  const isSubscribed = useIsSubscribedToArtist(localArtistId);
   const [isFollowing, setIsFollowing] = React.useState(
     !!user?.artistUserSubscriptions?.find(
       (aus) =>
@@ -49,13 +44,6 @@ const FollowArtist: React.FC<{
         aus.artistSubscriptionTier.artistId === localArtistId
     );
     setIsFollowing(!!found);
-
-    const foundSubscribed = artistUserSubscriptions?.find(
-      (aus) =>
-        !aus.artistSubscriptionTier.isDefaultTier &&
-        aus.artistSubscriptionTier.artistId === localArtistId
-    );
-    setIsSubscribed(!!foundSubscribed);
   }, [artistUserSubscriptions, localArtistId]);
 
   const onFollowClick = React.useCallback(async () => {
@@ -146,14 +134,14 @@ const FollowArtist: React.FC<{
             {t(
               hasNoneDefaultSubscriptionTiers
                 ? "chooseSupportLevel"
-                : "youCanFollowThisArtist",
+                : "enterEmailToSubscribeToNewsletter",
               {
                 artistName: artist?.name,
               }
             )}
           </p>
         )}
-        {hasNoneDefaultSubscriptionTiers && (
+        {(hasNoneDefaultSubscriptionTiers || !user) && (
           <SupportArtistTiersForm artist={artist} excludeDefault={!!user} />
         )}
       </Modal>
@@ -167,6 +155,7 @@ const FollowArtist: React.FC<{
         startIcon={isFollowing ? <FaMinus /> : <FaPlus />}
         className={css`
           font-size: 0.75em !important;
+          background-color: var(--mi-button-tint-color) !important;
         `}
       >
         {t(isFollowing ? "unfollow" : "follow")}

--- a/client/src/components/common/ShareButton.tsx
+++ b/client/src/components/common/ShareButton.tsx
@@ -1,0 +1,65 @@
+import { ArtistButton } from "components/Artist/ArtistButtons";
+import Modal from "components/common/Modal";
+import ShareToSocials from "components/common/ShareToSocials";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { BsShare } from "react-icons/bs";
+
+const ShareButton: React.FC<{
+  title: string;
+  url: string;
+  modalTitle: string;
+  buttonClassName?: string;
+  size?: "compact" | "big" | "tiny";
+}> = ({ title, url, modalTitle, buttonClassName, size }) => {
+  const { t } = useTranslation("translation", { keyPrefix: "share" });
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const handleShareClick = async () => {
+    const shareData = { title, url };
+    const isTouchPrimary =
+      typeof window !== "undefined" &&
+      window.matchMedia("(pointer: coarse)").matches;
+    const canNativeShare =
+      typeof navigator !== "undefined" &&
+      typeof navigator.share === "function" &&
+      (typeof navigator.canShare !== "function" ||
+        navigator.canShare(shareData));
+
+    if (isTouchPrimary && canNativeShare) {
+      try {
+        await navigator.share(shareData);
+      } catch {}
+      return;
+    }
+    setIsOpen(true);
+  };
+
+  return (
+    <>
+      <ArtistButton
+        onlyIcon
+        aria-label={t("share") ?? ""}
+        title={t("share") ?? ""}
+        onClick={handleShareClick}
+        startIcon={<BsShare />}
+        size={size}
+        className={buttonClassName}
+      />
+      <Modal
+        size="small"
+        title={modalTitle}
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+      >
+        <ShareToSocials
+          url={url}
+          title={title}
+          socials={["mastodon", "bluesky", "email"]}
+        />
+      </Modal>
+    </>
+  );
+};
+
+export default ShareButton;

--- a/client/src/components/common/SupportArtistTiersForm.tsx
+++ b/client/src/components/common/SupportArtistTiersForm.tsx
@@ -14,10 +14,10 @@ import { useSnackbar } from "state/SnackbarContext";
 import { getArtistUrl } from "utils/artist";
 import useGetArtistSubscriptionTiers from "utils/useGetArtistSubscriptionTiers";
 
-import EmbeddedStripeForm from "./stripe/EmbeddedStripe";
 import FormComponent from "./FormComponent";
 import { InputEl } from "./Input";
 import { moneyDisplay } from "./Money";
+import EmbeddedStripeForm from "./stripe/EmbeddedStripe";
 import SupportArtistPopUpTiers from "./SupportArtistPopUpTiers";
 
 const SupportArtistTiersForm: React.FC<{
@@ -124,6 +124,29 @@ const SupportArtistTiersForm: React.FC<{
   }
   const value = methods.watch("tier");
 
+  const effectiveOptions = excludeDefault
+    ? options.filter((option) => !option.isDefaultTier)
+    : options;
+
+  const singleOption =
+    effectiveOptions.length === 1 ? effectiveOptions[0] : null;
+
+  const singleOptionCurrency = artistDetails?.user?.currency ?? "usd";
+
+  React.useEffect(() => {
+    if (singleOption && value?.id !== singleOption.id) {
+      methods.setValue(
+        "tier",
+        {
+          ...singleOption,
+          currency: singleOptionCurrency,
+          minAmount: singleOption.minAmount ?? 0,
+        },
+        { shouldDirty: false }
+      );
+    }
+  }, [singleOption, singleOptionCurrency, value?.id, methods]);
+
   const noErrors =
     methods.formState.isValid || isEmpty(methods.formState.errors);
 
@@ -134,21 +157,19 @@ const SupportArtistTiersForm: React.FC<{
     <>
       {!artistDetails && <LoadingBlocks rows={1} margin="1rem" />}
       <FormProvider {...methods}>
-        <Controller
-          name="tier"
-          control={methods.control}
-          render={({ ...props }) => (
-            <SupportArtistPopUpTiers
-              {...props}
-              currency={artistDetails?.user?.currency ?? "usd"}
-              options={
-                excludeDefault
-                  ? options.filter((option) => !option.isDefaultTier)
-                  : options
-              }
-            />
-          )}
-        />
+        {!singleOption && (
+          <Controller
+            name="tier"
+            control={methods.control}
+            render={({ ...props }) => (
+              <SupportArtistPopUpTiers
+                {...props}
+                currency={artistDetails?.user?.currency ?? "usd"}
+                options={effectiveOptions}
+              />
+            )}
+          />
+        )}
 
         {!user && (
           <FormComponent>

--- a/client/src/components/common/TipArtist.tsx
+++ b/client/src/components/common/TipArtist.tsx
@@ -1,23 +1,25 @@
-import React from "react";
-import Button from "./Button";
-import { FaDonate } from "react-icons/fa";
-import { useTranslation } from "react-i18next";
-import Modal from "./Modal";
-
-import { useAuthContext } from "state/AuthContext";
-import SupportArtistTiersForm from "./SupportArtistTiersForm";
-import { useQuery } from "@tanstack/react-query";
-import { queryArtist, queryUserStripeStatus } from "queries";
 import { css } from "@emotion/css";
-import TipArtistForm from "./TipArtistForm";
-import { FixedButton } from "./FixedButton";
-import UnsubscribeButton from "./UnsubscribeButton";
+import { useQuery } from "@tanstack/react-query";
+import { ArtistButton } from "components/Artist/ArtistButtons";
+import { queryArtist, queryUserStripeStatus } from "queries";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { FaDonate } from "react-icons/fa";
+import { useAuthContext } from "state/AuthContext";
 import useGetArtistSubscriptionTiers from "utils/useGetArtistSubscriptionTiers";
 
-const TipArtist: React.FC<{ artistId: number; fixed?: boolean }> = ({
-  artistId,
-  fixed = false,
-}) => {
+import Button from "./Button";
+import { FixedButton } from "./FixedButton";
+import Modal from "./Modal";
+import SupportArtistTiersForm from "./SupportArtistTiersForm";
+import TipArtistForm from "./TipArtistForm";
+import UnsubscribeButton from "./UnsubscribeButton";
+
+const TipArtist: React.FC<{
+  artistId: number;
+  fixed?: boolean;
+  compact?: boolean;
+}> = ({ artistId, fixed = false, compact = false }) => {
   const { t } = useTranslation("translation", { keyPrefix: "artist" });
   const { user } = useAuthContext();
   const { data: artist } = useQuery(
@@ -48,6 +50,20 @@ const TipArtist: React.FC<{ artistId: number; fixed?: boolean }> = ({
     >
       {t("tipArtist")}
     </FixedButton>
+  ) : compact ? (
+    <ArtistButton
+      className={`tip-artist ${css`
+        font-size: 0.75em !important;
+        background-color: var(--mi-button-tint-color) !important;
+      `}`}
+      size="compact"
+      variant="outlined"
+      type="button"
+      onClick={onTipClick}
+      startIcon={<FaDonate />}
+    >
+      {t("tipArtist")}
+    </ArtistButton>
   ) : (
     <Button
       className="tip-artist"

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -710,7 +710,10 @@
     "edit": "Edit",
     "notAvailable": "This post is for subscribers only. <support>Support this artist</support> to get access.",
     "publishedAt": "Published {{ date }}",
-    "likedThisPost": "Liked this post?"
+    "likedThisPost": "Liked this post?",
+    "readPost": "Read post",
+    "tracksInPost_one": "{{count}} track",
+    "tracksInPost_other": "{{count}} tracks"
   },
   "postTracksDock": {
     "label": "Playing in this post"

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -580,7 +580,7 @@
     "enterEmail": "Enter your email:",
     "tipThisArtist": "Tip this artist",
     "manageArtistSubscription": "Manage artist subscription",
-    "tipArtist": "Tip artist",
+    "tipArtist": "Tip",
     "likeWhatTheyAreDoing": "Like what {{artistName}} is doing? The best way to support them is on a monthly basis.",
     "unsubscribeFromArtist": "Stop receiving emails from {{artistName}}",
     "stopReceivingUpdates": "Stop receiving posts from {{artistName}}",
@@ -1377,6 +1377,7 @@
     "copyLink": "Copy link",
     "share": "Share",
     "shareArtist": "Share {{artistName}}'s page",
+    "sharePost": "Share this post",
     "urlToShare": "URL to share"
   },
   "subscriptionForm": {

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -654,7 +654,7 @@
     "contributionIsMonthly": "Make contribution monthly",
     "subscribeToArtist": "Subscribe to {{ artist }}",
     "chooseSupportLevel": "You can follow {{artistName}} or choose to support them financially",
-    "youCanFollowThisArtist": "You can follow {{artistName}}",
+    "enterEmailToSubscribeToNewsletter": "Enter your email to subscribe to {{artistName}}'s newsletter",
     "continueWithPriceMonthly": "Continue with {{ amount }}/month",
     "continueWithPriceYearly": "Continue with {{ amount }}/year",
     "chooseToContinue": "Choose a support tier to continue",

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -178,6 +178,7 @@ interface Post {
     title?: string;
     audioDuration?: number;
   }[];
+  trackCount?: number;
 }
 
 interface PostImage {

--- a/client/src/utils/useIsSubscribedToArtist.ts
+++ b/client/src/utils/useIsSubscribedToArtist.ts
@@ -1,0 +1,13 @@
+import { useAuthContext } from "state/AuthContext";
+
+const useIsSubscribedToArtist = (artistId?: number) => {
+  const { user } = useAuthContext();
+
+  return !!user?.artistUserSubscriptions?.find(
+    (aus) =>
+      !aus.artistSubscriptionTier.isDefaultTier &&
+      aus.artistSubscriptionTier.artistId === artistId
+  );
+};
+
+export default useIsSubscribedToArtist;

--- a/src/routers/v1/artists/{id}/feed.ts
+++ b/src/routers/v1/artists/{id}/feed.ts
@@ -39,6 +39,7 @@ export const getPostsVisibleToUser = async (
         minimumSubscriptionTier: true,
         postSubscriptionTiers: true,
         featuredImage: true,
+        _count: { select: { tracks: true } },
       },
       orderBy: { publishedAt: "desc" },
       take,

--- a/src/utils/serialize/post.ts
+++ b/src/utils/serialize/post.ts
@@ -68,7 +68,7 @@ export const serializePost = (
         audio?: { duration: number | null } | null;
       };
     }[];
-  },
+  } & { _count?: { tracks?: number } },
   userTrackGroupPurchases?: Array<{ userId: number; trackGroupId: number }>,
   userTrackPurchases?: Array<{ userId: number; trackId: number }>,
   isUserSubscriber?: boolean
@@ -76,6 +76,7 @@ export const serializePost = (
   const canSeeContent = !!(isUserSubscriber || post.isPublic);
   return {
     ...post,
+    trackCount: post._count?.tracks ?? post.tracks?.length ?? 0,
     tracks: canSeeContent
       ? post.tracks?.map((pt) => {
           const tgPurchases = userTrackGroupPurchases ?? [];


### PR DESCRIPTION
Last overhaul to "make things look more consistent". Blog posts had several different looks based on where they were, and "subscriber/non-subscribers behavior could be weird" (buttons still visible asking to support if you like when you're already subscribed, that sort of thing) : 

- refactors post cards on artist pages to match the look of post cards notifications in the "feed/notification" section 
- make sure blog posts are always written on black over white background (as it might not be clear while setting up artist colors that this will influence readbility on blog posts), artist layout remains present in the header section and background color. 
- adds a share button to the blogpost (by refactoring the share button on the "artist page")
- Reintroduces the tip button that had been removed, but as part of an action strip side by side with share button