### PR TITLE
feat: add support and purchase links to canimus feed

### DIFF
--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -141,6 +141,8 @@ export default function () {
               deletedAt: null,
             },
           },
+          user: { select: { stripeAccountId: true } },
+          paymentToUser: { select: { stripeAccountId: true } },
         },
       });
 

--- a/src/utils/serialize/artist.ts
+++ b/src/utils/serialize/artist.ts
@@ -125,8 +125,21 @@ export const processSingleArtist = (
 };
 
 export const serializeSingleArtistIntoCanimus = (artist: LocalArtist) => {
-  const artistUrl = join(String(process.env.API_DOMAIN), artist.urlSlug);
+  const artistUrl = new URL(artist.urlSlug, String(process.env.API_DOMAIN))
+    .href;
   const avatarString = artist.avatar?.url.find((u) => u.includes("x600"));
+  const artistLinks = artist.linksJson.map((link: any) => ({
+    name: link.linkLabel,
+    href: link.url,
+    type: link.linkType,
+    rel: "me",
+  }));
+  artistLinks.unshift({
+    name: "Support",
+    href: new URL("support", `${artistUrl}/`).href,
+    type: "Support",
+    rel: "support",
+  });
 
   return {
     type: "artist",
@@ -147,12 +160,8 @@ export const serializeSingleArtistIntoCanimus = (artist: LocalArtist) => {
     },
     summary: artist.shortDescription,
     description: artist.bio,
-    links: artist.linksJson.map((link: any) => ({
-      name: link.linkLabel,
-      href: link.url,
-      type: link.linkType,
-    })),
     updated_date: artist.updatedAt?.toISOString().split("T")[0],
+    links: artistLinks,
     children: artist.trackGroups?.map((trackGroup: TrackGroup) =>
       serializeSingleTrackGroupIntoCanimus(trackGroup, artistUrl, artist.name)
     ),

--- a/src/utils/serialize/artist.ts
+++ b/src/utils/serialize/artist.ts
@@ -41,7 +41,11 @@ interface LocalArtist extends Artist {
     images?: { image: Image }[];
     releases?: { trackGroup: { cover?: TrackGroupCover | null } }[];
   })[];
+  paymentToUser?: {
+    stripeAccountId?: string | null;
+  } | null;
   user?: {
+    stripeAccountId?: string | null;
     currency?: string | null;
     artistLabels?: {
       artist: Artist & {
@@ -134,12 +138,17 @@ export const serializeSingleArtistIntoCanimus = (artist: LocalArtist) => {
     type: link.linkType,
     rel: "me",
   }));
-  artistLinks.unshift({
-    name: "Support",
-    href: new URL("support", `${artistUrl}/`).href,
-    type: "Support",
-    rel: "support",
-  });
+  const artistSupportsPayment = Boolean(
+    artist.paymentToUser?.stripeAccountId ?? artist.user?.stripeAccountId
+  );
+  if (artistSupportsPayment) {
+    artistLinks.unshift({
+      name: "Support",
+      href: new URL("support", `${artistUrl}/`).href,
+      type: "Support",
+      rel: "support",
+    });
+  }
 
   return {
     type: "artist",
@@ -160,10 +169,15 @@ export const serializeSingleArtistIntoCanimus = (artist: LocalArtist) => {
     },
     summary: artist.shortDescription,
     description: artist.bio,
-    updated_date: artist.updatedAt?.toISOString().split("T")[0],
     links: artistLinks,
+    updated_date: artist.updatedAt?.toISOString().split("T")[0],
     children: artist.trackGroups?.map((trackGroup: TrackGroup) =>
-      serializeSingleTrackGroupIntoCanimus(trackGroup, artistUrl, artist.name)
+      serializeSingleTrackGroupIntoCanimus(
+        trackGroup,
+        artistUrl,
+        artist.name,
+        artistSupportsPayment
+      )
     ),
   };
 };

--- a/src/utils/serialize/trackGroup.ts
+++ b/src/utils/serialize/trackGroup.ts
@@ -91,10 +91,24 @@ export const processSingleTrackGroup = (
 export const serializeSingleTrackGroupIntoCanimus = (
   trackGroup: LocalTrackGroup,
   artistUrl: string,
-  artistName: string
+  artistName: string,
+  canBePurchased: boolean
 ) => {
-  const releaseUrl = join(artistUrl, "release", trackGroup.urlSlug);
+  const releaseUrl = `${artistUrl}/release/${trackGroup.urlSlug}`;
   const coverString = trackGroup.cover?.url.find((u) => u.includes("x600"));
+  let links;
+  if (canBePurchased) {
+    // TODO: replace with a standalone buy page once that exists
+    const purchaseUrl = `${releaseUrl}?buy=true`;
+    links = [
+      {
+        name: `Buy ${trackGroup.title} on Mirlo`,
+        href: purchaseUrl,
+        type: "Purchase",
+        rel: "purchase",
+      },
+    ];
+  }
 
   return {
     type: "album",
@@ -113,6 +127,7 @@ export const serializeSingleTrackGroupIntoCanimus = (
           }
         : undefined,
     },
+    links,
     description: trackGroup.about,
     children: trackGroup.tracks?.map((track: CanimusTrack) =>
       serializeSingleTrackIntoCanimus(track, releaseUrl)


### PR DESCRIPTION
Ensure that the canimus feed includes a link to the artist's support page.
Additionally fixes the creation of URLs since `join` as a file path function was modifying all `//` into `/` (even for `http[s]://` which ended up with invalid URLs).

Pending adding some test, waiting to sync up with @MaciAC 's tests for https://github.com/funmusicplace/mirlo/pull/2190