### PR TITLE
Improve accessibility of navigation

### DIFF
--- a/client/cypress/e2e/skip-links.cy.ts
+++ b/client/cypress/e2e/skip-links.cy.ts
@@ -1,0 +1,102 @@
+import { TRACK_GROUP_EXAMPLE } from "../../../client/test/mocks";
+
+const trackId = 1;
+const artistSlug = "example-artist";
+
+const featuredRelease = {
+  ...TRACK_GROUP_EXAMPLE,
+  artist: { ...TRACK_GROUP_EXAMPLE.artist, urlSlug: artistSlug },
+};
+
+const track = {
+  id: trackId,
+  title: "Example Track",
+  order: 1,
+  trackGroupId: TRACK_GROUP_EXAMPLE.id,
+  trackGroup: featuredRelease,
+  isPreview: true,
+  audio: {
+    id: "audio-1",
+    duration: 60,
+    uploadState: "SUCCESS",
+  },
+  trackArtists: [],
+  license: null,
+};
+
+describe("skip links", { screenshotOnRunFailure: false }, () => {
+  beforeEach(() => {
+    cy.intercept("GET", `/v1/tracks/${trackId}`, {
+      statusCode: 200,
+      body: { result: track },
+    });
+
+    cy.visit("/", {
+      onBeforeLoad(window) {
+        window.localStorage.removeItem("nomadState");
+      },
+    });
+  });
+
+  it("has a skip to main content link as the first link", () => {
+    cy.get("a").first().should("have.text", "Skip to main content");
+  });
+
+  it("has a valid target for the skip to main content link", () => {
+    cy.get("a")
+      .first()
+      .then(($element) => {
+        const idFromHref = $element.attr("href");
+        cy.get(idFromHref);
+      });
+  });
+
+  it("has a skip to audio player link as the second link when player is visible", () => {
+    cy.visit("/", {
+      onBeforeLoad(window) {
+        window.localStorage.setItem(
+          "nomadState",
+          JSON.stringify({
+            playerQueueIds: [trackId],
+            currentlyPlayingIndex: 0,
+          })
+        );
+      },
+    });
+    cy.get("a").first().next().should("have.text", "Skip to audio player");
+  });
+
+  it("doesn't have a skip to audio player link when player is not visible", () => {
+    cy.get("a").eq(1).should("not.have.text", "Skip to audio player");
+  });
+
+  it("has a valid target for the skip to audio player link", () => {
+    cy.visit("/", {
+      onBeforeLoad(window) {
+        window.localStorage.setItem(
+          "nomadState",
+          JSON.stringify({
+            playerQueueIds: [trackId],
+            currentlyPlayingIndex: 0,
+          })
+        );
+      },
+    });
+    cy.get("a")
+      .first()
+      .next()
+      .then(($element) => {
+        const idFromHref = $element.attr("href");
+        cy.get(idFromHref);
+      });
+  });
+
+  it("visually hides skip links unless they are focused", () => {
+    cy.get("a").first().parent().should("have.class", "sr-only");
+    cy.get("a").first().focus();
+    cy.get("a")
+      .first()
+      .parent()
+      .should("have.class", "focus-within:not-sr-only");
+  });
+});

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -102,7 +102,7 @@ function App() {
           >
             <ManageArtistButtons />
             <div className="w-full flex flex-col min-h-screen">
-              <div
+              <main
                 className={css`
                   margin: 0 auto;
                   width: 100%;
@@ -115,7 +115,7 @@ function App() {
                 `}
               >
                 <Outlet />
-              </div>
+              </main>
               <Footer />
             </div>
           </div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,23 +11,28 @@ import CookieDisclaimer from "components/CookieDisclaimer";
 import { Footer } from "components/Footer";
 import ManageArtistButtons from "components/ManageArtist/ManageArtistButtons";
 import Player from "components/Player";
+import useCurrentTrackHook from "components/Player/useCurrentTrackHook";
 import ScrollToTop from "components/ScrollToTop";
 import { useContext, useEffect } from "react";
 import { Outlet, useLocation, useSearchParams } from "react-router-dom";
 import { useAuthContext } from "state/AuthContext";
 import SnackbarContext, { useSnackbar } from "state/SnackbarContext";
 import { useGlobalPlayerSyncIntegration } from "utils/playerSync";
+import { isEmpty } from "lodash";
+import { useTranslation } from "react-i18next";
 
 import Header from "./components/Header/Header";
 import { bp } from "./constants";
 
 function App() {
+  const { t } = useTranslation("translation", { keyPrefix: "app" });
   const { isDisplayed } = useContext(SnackbarContext);
   useGlobalPlayerSyncIntegration();
   const location = useLocation();
   const snackbar = useSnackbar();
   const [search, setSearch] = useSearchParams();
   const { user } = useAuthContext();
+  const { currentTrack } = useCurrentTrackHook();
 
   const isWidget = location.pathname.includes("widget");
 
@@ -57,12 +62,7 @@ function App() {
     }
   }, [search]);
 
