### PR TITLE
fix: clarify the coauthor toggle impact on album page

### DIFF
--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -1224,7 +1224,7 @@
     "recommendationError": "Error managing recommendation",
     "remove": "Remove",
     "cancel": "Cancel",
-    "coAuthorCheck": "List them in the track listing, like a featured artist or as a secondary main artist",
+    "coAuthorCheck": "Display this artist's name next to the track title on the release page (as a featured guest or a secondary main artist)",
     "removeArtist": "Remove this artist",
     "moreTrackDetails": "More track details",
     "saveDraft": "Save draft",


### PR DESCRIPTION
It hit me that what this button does is not clear. The previous wording _felt like metadata_ but you couldn't really tell that it's also impacting the look of your album page (typically : making your main artist name appear next to every song when it's already in the title).