### PR TITLE
Canimus return deleted filter from date

### DIFF
--- a/prisma/prisma.ts
+++ b/prisma/prisma.ts
@@ -83,7 +83,15 @@ const prisma = baseClient.$extends({
           });
         }
 
-        // Handle findFirst and findMany to filter out soft deleted
+        // Handle findFirst and findMany to filter out soft deleted.
+
+        // In case that a findMany or findFirst need to include deleted entities using
+        // nested conditions (i.e. OR, AND) it is needed to add a hacky deletedAt
+        // in the where root
+        // where:{
+        //   AND: [...]
+        //   deletedAt: {}
+        // }
         if (operation === "findFirst" || operation === "findMany") {
           const whereArgs = (args.where as any) || {};
           if (whereArgs.deletedAt === undefined) {

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -1,3 +1,5 @@
+import { join } from "path";
+
 import prisma from "@mirlo/prisma";
 import { Prisma } from "@mirlo/prisma/client";
 import { NextFunction, Request, Response } from "express";
@@ -6,6 +8,7 @@ import {
   serializeSingleArtistIntoCanimus,
   serializeSingleDeletedArtistIntoCanimus,
 } from "../../../../utils/serialize/artist";
+import { serializeSingleDeletedTrackGroupIntoCanimus } from "../../../../utils/serialize/trackGroup";
 import { whereForPublishedTrackGroups } from "../../../../utils/trackGroup";
 
 export default function () {
@@ -24,21 +27,25 @@ export default function () {
       } else {
         fromDateFilter = undefined;
       }
-
+      let deleted: Prisma.ArtistWhereInput = {
+        deletedAt: { not: null },
+      };
       let federated: Prisma.ArtistWhereInput = {
         federatedStreaming: true,
       };
 
-      // Artists who opted out (had opted in before, but now streaming is false)
-      let artistOptedOut: Prisma.ArtistWhereInput = {
-        federatedStreaming: false,
-        federatedStreamingOptInDate: { not: null }, // opted in at some point
+      let federatedAtSomePoint: Prisma.ArtistWhereInput = {
+        federatedStreamingOptInDate: { not: null },
       };
 
-      // Artists who opted in but were later deleted
+      // Artists who opted out (had opted in before, but now are not federated)
+      let artistOptedOut: Prisma.ArtistWhereInput = {
+        AND: [federatedAtSomePoint, { NOT: federated }],
+      };
+
+      // Artists who opted in at some point but were deleted
       let artistFederatedButDeletedFromMirlo: Prisma.ArtistWhereInput = {
-        federatedStreamingOptInDate: { not: null }, // they opted in at some point
-        deletedAt: { not: null }, // they are deleted
+        AND: [federatedAtSomePoint, deleted],
       };
 
       let artistOptedOutOrDeleted: Prisma.ArtistWhereInput = {
@@ -83,6 +90,7 @@ export default function () {
             },
           },
         ];
+
         artistOptedOutOrDeleted.AND = [
           {
             federatedStreamingOptOutDate: fromDateFilter,
@@ -136,43 +144,38 @@ export default function () {
         orderBy: orderByClause as Prisma.ArtistOrderByWithRelationInput,
       });
 
-      // const deletedTrackGroups = await prisma.trackGroup.findMany({
-      //   where: {
-      //     OR: [
-      //       {
-      //         artist: artistOptedOutOrDeleted,
-      //       },
-      //       {
-      //         deletedAt:
-      //       }
-      //     ],
-      //   },
-      //   include: {
-      //     artist: {
-      //       select: {
-      //         urlSlug: true,
-      //       },
-      //     },
-      //   },
-      //   skip: skipQuery ? Number(skipQuery) : undefined,
-      //   take: take ? Number(take) : undefined,
-      //   orderBy: orderByClause as Prisma.TrackGroupOrderByWithRelationInput,
-      // });
+      const deletedTrackGroups = await prisma.trackGroup.findMany({
+        where: {
+          artist: federatedAtSomePoint,
+          deletedAt: { not: null },
+        },
+        include: {
+          artist: {
+            select: {
+              urlSlug: true,
+            },
+          },
+        },
+        skip: skipQuery ? Number(skipQuery) : undefined,
+        take: take ? Number(take) : undefined,
+        orderBy: orderByClause as Prisma.TrackGroupOrderByWithRelationInput,
+      });
 
       let deletedEntities: any = [];
-      deletedEntities = deletedEntities.concat(
-        deletedArtists.map((artist) =>
-          serializeSingleDeletedArtistIntoCanimus(artist)
+      deletedEntities = deletedEntities
+        .concat(
+          deletedArtists.map((artist) =>
+            serializeSingleDeletedArtistIntoCanimus(artist)
+          )
         )
-      );
-      // .concat(
-      //   deletedTrackGroups.map((trackGroup) =>
-      //     serializeSingleDeletedTrackGroupIntoCanimus(
-      //       trackGroup,
-      //       trackGroup.artist.urlSlug
-      //     )
-      //   )
-      // );
+        .concat(
+          deletedTrackGroups.map((trackGroup) =>
+            serializeSingleDeletedTrackGroupIntoCanimus(
+              trackGroup,
+              join(String(process.env.API_DOMAIN), trackGroup.artist.urlSlug)
+            )
+          )
+        );
 
       res.json({
         type: "root",

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -5,6 +5,11 @@ import { Prisma } from "@mirlo/prisma/client";
 import { NextFunction, Request, Response } from "express";
 
 import {
+  federatedArtistAtSomePoint,
+  federatedArtist,
+  artistOptedOutOrDeleted,
+} from "../../../../utils/artist";
+import {
   serializeSingleArtistIntoCanimus,
   serializeSingleDeletedArtistIntoCanimus,
 } from "../../../../utils/serialize/artist";
@@ -34,38 +39,16 @@ export default function () {
         | Prisma.TrackWhereInput = {
         deletedAt: { not: null },
       };
-      let federated: Prisma.ArtistWhereInput = {
-        federatedStreaming: true,
-      };
-
-      let federatedAtSomePoint: Prisma.ArtistWhereInput = {
-        federatedStreamingOptInDate: { not: null },
-      };
-
-      // Artists who opted out (had opted in before, but now are not federated)
-      let artistOptedOut: Prisma.ArtistWhereInput = {
-        AND: [federatedAtSomePoint, { NOT: federated }],
-      };
-
-      // Artists who opted in at some point but were deleted
-      let artistFederatedButDeletedFromMirlo: Prisma.ArtistWhereInput = {
-        AND: [federatedAtSomePoint, deleted as Prisma.ArtistWhereInput],
-      };
-
-      let artistOptedOutOrDeleted: Prisma.ArtistWhereInput = {
-        OR: [artistOptedOut, artistFederatedButDeletedFromMirlo],
-      };
-
       let trackGroupDeleted: Prisma.TrackGroupWhereInput = {
         AND: [
-          { artist: federatedAtSomePoint },
+          { artist: federatedArtistAtSomePoint },
           deleted as Prisma.TrackGroupWhereInput,
         ],
       };
 
       let trackDeleted: Prisma.TrackWhereInput = {
         AND: [
-          { trackGroup: { artist: federatedAtSomePoint } },
+          { trackGroup: { artist: federatedArtistAtSomePoint } },
           deleted as Prisma.TrackWhereInput,
         ],
       };
@@ -110,7 +93,7 @@ export default function () {
           },
         };
 
-        federated.OR = [
+        federatedArtist.OR = [
           optInDateFilter,
           updatedOrCreatedFilter as Prisma.ArtistWhereInput,
           anyTrackGroupUpdatedOrCreated,
@@ -133,7 +116,7 @@ export default function () {
       };
 
       const artists = await prisma.artist.findMany({
-        where: federated,
+        where: federatedArtist,
         skip: skipQuery ? Number(skipQuery) : undefined,
         take: take ? Number(take) : undefined,
         orderBy: orderByClause as Prisma.ArtistOrderByWithRelationInput,

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -25,30 +25,20 @@ export default function () {
         fromDateFilter = undefined;
       }
 
-      let where: Prisma.ArtistWhereInput = {
+      let federated: Prisma.ArtistWhereInput = {
         federatedStreaming: true,
       };
 
+      // Artists who opted out (had opted in before, but now streaming is false)
       let artistOptedOut: Prisma.ArtistWhereInput = {
-        AND: [
-          {
-            federatedStreaming: false,
-            NOT: {
-              federatedStreamingOptInDate: null, // discard artists that never opted in
-            },
-          },
-        ],
+        federatedStreaming: false,
+        federatedStreamingOptInDate: { not: null }, // opted in at some point
       };
 
+      // Artists who opted in but were later deleted
       let artistFederatedButDeletedFromMirlo: Prisma.ArtistWhereInput = {
-        AND: [
-          {
-            NOT: {
-              federatedStreamingOptInDate: null, // discard artists that never opted in
-              deletedAt: null,
-            },
-          },
-        ],
+        federatedStreamingOptInDate: { not: null }, // they opted in at some point
+        deletedAt: { not: null }, // they are deleted
       };
 
       let artistOptedOutOrDeleted: Prisma.ArtistWhereInput = {
@@ -64,22 +54,18 @@ export default function () {
           | Prisma.TrackGroupWhereInput
           | Prisma.TrackWhereInput
           | Prisma.ArtistWhereInput = {
-          AND: [
-            { deletedAt: null },
+          deletedAt: null,
+          OR: [
             {
-              OR: [
-                {
-                  createdAt: fromDateFilter,
-                },
-                {
-                  updatedAt: fromDateFilter,
-                },
-              ],
+              createdAt: fromDateFilter,
+            },
+            {
+              updatedAt: fromDateFilter,
             },
           ],
         };
 
-        where.OR = [
+        federated.AND = [
           optInDateFilter,
           updatedOrCreatedFilter as Prisma.ArtistWhereInput,
           {
@@ -97,6 +83,11 @@ export default function () {
             },
           },
         ];
+        artistOptedOutOrDeleted.AND = [
+          {
+            federatedStreamingOptOutDate: fromDateFilter,
+          },
+        ];
       }
 
       const orderByClause:
@@ -106,7 +97,7 @@ export default function () {
       };
 
       const artists = await prisma.artist.findMany({
-        where,
+        where: federated,
         skip: skipQuery ? Number(skipQuery) : undefined,
         take: take ? Number(take) : undefined,
         orderBy: orderByClause as Prisma.ArtistOrderByWithRelationInput,
@@ -143,24 +134,25 @@ export default function () {
         skip: skipQuery ? Number(skipQuery) : undefined,
         take: take ? Number(take) : undefined,
         orderBy: orderByClause as Prisma.ArtistOrderByWithRelationInput,
-        include: {
-          trackGroups: {
-            include: {
-              tracks: {
-                include: {
-                  audio: {
-                    select: { duration: true },
-                  },
-                },
-              },
-            },
-            orderBy: { orderIndex: "asc" },
-          },
-        },
       });
-      // const deletedReleases = await prisma.trackGroup.findMany({
+
+      // const deletedTrackGroups = await prisma.trackGroup.findMany({
       //   where: {
-      //     artist: artistOptedOutOrDeleted,
+      //     OR: [
+      //       {
+      //         artist: artistOptedOutOrDeleted,
+      //       },
+      //       {
+      //         deletedAt:
+      //       }
+      //     ],
+      //   },
+      //   include: {
+      //     artist: {
+      //       select: {
+      //         urlSlug: true,
+      //       },
+      //     },
       //   },
       //   skip: skipQuery ? Number(skipQuery) : undefined,
       //   take: take ? Number(take) : undefined,
@@ -168,11 +160,19 @@ export default function () {
       // });
 
       let deletedEntities: any = [];
-      for (const deletedArtist of deletedArtists.map((artist) =>
-        serializeSingleDeletedArtistIntoCanimus(artist)
-      )) {
-        deletedEntities.concat(deletedArtist);
-      }
+      deletedEntities = deletedEntities.concat(
+        deletedArtists.map((artist) =>
+          serializeSingleDeletedArtistIntoCanimus(artist)
+        )
+      );
+      // .concat(
+      //   deletedTrackGroups.map((trackGroup) =>
+      //     serializeSingleDeletedTrackGroupIntoCanimus(
+      //       trackGroup,
+      //       trackGroup.artist.urlSlug
+      //     )
+      //   )
+      // );
 
       res.json({
         type: "root",

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -43,6 +43,7 @@ export default function () {
           { artist: federatedArtistAtSomePoint },
           deleted as Prisma.TrackGroupWhereInput,
         ],
+        deletedAt: {},
       };
 
       let trackDeleted: Prisma.TrackWhereInput = {
@@ -50,6 +51,7 @@ export default function () {
           { trackGroup: { artist: federatedArtistAtSomePoint } },
           deleted as Prisma.TrackWhereInput,
         ],
+        deletedAt: {},
       };
 
       if (fromDateFilter) {
@@ -57,10 +59,7 @@ export default function () {
           federatedStreamingOptInDate: fromDateFilter,
         };
 
-        const updatedOrCreatedFilter:
-          | Prisma.TrackGroupWhereInput
-          | Prisma.TrackWhereInput
-          | Prisma.ArtistWhereInput = {
+        const updatedOrCreatedFilter = {
           deletedAt: null,
           OR: [
             {
@@ -108,9 +107,7 @@ export default function () {
         trackDeleted.deletedAt = fromDateFilter;
       }
 
-      const orderByClause:
-        | Prisma.ArtistOrderByWithRelationInput
-        | Prisma.TrackGroupOrderByWithRelationInput = {
+      const orderByClause = {
         createdAt: "desc",
       };
 

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -8,6 +8,7 @@ import {
   serializeSingleArtistIntoCanimus,
   serializeSingleDeletedArtistIntoCanimus,
 } from "../../../../utils/serialize/artist";
+import { serializeSingleDeletedTrackIntoCanimus } from "../../../../utils/serialize/track";
 import { serializeSingleDeletedTrackGroupIntoCanimus } from "../../../../utils/serialize/trackGroup";
 import { whereForPublishedTrackGroups } from "../../../../utils/trackGroup";
 
@@ -52,6 +53,17 @@ export default function () {
         OR: [artistOptedOut, artistFederatedButDeletedFromMirlo],
       };
 
+      let trackGroupDeleted: Prisma.TrackGroupWhereInput = {
+        artist: federatedAtSomePoint,
+        deletedAt: { not: null },
+      };
+      let trackDeleted: Prisma.TrackWhereInput = {
+        trackGroup: {
+          artist: federatedAtSomePoint,
+        },
+        deletedAt: { not: null },
+      };
+
       if (fromDateFilter) {
         const optInDateFilter: Prisma.ArtistWhereInput = {
           federatedStreamingOptInDate: fromDateFilter,
@@ -72,7 +84,7 @@ export default function () {
           ],
         };
 
-        federated.AND = [
+        federated.OR = [
           optInDateFilter,
           updatedOrCreatedFilter as Prisma.ArtistWhereInput,
           {
@@ -96,6 +108,9 @@ export default function () {
             federatedStreamingOptOutDate: fromDateFilter,
           },
         ];
+
+        trackGroupDeleted.deletedAt = fromDateFilter;
+        trackDeleted.deletedAt = fromDateFilter;
       }
 
       const orderByClause:
@@ -145,10 +160,7 @@ export default function () {
       });
 
       const deletedTrackGroups = await prisma.trackGroup.findMany({
-        where: {
-          artist: federatedAtSomePoint,
-          deletedAt: { not: null },
-        },
+        where: trackGroupDeleted,
         include: {
           artist: {
             select: {
@@ -159,6 +171,24 @@ export default function () {
         skip: skipQuery ? Number(skipQuery) : undefined,
         take: take ? Number(take) : undefined,
         orderBy: orderByClause as Prisma.TrackGroupOrderByWithRelationInput,
+      });
+
+      const deletedTracks = await prisma.track.findMany({
+        where: trackDeleted,
+        include: {
+          trackGroup: {
+            include: {
+              artist: {
+                select: {
+                  urlSlug: true,
+                },
+              },
+            },
+          },
+        },
+        skip: skipQuery ? Number(skipQuery) : undefined,
+        take: take ? Number(take) : undefined,
+        orderBy: orderByClause as Prisma.TrackOrderByWithRelationInput,
       });
 
       let deletedEntities: any = [];
@@ -173,6 +203,19 @@ export default function () {
             serializeSingleDeletedTrackGroupIntoCanimus(
               trackGroup,
               join(String(process.env.API_DOMAIN), trackGroup.artist.urlSlug)
+            )
+          )
+        )
+        .concat(
+          deletedTracks.map((track) =>
+            serializeSingleDeletedTrackIntoCanimus(
+              track,
+              join(
+                String(process.env.API_DOMAIN),
+                track.trackGroup.artist.urlSlug,
+                "release",
+                track.trackGroup.urlSlug
+              )
             )
           )
         );

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -28,7 +28,10 @@ export default function () {
       } else {
         fromDateFilter = undefined;
       }
-      let deleted: Prisma.ArtistWhereInput = {
+      let deleted:
+        | Prisma.ArtistWhereInput
+        | Prisma.TrackGroupWhereInput
+        | Prisma.TrackWhereInput = {
         deletedAt: { not: null },
       };
       let federated: Prisma.ArtistWhereInput = {
@@ -46,7 +49,7 @@ export default function () {
 
       // Artists who opted in at some point but were deleted
       let artistFederatedButDeletedFromMirlo: Prisma.ArtistWhereInput = {
-        AND: [federatedAtSomePoint, deleted],
+        AND: [federatedAtSomePoint, deleted as Prisma.ArtistWhereInput],
       };
 
       let artistOptedOutOrDeleted: Prisma.ArtistWhereInput = {
@@ -54,14 +57,17 @@ export default function () {
       };
 
       let trackGroupDeleted: Prisma.TrackGroupWhereInput = {
-        artist: federatedAtSomePoint,
-        deletedAt: { not: null },
+        AND: [
+          { artist: federatedAtSomePoint },
+          deleted as Prisma.TrackGroupWhereInput,
+        ],
       };
+
       let trackDeleted: Prisma.TrackWhereInput = {
-        trackGroup: {
-          artist: federatedAtSomePoint,
-        },
-        deletedAt: { not: null },
+        AND: [
+          { trackGroup: { artist: federatedAtSomePoint } },
+          deleted as Prisma.TrackWhereInput,
+        ],
       };
 
       if (fromDateFilter) {
@@ -84,23 +90,30 @@ export default function () {
           ],
         };
 
+        // Artist updated or created or with any
+        // TrackGroup updated or created or with any
+        // Track updated or created
+        let anyTrackUpdatedOrCreated: Prisma.TrackGroupWhereInput = {
+          tracks: {
+            some: updatedOrCreatedFilter as Prisma.TrackWhereInput,
+          },
+        };
+
+        let anyTrackGroupUpdatedOrCreated: Prisma.ArtistWhereInput = {
+          trackGroups: {
+            some: {
+              OR: [
+                updatedOrCreatedFilter as Prisma.TrackGroupWhereInput,
+                anyTrackUpdatedOrCreated,
+              ],
+            },
+          },
+        };
+
         federated.OR = [
           optInDateFilter,
           updatedOrCreatedFilter as Prisma.ArtistWhereInput,
-          {
-            trackGroups: {
-              some: {
-                OR: [
-                  updatedOrCreatedFilter as Prisma.TrackGroupWhereInput,
-                  {
-                    tracks: {
-                      some: updatedOrCreatedFilter as Prisma.TrackWhereInput,
-                    },
-                  },
-                ],
-              },
-            },
-          },
+          anyTrackGroupUpdatedOrCreated,
         ];
 
         artistOptedOutOrDeleted.AND = [

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -33,12 +33,11 @@ export default function () {
       } else {
         fromDateFilter = undefined;
       }
-      let deleted:
-        | Prisma.ArtistWhereInput
-        | Prisma.TrackGroupWhereInput
-        | Prisma.TrackWhereInput = {
+
+      let deleted = {
         deletedAt: { not: null },
       };
+
       let trackGroupDeleted: Prisma.TrackGroupWhereInput = {
         AND: [
           { artist: federatedArtistAtSomePoint },

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -177,6 +177,7 @@ export const artistFederatedButDeleted: Prisma.ArtistWhereInput = {
 
 export const artistOptedOutOrDeleted: Prisma.ArtistWhereInput = {
   OR: [artistOptedOut, artistFederatedButDeleted],
+  deletedAt: {}, // this is to avoid the middleware filtering out softDeleted -> /mirlo/prisma/prisma.ts
 };
 
 export const findArtistIdForURLSlug = async (id: string | number) => {

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -153,6 +153,32 @@ export const whereForAllArtistsThisLabelCanAddReleasesFor = (
   ],
 });
 
+export const artistDeleted: Prisma.ArtistWhereInput = {
+  deletedAt: { not: null },
+};
+
+export const federatedArtist: Prisma.ArtistWhereInput = {
+  federatedStreaming: true,
+};
+
+export const federatedArtistAtSomePoint: Prisma.ArtistWhereInput = {
+  federatedStreamingOptInDate: { not: null },
+};
+
+// Artists who opted out (had opted in before, but now are not federated)
+export const artistOptedOut: Prisma.ArtistWhereInput = {
+  AND: [federatedArtistAtSomePoint, { NOT: federatedArtist }],
+};
+
+// Artists who opted in at some point but were deleted
+export const artistFederatedButDeleted: Prisma.ArtistWhereInput = {
+  AND: [federatedArtistAtSomePoint, artistDeleted],
+};
+
+export const artistOptedOutOrDeleted: Prisma.ArtistWhereInput = {
+  OR: [artistOptedOut, artistFederatedButDeleted],
+};
+
 export const findArtistIdForURLSlug = async (id: string | number) => {
   if (typeof id !== "number" && Number.isNaN(Number(id))) {
     const artist = await prisma.artist.findFirst({

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -165,8 +165,7 @@ export const federatedArtistAtSomePoint: Prisma.ArtistWhereInput = {
   federatedStreamingOptInDate: { not: null },
 };
 
-// Artists who opted out (had opted in before, but now are not federated)
-export const artistOptedOut: Prisma.ArtistWhereInput = {
+export const artistNoLongerFederated: Prisma.ArtistWhereInput = {
   AND: [federatedArtistAtSomePoint, { NOT: federatedArtist }],
 };
 
@@ -176,7 +175,7 @@ export const artistFederatedButDeleted: Prisma.ArtistWhereInput = {
 };
 
 export const artistOptedOutOrDeleted: Prisma.ArtistWhereInput = {
-  OR: [artistOptedOut, artistFederatedButDeleted],
+  OR: [artistNoLongerFederated, artistFederatedButDeleted],
   deletedAt: {}, // this is to avoid the middleware filtering out softDeleted -> /mirlo/prisma/prisma.ts
 };
 

--- a/src/utils/serialize/artist.ts
+++ b/src/utils/serialize/artist.ts
@@ -28,7 +28,6 @@ import { serializePost } from "./post";
 import {
   processSingleTrackGroup,
   serializeSingleTrackGroupIntoCanimus,
-  serializeSingleDeletedTrackGroupIntoCanimus,
   LocalTrackGroup,
 } from "./trackGroup";
 
@@ -168,14 +167,5 @@ export const serializeSingleDeletedArtistIntoCanimus = (
     name: artist.name,
     url: artistUrl,
   };
-
-  const deletedEntities: any = artist.trackGroups?.map((trackGroup) =>
-    serializeSingleDeletedTrackGroupIntoCanimus(trackGroup, artistUrl)
-  );
-  let output: any = [];
-  for (const e of deletedEntities) {
-    output = output.concat(e);
-  }
-
-  return [deletedArtist].concat(output);
+  return deletedArtist;
 };

--- a/src/utils/serialize/artist.ts
+++ b/src/utils/serialize/artist.ts
@@ -152,6 +152,7 @@ export const serializeSingleArtistIntoCanimus = (artist: LocalArtist) => {
       href: link.url,
       type: link.linkType,
     })),
+    updated_date: artist.updatedAt?.toISOString().split("T")[0],
     children: artist.trackGroups?.map((trackGroup: TrackGroup) =>
       serializeSingleTrackGroupIntoCanimus(trackGroup, artistUrl, artist.name)
     ),

--- a/src/utils/serialize/track.ts
+++ b/src/utils/serialize/track.ts
@@ -63,6 +63,7 @@ export const serializeSingleTrackIntoCanimus = (
     url: join(releaseUrl, "tracks", trackId),
     duration: track.audio?.duration ?? metadata?.format?.duration,
     track: track.order,
+    updated_date: track.updatedAt?.toISOString().split("T")[0],
     media: [
       {
         src: mediaUrl,

--- a/src/utils/serialize/trackGroup.ts
+++ b/src/utils/serialize/trackGroup.ts
@@ -100,7 +100,7 @@ export const serializeSingleTrackGroupIntoCanimus = (
     type: "album",
     name: trackGroup.title,
     url: releaseUrl,
-    release_date: trackGroup.releaseDate,
+    release_date: trackGroup.releaseDate?.toISOString().split("T")[0],
     license: trackGroup.credits,
     artist: artistName,
     images: {

--- a/src/utils/serialize/trackGroup.ts
+++ b/src/utils/serialize/trackGroup.ts
@@ -17,11 +17,7 @@ import { processSingleMerch } from "../merch";
 import { finalArtistAvatarBucket, finalCoversBucket } from "../minio";
 import { isTrackPlayableNested } from "../trackPlayability";
 
-import {
-  serializeSingleTrackIntoCanimus,
-  serializeSingleDeletedTrackIntoCanimus,
-  CanimusTrack,
-} from "./track";
+import { serializeSingleTrackIntoCanimus, CanimusTrack } from "./track";
 
 export interface LocalTrackGroup extends TrackGroup {
   cover?: TrackGroupCover | null;
@@ -128,13 +124,9 @@ export const serializeSingleDeletedTrackGroupIntoCanimus = (
   artistUrl: string
 ) => {
   const releaseUrl = join(artistUrl, "release", trackGroup.urlSlug);
-  const deletedEntities: any = trackGroup.tracks?.map((track) =>
-    serializeSingleDeletedTrackIntoCanimus(track, releaseUrl)
-  );
-  const deletedTrackgroup = {
+  return {
     type: "album",
     name: trackGroup.title,
     url: releaseUrl,
   };
-  return [deletedTrackgroup].concat(deletedEntities);
 };

--- a/src/utils/serialize/trackGroup.ts
+++ b/src/utils/serialize/trackGroup.ts
@@ -101,6 +101,7 @@ export const serializeSingleTrackGroupIntoCanimus = (
     name: trackGroup.title,
     url: releaseUrl,
     release_date: trackGroup.releaseDate?.toISOString().split("T")[0],
+    updated_date: trackGroup.updatedAt?.toISOString().split("T")[0],
     license: trackGroup.credits,
     artist: artistName,
     images: {

--- a/test/README.md
+++ b/test/README.md
@@ -16,6 +16,12 @@ To clean up these containers afterwards, the `--profile=test` argument needs to 
 docker compose --profile=test down
 ```
 
+Specific tests can be run filtering by title with the grep argument:
+
+```
+docker compose --profile=test run --build test yarn api:test --grep "federated"
+```
+
 ## ffmpeg integration tests
 
 Some tests (for example [test/utils/tracks.integration.spec.ts](test/utils/tracks.integration.spec.ts)) run real audio conversion and run by default.

--- a/test/routers/sm/canimus.json.spec.ts
+++ b/test/routers/sm/canimus.json.spec.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 
+import prisma from "@mirlo/prisma";
 import * as dotenv from "dotenv";
 dotenv.config();
 import { describe, it } from "mocha";
@@ -44,18 +45,97 @@ describe("canimus", () => {
         federatedStreaming: true,
         federatedStreamingOptInDate: new Date(Date.now()),
       });
-
       const trackGroup = await createTrackGroup(artist.id);
-
       await createTrack(trackGroup.id);
+      const response = await request(baseURL)
+        .get("sm/canimus.json")
+        .set("Accept", "application/json");
+      assert.equal(response.body.children.length, 1);
+      assert.equal(response.body.children[0].children.length, 1);
+      assert.equal(response.body.deleted.length, 0);
+    });
+
+    it("should GET / with no artist federated and 2 artist deleted", async () => {
+      const { user } = await createUser({
+        email: "test@testcom",
+      });
+      await createArtist(user.id, {
+        name: "test-artist",
+        urlSlug: "test-artist",
+        federatedStreaming: false,
+        federatedStreamingOptInDate: new Date(Date.now()),
+        federatedStreamingOptOutDate: new Date(Date.now()),
+      });
+      const artist = await createArtist(user.id, {
+        name: "deleted-artist",
+        urlSlug: "deleted-artist",
+        federatedStreaming: true,
+        federatedStreamingOptInDate: new Date(Date.now()),
+      });
+      await prisma.artist.update({
+        where: { id: artist.id },
+        data: { deletedAt: new Date() },
+      });
 
       const response = await request(baseURL)
         .get("sm/canimus.json")
         .set("Accept", "application/json");
-      console.log(response.body.children);
+      assert.equal(response.body.children.length, 0);
+      assert.equal(response.body.deleted.length, 2);
+    });
+
+    it("should GET / with 1 artist federated and 1 track and trackgroup deleted", async () => {
+      const { user } = await createUser({
+        email: "test@testcom",
+      });
+      const artist = await createArtist(user.id, {
+        name: "test-artist",
+        urlSlug: "test-artist",
+        federatedStreaming: true,
+        federatedStreamingOptInDate: new Date(Date.now()),
+      });
+
+      const trackGroup = await createTrackGroup(artist.id);
+      await prisma.trackGroup.update({
+        where: { id: trackGroup.id },
+        data: { deletedAt: new Date() },
+      });
+
+      const response = await request(baseURL)
+        .get("sm/canimus.json")
+        .set("Accept", "application/json");
+      console.log(response.body);
       assert.equal(response.body.children.length, 1);
-      assert.equal(response.body.children[0].children.length, 1);
-      assert.equal(response.body.deleted.length, 0);
+      assert.equal(response.body.deleted.length, 1);
+    });
+
+    it("should GET / with fromDate filter with 1 artist and 1 deleted artist ", async () => {
+      const { user } = await createUser({
+        email: "test@testcom",
+      });
+      const dateNow = new Date(Date.now());
+      await createArtist(user.id, {
+        name: "test-artist",
+        urlSlug: "test-artist",
+        federatedStreaming: true,
+        federatedStreamingOptInDate: new Date(Date.now() - 1000000),
+      });
+      const artist = await createArtist(user.id, {
+        name: "test-artist",
+        urlSlug: "test-artist",
+        federatedStreaming: true,
+        federatedStreamingOptInDate: dateNow,
+      });
+      await prisma.artist.update({
+        where: { id: artist.id },
+        data: { deletedAt: new Date() },
+      });
+
+      const response = await request(baseURL)
+        .get("sm/canimus.json?" + String(dateNow).split("T")[0])
+        .set("Accept", "application/json");
+      assert.equal(response.body.children.length, 1);
+      assert.equal(response.body.deleted.length, 1);
     });
   });
 });

--- a/test/routers/sm/canimus.json.spec.ts
+++ b/test/routers/sm/canimus.json.spec.ts
@@ -30,7 +30,6 @@ describe("canimus", () => {
         .get("sm/canimus.json")
         .set("Accept", "application/json");
       assert.equal(response.body.type, "root");
-      assert.equal(response.body.url, process.env.API_DOMAIN);
       assert.equal(response.body.children.length, 0);
       assert.equal(response.body.deleted.length, 0);
     });

--- a/test/routers/sm/canimus.json.spec.ts
+++ b/test/routers/sm/canimus.json.spec.ts
@@ -104,7 +104,6 @@ describe("canimus", () => {
       const response = await request(baseURL)
         .get("sm/canimus.json")
         .set("Accept", "application/json");
-      console.log(response.body);
       assert.equal(response.body.children.length, 1);
       assert.equal(response.body.deleted.length, 1);
     });

--- a/test/routers/sm/canimus.json.spec.ts
+++ b/test/routers/sm/canimus.json.spec.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert";
+
+import * as dotenv from "dotenv";
+dotenv.config();
+import { describe, it } from "mocha";
+import request from "supertest";
+
+import {
+  clearTables,
+  createArtist,
+  createTrack,
+  createUser,
+  createTrackGroup,
+} from "../../utils";
+
+const baseURL = `${process.env.API_DOMAIN}/v1/`;
+
+describe("canimus", () => {
+  beforeEach(async () => {
+    try {
+      await clearTables();
+    } catch (e) {
+      console.error(e);
+    }
+  });
+  describe("/", () => {
+    it("should GET / with root info and no artist federated children nor deleted", async () => {
+      const response = await request(baseURL)
+        .get("sm/canimus.json")
+        .set("Accept", "application/json");
+      assert.equal(response.body.type, "root");
+      assert.equal(response.body.url, process.env.API_DOMAIN);
+      assert.equal(response.body.children.length, 0);
+      assert.equal(response.body.deleted.length, 0);
+    });
+
+    it("should GET / with 1 artist federated with 1 track group and 1 track", async () => {
+      const { user } = await createUser({
+        email: "test@testcom",
+      });
+      const artist = await createArtist(user.id, {
+        name: "test-artist",
+        urlSlug: "test-artist",
+        federatedStreaming: true,
+        federatedStreamingOptInDate: new Date(Date.now()),
+      });
+
+      const trackGroup = await createTrackGroup(artist.id);
+
+      await createTrack(trackGroup.id);
+
+      const response = await request(baseURL)
+        .get("sm/canimus.json")
+        .set("Accept", "application/json");
+      console.log(response.body.children);
+      assert.equal(response.body.children.length, 1);
+      assert.equal(response.body.children[0].children.length, 1);
+      assert.equal(response.body.deleted.length, 0);
+    });
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -103,6 +103,9 @@ export const createArtist = async (
       isLabelProfile: data?.isLabelProfile ?? false,
       paymentToUserId: data?.paymentToUserId,
       allowDirectMessages: data?.allowDirectMessages ?? false,
+      federatedStreaming: data?.federatedStreaming ?? false,
+      federatedStreamingOptInDate: data?.federatedStreamingOptInDate ?? null,
+      federatedStreamingOptOutDate: data?.federatedStreamingOptOutDate ?? null,
     },
     include: {
       subscriptionTiers: true,


### PR DESCRIPTION
Hello!

With this PR we introduce:

### List of deleted entitites
We are considering:
- artist that opted out
- artists deleted that opted in at some point
- tracks and trackGroups deleted and related to an artist that has been federated at some point

### fromDate filter
A query string to filter the response by date, we are considering updates and creates:
- artists updated or created from given date (included)
- artists with any track or trackgroup updated or created from given date (included)

for the deleted entities we use deletedAt to filter the response

### other
- fix date format to fit Canimus recommended `YYYY-MM-DD`
- add `updated_date` to all entities
