### PR TITLE
fix: avoids add to collection enabled and sending success notif when logged out

### DIFF
--- a/client/src/components/TrackGroup/AddToCollection.tsx
+++ b/client/src/components/TrackGroup/AddToCollection.tsx
@@ -1,14 +1,14 @@
 import { css } from "@emotion/css";
-import Button from "components/common/Button";
-import Modal from "components/common/Modal";
-import React from "react";
-import { useTranslation } from "react-i18next";
-import { useSnackbar } from "state/SnackbarContext";
-import api from "services/api";
-import { useNavigate } from "react-router-dom";
 import { ArtistButton } from "components/Artist/ArtistButtons";
-import { IoAddSharp } from "react-icons/io5";
 import { FixedButton } from "components/common/FixedButton";
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { IoAddSharp } from "react-icons/io5";
+import { Link, useNavigate } from "react-router-dom";
+import api from "services/api";
+import { useAuthContext } from "state/AuthContext";
+import { useSnackbar } from "state/SnackbarContext";
+
 import { bp } from "../../constants";
 
 const AddToCollection: React.FC<{
@@ -17,7 +17,9 @@ const AddToCollection: React.FC<{
 }> = ({ trackGroup, fixed }) => {
   const snackbar = useSnackbar();
   const navigate = useNavigate();
+  const { user } = useAuthContext();
   const { t } = useTranslation("translation", { keyPrefix: "trackGroupCard" });
+  const isLoggedOut = !user;
 
   const purchaseAlbum = React.useCallback(async () => {
     try {
@@ -37,9 +39,21 @@ const AddToCollection: React.FC<{
 
   return (
     <>
+      {isLoggedOut && (
+        <p className="mb-2 text-sm text-(--mi-light-foreground-color)">
+          <Trans
+            t={t}
+            i18nKey="addToCollectionLoggedOut"
+            components={{
+              signupLink: <Link to="/signup" className="underline" />,
+            }}
+          />
+        </p>
+      )}
       {fixed ? (
         <FixedButton
           rounded
+          disabled={isLoggedOut}
           onClick={() => purchaseAlbum()}
           startIcon={<IoAddSharp />}
         >
@@ -48,6 +62,7 @@ const AddToCollection: React.FC<{
       ) : (
         <ArtistButton
           variant="outlined"
+          disabled={isLoggedOut}
           onClick={() => purchaseAlbum()}
           className={css`
             font-size: 1rem !important;

--- a/client/src/components/TrackGroup/BuyTrackGroup.tsx
+++ b/client/src/components/TrackGroup/BuyTrackGroup.tsx
@@ -160,11 +160,13 @@ const BuyTrackGroup: React.FC<{
     if (minPrice === 0 || minPrice === null) {
       return (
         <div className="m-4">
-          <p className="mb-2">
-            {t("addAlbumToCollection", { title: trackGroup.title }) ?? ""}
-          </p>
+          {user && (
+            <p className="mb-2">
+              {t("addAlbumToCollection", { title: trackGroup.title }) ?? ""}
+            </p>
+          )}
           <AddToCollection trackGroup={trackGroup} />{" "}
-          <p className="mt-2">{t("addToCollectionDescription")}</p>
+          {user && <p className="mt-2">{t("addToCollectionDescription")}</p>}
         </div>
       );
     }
@@ -298,11 +300,13 @@ const BuyTrackGroup: React.FC<{
         <hr />
         {(minPrice === 0 || minPrice === null) && (
           <div className="mt-4">
-            <p className="mb-2">
-              {t("addAlbumToCollection", { title: trackGroup.title }) ?? ""}
-            </p>
+            {user && (
+              <p className="mb-2">
+                {t("addAlbumToCollection", { title: trackGroup.title }) ?? ""}
+              </p>
+            )}
             <AddToCollection trackGroup={trackGroup} />{" "}
-            <p className="mt-2">{t("addToCollectionDescription")}</p>
+            {user && <p className="mt-2">{t("addToCollectionDescription")}</p>}
           </div>
         )}
       </div>

--- a/client/src/components/TrackGroup/BuyTrackGroup.tsx
+++ b/client/src/components/TrackGroup/BuyTrackGroup.tsx
@@ -296,16 +296,15 @@ const BuyTrackGroup: React.FC<{
           </>
         )}
         <hr />
-        {minPrice === 0 ||
-          (minPrice === null && (
-            <div className="mt-4">
-              <p className="mb-2">
-                {t("addAlbumToCollection", { title: trackGroup.title }) ?? ""}
-              </p>
-              <AddToCollection trackGroup={trackGroup} />{" "}
-              <p className="mt-2">{t("addToCollectionDescription")}</p>
-            </div>
-          ))}
+        {(minPrice === 0 || minPrice === null) && (
+          <div className="mt-4">
+            <p className="mb-2">
+              {t("addAlbumToCollection", { title: trackGroup.title }) ?? ""}
+            </p>
+            <AddToCollection trackGroup={trackGroup} />{" "}
+            <p className="mt-2">{t("addToCollectionDescription")}</p>
+          </div>
+        )}
       </div>
     </FormProvider>
   );

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -313,6 +313,7 @@
     "price": "Price:",
     "addToCollection": "Add to collection",
     "addToCollectionDescription": "You'll add this free release to your collection.",
+    "addToCollectionLoggedOut": "You can <signupLink>create a Mirlo account</signupLink> to add this release to your music collection.",
     "addAlbumToCollection": "Add {{ title }} to your collection",
     "getDownloadLink": "Get download link in email",
     "email": "Email",


### PR DESCRIPTION
This was hidden before because add to collection button didn't work as it should. But now that it does I realized it allowed me to "add to collection" even when logged out and even threw a "success" notif (which makes no sense) so I disabled it when logged out and added a message as an incentive to join Mirlo to add to your music collection.