### PR TITLE
chore: increase playtoken expiry for federated streaming

### DIFF
--- a/src/routers/v1/tracks/{id}/stream/external/{segment}.ts
+++ b/src/routers/v1/tracks/{id}/stream/external/{segment}.ts
@@ -92,7 +92,7 @@ export default function () {
           const payload = { song: id, userid };
           log.debug("Generate playtoken:", payload);
           const playToken = jwt.sign(payload, jwt_secret, {
-            expiresIn: "4h",
+            expiresIn: "2d",
           });
           res.setHeader(socialMusic.HEADER_PLAYTOKEN, playToken);
         } else {


### PR DESCRIPTION
Related to https://codeberg.org/fairplayer/fairplayer/issues/409 - pausing a Mirlo song in Fairplayer to continue listening the next day causes errors because the playtoken has expired. As a mitigation we make the token longer, while we figure out a better way to gracefully handle this at the client's end.

(In the original PR @simonv3 and I briefly discussed token durations but I did not consider that edge case https://github.com/funmusicplace/mirlo/pull/2128#discussion_r3277982924 so I went for too short).