### PR TITLE
fix: adjust social streaming error logging to real exceptional cases

### DIFF
--- a/src/routers/v1/tracks/{id}/stream/external/{segment}.ts
+++ b/src/routers/v1/tracks/{id}/stream/external/{segment}.ts
@@ -138,7 +138,11 @@ export default function () {
         await fetchFile(res, track.audio.id, segment);
       }
     } catch (e) {
-      console.error(e);
+      if (e instanceof AppError) {
+        log.info(e);
+      } else {
+        log.error(e);
+      }
       return next(e);
     }
   }


### PR DESCRIPTION
Fixes #2167 by only logging errors on exceptional situations