-  useEffect(() => {
-    const h1 = document.querySelector("h1");
-    const tabIndex = h1?.getAttribute("tabindex");
-    h1?.setAttribute("tabindex", tabIndex ?? "-1");
-    h1?.focus();
-  }, [location]);
+  const isPlayerVisible = !(!currentTrack || isEmpty(currentTrack.trackGroup));
 
   return (
     <>
@@ -76,7 +76,10 @@ function App() {
         <>
           {/* <Snackbar /> */}
           {isDisplayed && <Snackbar />}
-
+          <div className="sr-only focus-within:not-sr-only flex gap-4 m-1!">
+            <a href="#main-content">{t("skipToMainContent")}</a>
+            {isPlayerVisible && <a href="#player">{t("skipToAudioPlayer")}</a>}
+          </div>
           <Header />
           <ReloadPrompt />
           <FailedSubscriptionBanner />
@@ -113,6 +116,7 @@ function App() {
                   ${user ? "display: flex;" : ""}
                   flex-grow: 1;
                 `}
+                id="main-content"
               >
                 <Outlet />
               </main>

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -50,25 +50,29 @@ export const Footer = () => {
               }}
             />
           </p>
-          <p
-            className={css`
-              margin-bottom: 1rem;
-            `}
-          >
-            <Trans
-              t={t}
-              i18nKey="aboutUs"
-              components={{
-                documentation: <Link to="https://docs.mirlo.space"></Link>,
-                about: <a href="https://docs.mirlo.space"></a>,
-                terms: <Link to="/pages/terms"></Link>,
-                privacy: <Link to="/pages/privacy"></Link>,
-                cookie: <Link to="/pages/cookie-policy"></Link>,
-                contact: <a href="mailto:hi@mirlo.space"></a>,
-                content: <Link to="/pages/content-policy"></Link>,
-              }}
-            />
-          </p>
+          <ul className="flex gap-4 justify-center flex-wrap mbe-4">
+            <li>
+              <a href="https://docs.mirlo.space">{t("about")}</a>
+            </li>
+            <li>
+              <a href="https://docs.mirlo.space">{t("documentation")}</a>
+            </li>
+            <li>
+              <Link to="/pages/terms">{t("terms")}</Link>
+            </li>
+            <li>
+              <Link to="/pages/privacy">{t("privacy")}</Link>
+            </li>
+            <li>
+              <Link to="/pages/cookie-policy">{t("cookies")}</Link>
+            </li>
+            <li>
+              <Link to="/pages/content-policy">{t("content")}</Link>
+            </li>
+            <li>
+              <a href="mailto:hi@mirlo.space">{t("contact")}</a>
+            </li>
+          </ul>
           <ul className="flex justify-center gap-4 pb-1">
             <li>
               <a

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -12,7 +12,7 @@ export const Footer = () => {
   const { t } = useTranslation("translation", { keyPrefix: "footer" });
 
   return (
-    <div
+    <footer
       className={css`
         text-align: center;
         display: block;
@@ -97,6 +97,6 @@ export const Footer = () => {
           </p>
         </div>
       </WidthContainer>
-    </div>
+    </footer>
   );
 };

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -69,32 +69,38 @@ export const Footer = () => {
               }}
             />
           </p>
-          <p className="flex justify-center gap-1 pb-1">
-            <a
-              href="https://instagram.com/mirlo.space"
-              title="Instagram"
-              className="text-2xl"
-              aria-label={`${t("socialInstagram", { username: "@mirlo.space" })}`}
-            >
-              <FaInstagram aria-hidden />
-            </a>
-            <a
-              href="https://musician.social/@mirlo"
-              title="Mastodon"
-              className="text-2xl"
-              aria-label={`${t("socialMastodon", { username: "@mirlo@musician.social" })}`}
-            >
-              <FaMastodon aria-hidden />
-            </a>
-            <a
-              href="https://bsky.app/profile/mirlo.space"
-              title="BlueSky"
-              className="text-2xl"
-              aria-label={`${t("socialBlueSky", { username: "mirlo.bsky.social" })}`}
-            >
-              <FaBluesky />
-            </a>
-          </p>
+          <ul className="flex justify-center gap-4 pb-1">
+            <li>
+              <a
+                href="https://instagram.com/mirlo.space"
+                title="Instagram"
+                className="text-2xl"
+                aria-label="Instagram"
+              >
+                <FaInstagram aria-hidden />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://musician.social/@mirlo"
+                title="Mastodon"
+                className="text-2xl"
+                aria-label="Mastodon"
+              >
+                <FaMastodon aria-hidden />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://bsky.app/profile/mirlo.space"
+                title="Bluesky"
+                className="text-2xl"
+                aria-label="Bluesky"
+              >
+                <FaBluesky aria-hidden />
+              </a>
+            </li>
+          </ul>
         </div>
       </WidthContainer>
     </footer>

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -232,7 +232,7 @@ const Header = () => {
           {isLoggedIn && (
             <Button
               aria-controls={menuDialogId}
-              aria-label={t("openMenu", { keyPrefix: "headerMenu" })}
+              aria-label={t("menu", { keyPrefix: "headerMenu" })}
               data-cy="user-nav"
               // @ts-ignore React doesn't support Invoker Commands API
               command="show-modal"
@@ -254,7 +254,7 @@ const Header = () => {
               }
               variant="transparent"
               className={menuButtonOverride}
-              title={t("openMenu", { keyPrefix: "headerMenu" })}
+              title={t("menu", { keyPrefix: "headerMenu" })}
             />
           )}
           {isLoggedIn &&

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -173,7 +173,6 @@ const Header = () => {
   const { data: instanceArtist } = useQuery(queryInstanceArtist());
 
   const menuRef = useRef<HTMLDialogElement | null>(null);
-  const menuButtonId = "menu-button";
   const menuDialogId = "menu-dialog";
 
   const openMenu = () => {
@@ -237,7 +236,6 @@ const Header = () => {
               // @ts-ignore React doesn't support Invoker Commands API
               command="show-modal"
               commandfor={menuDialogId}
-              id={menuButtonId}
               onClick={() => openMenu()}
               startIcon={
                 <svg
@@ -260,7 +258,6 @@ const Header = () => {
           {isLoggedIn &&
             createPortal(
               <Menu
-                buttonId={menuButtonId}
                 dialogId={menuDialogId}
                 isAdmin={user.isAdmin}
                 isLabelAccount={user.isLabelAccount}

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -231,6 +231,7 @@ const Header = () => {
           {isLoggedIn && (
             <Button
               aria-controls={menuDialogId}
+              aria-haspopup="dialog"
               aria-label={t("menu", { keyPrefix: "headerMenu" })}
               data-cy="user-nav"
               // @ts-ignore React doesn't support Invoker Commands API

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -21,7 +21,7 @@ import { bp } from "../../constants";
 
 import HeaderSearch from "./HeaderSearch";
 
-const HeaderWrapper = styled.div<{
+const HeaderWrapper = styled.header<{
   hasBackground?: boolean;
   transparent?: boolean;
   artistId?: boolean;

--- a/client/src/components/Header/Menu.tsx
+++ b/client/src/components/Header/Menu.tsx
@@ -15,13 +15,12 @@ import { getArtistManageUrl } from "utils/artist";
 const Menu = forwardRef<
   HTMLDialogElement,
   {
-    buttonId: string;
     dialogId: string;
     isAdmin: boolean;
     isLabelAccount: boolean;
     onClose: () => void;
   }
->(({ buttonId, dialogId, isAdmin, isLabelAccount, onClose }, ref) => {
+>(({ dialogId, isAdmin, isLabelAccount, onClose }, ref) => {
   const { t } = useTranslation("translation", { keyPrefix: "headerMenu" });
 
   const {
@@ -54,7 +53,7 @@ const Menu = forwardRef<
 
   return (
     <dialog
-      aria-labelledby={buttonId}
+      aria-label={t("menu")}
       className="inset-s-0 sm:inset-s-auto sm:inset-e-0 max-w-[100vw] max-h-full w-screen sm:w-[300px] h-full backdrop:bg-[rgba(0,0,0,.5)]"
       closedby="any"
       data-nosnippet

--- a/client/src/components/Header/Menu.tsx
+++ b/client/src/components/Header/Menu.tsx
@@ -73,7 +73,7 @@ const Menu = forwardRef<
       {/* This div can be removed once `closedby` is baseline*/}
       <div className="flex flex-col h-full p-[1rem]">
         <Button
-          aria-label="Close menu"
+          aria-label={t("close", { keyPrefix: "common" })}
           autoFocus
           className="self-end border-none bg-transparent! text-black! hover:bg-transparent! hover:no-underline focus:bg-transparent! focus:no-underline [&_svg]:fill-black!"
           // @ts-ignore React doesn't support Invoker Commands API

--- a/client/src/components/Header/Menu.tsx
+++ b/client/src/components/Header/Menu.tsx
@@ -83,7 +83,7 @@ const Menu = forwardRef<
           onlyIcon
           startIcon={<FaTimes />}
         />
-        <nav className="flex-auto">
+        <nav aria-label={t("main")} className="flex-auto">
           <ul>
             <li>
               <MenuLink onClick={onClose} to="/profile/notifications">

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -141,7 +141,7 @@
     "viewLabelPage": "View {{labelName}} page",
     "fulfillment": "Order fulfillment",
     "viewSalesPage": "View sales",
-    "openMenu": "Open menu"
+    "menu": "Menu"
   },
   "headerSearch": {
     "searchSuggestions": "Search suggestions:",

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -1,4 +1,8 @@
 {
+  "app": {
+    "skipToMainContent": "Skip to main content",
+    "skipToAudioPlayer": "Skip to audio player"
+  },
   "signUp": {
     "hasRegistered": "Cool! We've sent you an e-mail to confirm your account. Click on the link in it to proceed.",
     "register": "Sign up",

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -1450,11 +1450,7 @@
   },
   "footer": {
     "getInTouch": "If you'd like to get in touch with Mirlo, join <discord>our Discord</discord>, <email>email us</email>, or check out <github>our Github</github>.",
-    "aboutUs": "<about>About us</about>, <documentation>Documentation</documentation>, <terms>Terms and conditions</terms>, <privacy>Privacy</privacy>, <cookie>Our use of cookies</cookie>, <content>Content policy</content>, <contact>Contact us</contact>",
-    "socialInstagram": "{{username}} on Instagram",
-    "socialMastodon": "{{username}} on Mastodon",
-    "socialX": "{{username}} on X",
-    "socialBlueSky": "{{username}} on BlueSky"
+    "aboutUs": "<about>About us</about>, <documentation>Documentation</documentation>, <terms>Terms and conditions</terms>, <privacy>Privacy</privacy>, <cookie>Our use of cookies</cookie>, <content>Content policy</content>, <contact>Contact us</contact>"
   },
   "notifications": {
     "notifications": "Notifications",

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -141,7 +141,8 @@
     "viewLabelPage": "View {{labelName}} page",
     "fulfillment": "Order fulfillment",
     "viewSalesPage": "View sales",
-    "menu": "Menu"
+    "menu": "Menu",
+    "main": "Main"
   },
   "headerSearch": {
     "searchSuggestions": "Search suggestions:",

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -1836,7 +1836,8 @@
     "discardDraft": "Discard",
     "fieldsRestored_one": "{{count}} field restored: {{fields}}",
     "fieldsRestored_other": "{{count}} fields restored: {{fields}}",
-    "restoredFromDraft": "Restored from draft"
+    "restoredFromDraft": "Restored from draft",
+    "close": "Close"
   },
   "uploadPanel": {
     "uploadsInProgress_one": "{{count}} upload in progress",

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -1450,7 +1450,13 @@
   },
   "footer": {
     "getInTouch": "If you'd like to get in touch with Mirlo, join <discord>our Discord</discord>, <email>email us</email>, or check out <github>our Github</github>.",
-    "aboutUs": "<about>About us</about>, <documentation>Documentation</documentation>, <terms>Terms and conditions</terms>, <privacy>Privacy</privacy>, <cookie>Our use of cookies</cookie>, <content>Content policy</content>, <contact>Contact us</contact>"
+    "about": "About us",
+    "documentation": "Documentation",
+    "terms": "Terms and conditions",
+    "privacy": "Privacy",
+    "cookies": "Our use of cookies",
+    "content": "Content policy",
+    "contact": "Contact us"
   },
   "notifications": {
     "notifications": "Notifications",

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,7 @@ pkgs.mkShell {
 
 	shellHook = ''
 		export PATH="$PWD/node_modules/.bin/:$PATH"
+		export DATABASE_URL="postgresql://nomads:nomads@localhost:5434/nomads?schema=public"
 		export CYPRESS_INSTALL_BINARY=0
 		export CYPRESS_RUN_BINARY=${pkgs.cypress}/bin/Cypress
 		export PKG_CONFIG_PATH="${pkgs.openssl}/lib/pkgconfig"

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ pkgs.mkShell {
 		nodejs_22
 		corepack
 		cypress
-		prisma
+		prisma_6
 		openssl
 	];
 
@@ -13,10 +13,10 @@ pkgs.mkShell {
 		export CYPRESS_INSTALL_BINARY=0
 		export CYPRESS_RUN_BINARY=${pkgs.cypress}/bin/Cypress
 		export PKG_CONFIG_PATH="${pkgs.openssl}/lib/pkgconfig"
-		export PRISMA_SCHEMA_ENGINE_BINARY="${pkgs.prisma-engines}/bin/schema-engine"
-		export PRISMA_QUERY_ENGINE_BINARY="${pkgs.prisma-engines}/bin/query-engine"
-		export PRISMA_QUERY_ENGINE_LIBRARY="${pkgs.prisma-engines}/lib/libquery_engine.node"
-		export PRISMA_FMT_BINARY="${pkgs.prisma-engines}/bin/prisma-fmt"
+		export PRISMA_SCHEMA_ENGINE_BINARY="${pkgs.prisma-engines_6}/bin/schema-engine"
+		export PRISMA_QUERY_ENGINE_BINARY="${pkgs.prisma-engines_6}/bin/query-engine"
+		export PRISMA_QUERY_ENGINE_LIBRARY="${pkgs.prisma-engines_6}/lib/libquery_engine.node"
+		export PRISMA_FMT_BINARY="${pkgs.prisma-engines_6}/bin/prisma-fmt"
 	'';
 }
 


### PR DESCRIPTION
- Improve menu button accessible name. Change from "Open menu" to "Menu" so it's more obvious for people using voice control.
- Menu dialog label separate from now invisible button label. Instead of using `aria-labelledby` to reference the `aria-label` (non-visual label) of the menu button, we give the dialog its own explicit `aria-label`.
- Translate close menu button to be the succinct and most obvious "Close".
- Menu button aria-haspopup. Helps make the menu button behavior more obvious, as most screenreaders will now announce something like "Menu, button, opens dialog"
- Label main navigation. Now when on an artist page where there is Artist navigation, it's explicitly distinguished from Main navigation.
- Use header, main, footer to establish landmarks. Now people using screenreaders can cycle through these landmarks to quickly get around a page.
- Footer social links. Now semantically in a list for people using screenreaders and with simplified labels for people using voice control.
- Footer legal and docs links. Now semantically in a list for people using screenreaders.
- Skip links. Removed the h1 focus feature and replaced with the more common "skip to main content" link, as well as a "skip to audio player" link which is especially handy for people using keyboards who don't have access to landmarks like people using screenreaders do.