### PR TITLE
Improve accessibility of search results

### DIFF
--- a/client/src/components/SearchResults.tsx
+++ b/client/src/components/SearchResults.tsx
@@ -217,7 +217,7 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
               </ButtonLink>
             </SpaceBetweenDiv>
           )}
-          <TrackgroupGrid gridNumber="4" as="ul" role="list">
+          <TrackgroupGrid gridNumber="4" as="ul">
             {newReleases?.results?.map((trackGroup) => (
               <ArtistTrackGroup
                 key={trackGroup.id}
@@ -266,7 +266,7 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
               </ButtonLink>
             </SpaceBetweenDiv>
           )}
-          <TrackgroupGrid gridNumber="4" as="ul" role="list">
+          <TrackgroupGrid gridNumber="4" as="ul">
             {tracks?.results?.map((track) => (
               <CollectionPurchaseSquare
                 trackGroup={track.trackGroup}

--- a/client/src/components/SearchResults.tsx
+++ b/client/src/components/SearchResults.tsx
@@ -8,7 +8,6 @@ import {
 } from "queries";
 import { queryTags } from "queries/tags";
 import { queryTracks } from "queries/tracks";
-import { useId } from "react";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { FaChevronRight } from "react-icons/fa";
@@ -80,9 +79,6 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
     })
   );
 
-  const id = useId();
-  const headingId = `${id}-recent-releases`;
-
   return (
     <div
       className={css`
@@ -105,7 +101,7 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h2 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading">
             {search ? t("tagSearchResults", { search }) : t("tags")}
           </h2>
         </WidthContainer>
@@ -147,7 +143,7 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h2 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading">
             {search ? t("artistsForSearch", { search }) : t("artists")}
           </h2>
         </WidthContainer>
@@ -193,7 +189,7 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h2 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading">
             {search ? t("releasesForSearch", { search }) : t("recentReleases")}
           </h2>
         </WidthContainer>
@@ -221,12 +217,7 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
               </ButtonLink>
             </SpaceBetweenDiv>
           )}
-          <TrackgroupGrid
-            gridNumber="4"
-            as="ul"
-            aria-labelledby={headingId}
-            role="list"
-          >
+          <TrackgroupGrid gridNumber="4" as="ul" role="list">
             {newReleases?.results?.map((trackGroup) => (
               <ArtistTrackGroup
                 key={trackGroup.id}
@@ -247,7 +238,7 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h2 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading">
             {search ? t("tracksForSearch", { search }) : t("recentTracks")}
           </h2>
         </WidthContainer>
@@ -275,12 +266,7 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
               </ButtonLink>
             </SpaceBetweenDiv>
           )}
-          <TrackgroupGrid
-            gridNumber="4"
-            as="ul"
-            aria-labelledby={headingId}
-            role="list"
-          >
+          <TrackgroupGrid gridNumber="4" as="ul" role="list">
             {tracks?.results?.map((track) => (
               <CollectionPurchaseSquare
                 trackGroup={track.trackGroup}
@@ -300,7 +286,7 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h2 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading">
             {search ? t("labelsForSearch", { search }) : t("labels")}
           </h2>
         </WidthContainer>

--- a/client/src/components/SearchResults.tsx
+++ b/client/src/components/SearchResults.tsx
@@ -91,7 +91,6 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
       `}
     >
       <h1>{t("searchResults", { search })}</h1>
-      {/* Tags Section */}
       <SectionHeader>
         <WidthContainer
           variant="big"

--- a/client/src/components/SearchResults.tsx
+++ b/client/src/components/SearchResults.tsx
@@ -94,6 +94,7 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
         }
       `}
     >
+      <h1>{t("searchResults", { search })}</h1>
       {/* Tags Section */}
       <SectionHeader>
         <WidthContainer
@@ -104,9 +105,9 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h1 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading" id={headingId}>
             {search ? t("tagSearchResults", { search }) : t("tags")}
-          </h1>
+          </h2>
         </WidthContainer>
       </SectionHeader>
       <WidthContainer variant="big" justify="center">
@@ -146,9 +147,9 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h1 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading" id={headingId}>
             {search ? t("artistsForSearch", { search }) : t("artists")}
-          </h1>
+          </h2>
         </WidthContainer>
       </SectionHeader>
       <WidthContainer variant="big" justify="center">
@@ -192,9 +193,9 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h1 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading" id={headingId}>
             {search ? t("releasesForSearch", { search }) : t("recentReleases")}
-          </h1>
+          </h2>
         </WidthContainer>
       </SectionHeader>
       <WidthContainer variant="big" justify="center">
@@ -246,9 +247,9 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h1 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading" id={headingId}>
             {search ? t("tracksForSearch", { search }) : t("recentTracks")}
-          </h1>
+          </h2>
         </WidthContainer>
       </SectionHeader>
       <WidthContainer variant="big" justify="center">
@@ -299,9 +300,9 @@ const SearchResults: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h1 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading" id={headingId}>
             {search ? t("labelsForSearch", { search }) : t("labels")}
-          </h1>
+          </h2>
         </WidthContainer>
       </SectionHeader>
       <WidthContainer variant="big" justify="center">

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -69,7 +69,8 @@
     "artists": "Artists",
     "releasesForSearch": "Releases for '{{ search }}'",
     "labelsForSearch": "Labels for '{{ search }}'",
-    "labels": "Labels"
+    "labels": "Labels",
+    "searchResults": "Search results for '{{ search }}'"
   },
   "cookies": {
     "weUseCookies": "We use cookies to keep you logged in and to maintain your music queue.",


### PR DESCRIPTION
- One `h1` on search results page.
- Remove duplicate heading `id`'s and `aria-describedby` references to them.
- Remove redundant `role="list"` on `ul` elements