### PR TITLE
feat: include track number in Canimus feed

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -16,6 +16,17 @@
     -->
     <link rel="manifest" href="/manifest.json" />
     <!--
+      canimus.json provides a catalog usable by the social music network
+      using the canimus format.
+      See https://github.com/PlaidWeb/Canimus/blob/main/format.md
+    -->
+    <link
+      rel="alternate"
+      href="/v1/sm/canimus.json"
+      type="application/canimus+json"
+      title="Canimus feed (JSON)"
+    />
+    <!--
       Notice that URLs begin with "/" in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.

--- a/src/parseIndex.ts
+++ b/src/parseIndex.ts
@@ -127,7 +127,6 @@ const buildOpenGraphTags = ($: cheerio.CheerioAPI, metadata: PageMetadata) => {
 
   $("head").append(`
     <link rel="canonical" href="${url}" />
-    <link rel="alternate" href="/v1/sm/canimus.json" type="application/canimus+json" title="Canimus feed (JSON)"/>
     <meta property="og:type" content="${determineType(metadata)}">
     <meta property="og:title" content="${title}">
     <meta property="og:description" content="${description}">

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -125,6 +125,7 @@ export default function () {
                 include: {
                   audio: { select: { duration: true } },
                 },
+                orderBy: { order: "asc" },
               },
             },
             orderBy: { orderIndex: "asc" },

--- a/src/utils/serialize/artist.ts
+++ b/src/utils/serialize/artist.ts
@@ -134,14 +134,17 @@ export const serializeSingleArtistIntoCanimus = (artist: LocalArtist) => {
     name: artist.name,
     url: artistUrl,
     images: {
-      cover: {
-        src: avatarString
-          ? generateFullStaticImageUrl(avatarString, finalArtistAvatarBucket)
-          : undefined,
-        alt: null,
-        width: 600,
-        height: 600,
-      },
+      cover: avatarString
+        ? {
+            src: generateFullStaticImageUrl(
+              avatarString,
+              finalArtistAvatarBucket
+            ),
+            alt: null,
+            width: 600,
+            height: 600,
+          }
+        : undefined,
     },
     summary: artist.shortDescription,
     description: artist.bio,

--- a/src/utils/serialize/track.ts
+++ b/src/utils/serialize/track.ts
@@ -62,6 +62,7 @@ export const serializeSingleTrackIntoCanimus = (
     name: track.title,
     url: join(releaseUrl, "tracks", trackId),
     duration: track.audio?.duration ?? metadata?.format?.duration,
+    track: track.order,
     media: [
       {
         src: mediaUrl,

--- a/src/utils/serialize/trackGroup.ts
+++ b/src/utils/serialize/trackGroup.ts
@@ -108,11 +108,13 @@ export const serializeSingleTrackGroupIntoCanimus = (
     license: trackGroup.credits,
     artist: artistName,
     images: {
-      cover: {
-        src: coverString
-          ? generateFullStaticImageUrl(coverString, finalCoversBucket)
-          : undefined,
-      },
+      cover: coverString
+        ? {
+            src: generateFullStaticImageUrl(coverString, finalCoversBucket),
+            width: 600,
+            height: 600,
+          }
+        : undefined,
     },
     description: trackGroup.about,
     children: trackGroup.tracks?.map((track: CanimusTrack) =>


### PR DESCRIPTION
I noticed that the track numbers in Fairplayer didn't match those in Mirlo, and the reason was that on the client side we were relying on sort order and the API output wasn't sorted. But I also realised that Canimus actually supports a track number so I added that as well (on the Fairplayer side we have changed ingestion to use track number if present).

I've also relocated the alt link for Canimus to where I think is a more appropriate location than "openGraph/sharing" stuff @simonv3 if that is ok?