### PR TITLE
Improve accessibility of home page

### DIFF
--- a/client/src/components/Home/HomeReleases.tsx
+++ b/client/src/components/Home/HomeReleases.tsx
@@ -4,9 +4,9 @@ import TrackgroupGrid from "components/common/TrackgroupGrid";
 import { queryTrackGroups } from "queries";
 import { queryTags } from "queries/tags";
 import { useTranslation } from "react-i18next";
-import { FaChevronRight, FaRss } from "react-icons/fa";
+import { FaRedoAlt, FaChevronRight, FaRss } from "react-icons/fa";
 import { bp } from "../../constants";
-import { ButtonAnchor, ButtonLink } from "components/common/Button";
+import { Button, ButtonAnchor, ButtonLink } from "components/common/Button";
 import WidthContainer from "components/common/WidthContainer";
 import { SectionHeader } from "components/Home/Home";
 import TrackGroupPills from "components/TrackGroup/TrackGroupPills";
@@ -36,8 +36,8 @@ const HomeReleases = () => {
     })
   );
 
-  const { data: newReleases } = useQuery(
-    queryTrackGroups({
+  const { data: newReleases, refetch } = useQuery({
+    ...queryTrackGroups({
       skip: 0,
       take: 8,
       orderBy: "random",
@@ -45,8 +45,9 @@ const HomeReleases = () => {
       title: undefined,
       isReleased: "released",
       license: undefined,
-    })
-  );
+    }),
+    refetchOnWindowFocus: false,
+  });
 
   const { data: popularReleases } = useQuery(
     queryTopSoldTrackGroups({
@@ -113,10 +114,7 @@ const HomeReleases = () => {
           <WidthContainer
             variant="big"
             justify="space-between"
-            className={css`
-              flex-direction: row;
-              display: flex;
-            `}
+            className="flex items-center"
           >
             <h3 className="h5 section-header__heading">
               {t("recentReleases")}
@@ -130,6 +128,13 @@ const HomeReleases = () => {
                 }
               `}
             >
+              <Button
+                onClick={() => refetch()}
+                startIcon={<FaRedoAlt />}
+                variant="transparent"
+              >
+                {t("refreshReleases", { keyPrefix: "home" })}
+              </Button>
               <ButtonAnchor
                 aria-label={t("rssFeed")}
                 title={t("rssFeed")}

--- a/client/src/components/Home/HomeReleases.tsx
+++ b/client/src/components/Home/HomeReleases.tsx
@@ -1,17 +1,20 @@
+import { SplashTitle } from "components/Home/Splash";
+import { css } from "@emotion/css";
+import TrackgroupGrid from "components/common/TrackgroupGrid";
+import { queryTrackGroups } from "queries";
+import { queryTags } from "queries/tags";
+import { useTranslation } from "react-i18next";
+import { FaChevronRight, FaRss } from "react-icons/fa";
+import { bp } from "../../constants";
+import { ButtonAnchor, ButtonLink } from "components/common/Button";
+import WidthContainer from "components/common/WidthContainer";
+import { SectionHeader } from "components/Home/Home";
+import TrackGroupPills from "components/TrackGroup/TrackGroupPills";
 import styled from "@emotion/styled";
 import { useQuery } from "@tanstack/react-query";
 import ArtistTrackGroup from "components/Artist/ArtistTrackGroup";
-import { ButtonLink } from "components/common/Button";
-import TrackgroupGrid from "components/common/TrackgroupGrid";
-import Releases from "components/Releases";
 import { queryTopSoldTrackGroups } from "queries";
-import { useTranslation } from "react-i18next";
-import { FaChevronRight } from "react-icons/fa";
-
-import WidthContainer from "../common/WidthContainer";
-
-import { SectionHeader } from "./Home";
-import HomeFeaturedArtists from "./HomeFeaturedArtists";
+import HomeFeaturedArtists from "components/Home/HomeFeaturedArtists";
 
 const futureReleasesPageSize = 6;
 
@@ -26,6 +29,25 @@ const PopularReleasesSection = styled.div`
 const HomeReleases = () => {
   const { t } = useTranslation("translation", { keyPrefix: "releases" });
 
+  const { data: tags } = useQuery(
+    queryTags({
+      orderBy: "count",
+      take: 24,
+    })
+  );
+
+  const { data: newReleases } = useQuery(
+    queryTrackGroups({
+      skip: 0,
+      take: 8,
+      orderBy: "random",
+      tag: undefined,
+      title: undefined,
+      isReleased: "released",
+      license: undefined,
+    })
+  );
+
   const { data: popularReleases } = useQuery(
     queryTopSoldTrackGroups({
       skip: 0,
@@ -36,7 +58,124 @@ const HomeReleases = () => {
 
   return (
     <div className="w-full">
-      <Releases limit={8} />
+      <div
+        className={css`
+          padding: 2rem 0;
+
+          @media screen and (max-width: ${bp.medium}px) {
+            margin-bottom: 0rem;
+          }
+        `}
+      >
+        <SectionHeader
+          className={css`
+            background-color: var(--mi-white);
+          `}
+        >
+          <WidthContainer variant="big">
+            <SplashTitle as="h2" className="mbe-8! mx-2">
+              {t("exploreMusic", { keyPrefix: "home" })}
+            </SplashTitle>
+            <h3 className="h5 section-header__heading">{t("popularTags")}</h3>
+            <div
+              className={css`
+                margin: 0 0.5rem;
+              `}
+            >
+              <TrackGroupPills tags={tags?.results.map((tag) => tag.tag)} />
+            </div>
+            <div
+              className={css`
+                display: flex;
+                justify-content: flex-end;
+
+                @media screen and (max-width: ${bp.medium}px) {
+                  padding: var(--mi-side-paddings-xsmall);
+                }
+              `}
+            >
+              <ButtonLink
+                to="/tags"
+                wrap
+                className={css`
+                  margin-top: 0.25rem;
+                `}
+                variant="outlined"
+                endIcon={<FaChevronRight />}
+              >
+                {t("browseTags")}
+              </ButtonLink>
+            </div>
+          </WidthContainer>
+        </SectionHeader>
+
+        <SectionHeader>
+          <WidthContainer
+            variant="big"
+            justify="space-between"
+            className={css`
+              flex-direction: row;
+              display: flex;
+            `}
+          >
+            <h3 className="h5 section-header__heading">
+              {t("recentReleases")}
+            </h3>
+            <div
+              className={css`
+                display: flex;
+                gap: 0.75rem;
+                @media screen and (max-width: ${bp.medium}px) {
+                  padding: var(--mi-side-paddings-xsmall);
+                }
+              `}
+            >
+              <ButtonAnchor
+                aria-label={t("rssFeed")}
+                title={t("rssFeed")}
+                target="_blank"
+                href={`${import.meta.env.VITE_API_DOMAIN}/v1/trackGroups&released=released&format=rss`}
+                rel="noreferrer"
+                onlyIcon
+                smallIcon
+                className={css`
+                  margin-top: 0.25rem;
+                `}
+                startIcon={<FaRss />}
+              />
+            </div>
+          </WidthContainer>
+        </SectionHeader>
+
+        <div
+          className={css`
+            padding-top: 0.25rem;
+          `}
+        >
+          <WidthContainer variant="big" justify="center">
+            <div
+              className={css`
+                display: flex;
+                width: 100%;
+                flex-direction: row;
+                flex-wrap: wrap;
+                padding: var(--mi-side-paddings-xsmall);
+              `}
+            >
+              <TrackgroupGrid gridNumber="4" as="ul">
+                {newReleases?.results?.map((trackGroup) => (
+                  <ArtistTrackGroup
+                    key={trackGroup.id}
+                    trackGroup={trackGroup}
+                    as="li"
+                    showArtist
+                  />
+                ))}
+              </TrackgroupGrid>
+            </div>
+          </WidthContainer>
+        </div>
+      </div>
 
       <WidthContainer
         variant="big"
@@ -60,20 +199,15 @@ const HomeReleases = () => {
               justify="space-between"
               className="flex flex-row"
             >
-              <h1 className="h5 section-header__heading" id="popular-releases">
+              <h3 className="h5 section-header__heading">
                 {t("popularReleases")}
-              </h1>
+              </h3>
             </WidthContainer>
           </SectionHeader>
           <div className="pt-1">
             <WidthContainer variant="big" justify="center">
               <div className="flex w-full flex-row flex-wrap p-[var(--mi-side-paddings-xsmall)]">
-                <TrackgroupGrid
-                  gridNumber="6"
-                  as="ul"
-                  aria-labelledby="popular-releases"
-                  role="list"
-                >
+                <TrackgroupGrid gridNumber="6" as="ul">
                   {popularReleases?.results?.map((trackGroup) => (
                     <ArtistTrackGroup
                       key={trackGroup.id}

--- a/client/src/components/Home/Splash.tsx
+++ b/client/src/components/Home/Splash.tsx
@@ -58,20 +58,21 @@ export const SplashButtonWrapper = styled.div`
 const ParallexObjectWrapper = styled.div`
   background-size: contain;
   background-repeat: no-repeat;
+  position: absolute;
 `;
 
 const Splash = () => {
   const sceneEl = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
-    if (sceneEl.current) {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+    if (sceneEl.current && !prefersReducedMotion) {
       const parallaxInstance = new Parallax(sceneEl.current, {
         relativeInput: true,
         hoverOnly: true,
       });
-
-      parallaxInstance.enable();
-
       return () => parallaxInstance.disable();
     }
   }, []);

--- a/client/src/components/Home/Splash.tsx
+++ b/client/src/components/Home/Splash.tsx
@@ -136,9 +136,8 @@ const Splash = () => {
             z-index: -1;
             background-image: url("/static/images/cloud-toneddowngrain-1-optimized.webp");
 
-            @media screen and (max-width: ${bp.medium}px) {
-              margin-bottom: 0rem;
-              top: 42% !important;
+            @media screen and (max-width: ${bp.xlarge}px) {
+              display: none !important;
             }
           `}
         ></ParallexObjectWrapper>

--- a/client/src/components/Home/SupportMirlo.tsx
+++ b/client/src/components/Home/SupportMirlo.tsx
@@ -64,7 +64,7 @@ const SupportMirlo = () => {
               gap: 24px;
             `}
           >
-            <SplashTitle>{t("sustainedBy")}</SplashTitle>
+            <SplashTitle as="h2">{t("sustainedBy")}</SplashTitle>
             <SplashButtonWrapper>
               <ButtonLink
                 to={

--- a/client/src/components/Releases.tsx
+++ b/client/src/components/Releases.tsx
@@ -3,11 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import TrackgroupGrid from "components/common/TrackgroupGrid";
 import { queryTrackGroups, TrackGroupQueryOptions } from "queries";
 import { queryTags } from "queries/tags";
-import { useId } from "react";
 import React from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { FaChevronRight, FaRss } from "react-icons/fa";
-import { useLocation, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import usePagination from "utils/usePagination";
 
 import { bp } from "../constants";
@@ -21,28 +20,24 @@ import TrackGroupPills from "./TrackGroup/TrackGroupPills";
 
 const pageSize = 40;
 
-const Releases: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
-  const location = useLocation();
-  const { pathname } = location;
+const Releases = () => {
   const [params] = useSearchParams();
   const { t } = useTranslation("translation", { keyPrefix: "releases" });
-  const { page, PaginationComponent } = usePagination({ pageSize: limit });
+  const { page, PaginationComponent } = usePagination({ pageSize });
   const tag = params.get("tag");
   const search = params.get("search");
   const [license, setLicense] = React.useState<
     TrackGroupQueryOptions["license"] | ""
   >((params.get("license") as TrackGroupQueryOptions["license"]) ?? "");
 
-  const onReleasesPage = pathname.includes("releases");
-
   const { data: newReleases } = useQuery(
     queryTrackGroups({
-      skip: limit * page,
-      take: limit,
-      orderBy: pathname?.includes("releases") ? undefined : "random",
+      skip: pageSize * page,
+      take: pageSize,
+      orderBy: undefined,
       tag: tag || undefined,
       title: search ?? undefined,
-      isReleased: pathname?.includes("releases") ? undefined : "released",
+      isReleased: undefined,
       license: license || undefined,
     })
   );
@@ -54,9 +49,6 @@ const Releases: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
     })
   );
 
-  const id = useId();
-  const headingId = `${id}-recent-releases`;
-
   return (
     <div
       className={css`
@@ -67,6 +59,7 @@ const Releases: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
         }
       `}
     >
+      <h1>{t("explore")}</h1>
       {!tag && (
         <SectionHeader
           className={css`
@@ -117,7 +110,7 @@ const Releases: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             display: flex;
           `}
         >
-          <h1 className="h5 section-header__heading" id={headingId}>
+          <h2 className="h5 section-header__heading">
             {tag ? (
               <Trans
                 t={t}
@@ -130,7 +123,7 @@ const Releases: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             ) : (
               t("recentReleases")
             )}
-          </h1>
+          </h2>
           <div
             className={css`
               display: flex;
@@ -140,26 +133,26 @@ const Releases: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
               }
             `}
           >
-            {onReleasesPage && (
-              <Select
-                value={license ?? ""}
-                onChange={(e) => {
-                  const newLicense = e.target
-                    .value as TrackGroupQueryOptions["license"];
-                  setLicense(newLicense);
-                }}
-                options={[
-                  { label: t("all"), value: "" },
-                  { label: t("publicDomain"), value: "public-domain" },
-                  { label: t("creativeCommons"), value: "creative-commons" },
-                  {
-                    label: t("allRightsReserved"),
-                    value: "all-rights-reserved",
-                  },
-                ]}
-              />
-            )}
+            <Select
+              value={license ?? ""}
+              onChange={(e) => {
+                const newLicense = e.target
+                  .value as TrackGroupQueryOptions["license"];
+                setLicense(newLicense);
+              }}
+              options={[
+                { label: t("all"), value: "" },
+                { label: t("publicDomain"), value: "public-domain" },
+                { label: t("creativeCommons"), value: "creative-commons" },
+                {
+                  label: t("allRightsReserved"),
+                  value: "all-rights-reserved",
+                },
+              ]}
+            />
             <ButtonAnchor
+              aria-label={t("rssFeed")}
+              title={t("rssFeed")}
               target="_blank"
               href={`${import.meta.env.VITE_API_DOMAIN}/v1/trackGroups?${tag ? `tag=${tag}` : ""}&released=released&format=rss`}
               rel="noreferrer"
@@ -189,12 +182,7 @@ const Releases: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
               padding: var(--mi-side-paddings-xsmall);
             `}
           >
-            <TrackgroupGrid
-              gridNumber="4"
-              as="ul"
-              aria-labelledby={headingId}
-              role="list"
-            >
+            <TrackgroupGrid gridNumber="4" as="ul">
               {newReleases?.results?.map((trackGroup) => (
                 <ArtistTrackGroup
                   key={trackGroup.id}
@@ -206,7 +194,7 @@ const Releases: React.FC<{ limit?: number }> = ({ limit = pageSize }) => {
             </TrackgroupGrid>
           </div>
 
-          {pathname.includes("releases") && newReleases && (
+          {newReleases && (
             <PaginationComponent amount={newReleases.results.length} />
           )}
         </WidthContainer>

--- a/client/src/components/common/MetaCard.tsx
+++ b/client/src/components/common/MetaCard.tsx
@@ -15,7 +15,7 @@ export const MetaCard: React.FC<{
     <>
       {/* @ts-ignore */}
       <Helmet>
-        <title>{`${title} on Mirlo`}</title>
+        <title>{`${title}`}</title>
         <meta name="description" content={description} />
       </Helmet>
     </>

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -70,7 +70,9 @@
     "releasesForSearch": "Releases for '{{ search }}'",
     "labelsForSearch": "Labels for '{{ search }}'",
     "labels": "Labels",
-    "searchResults": "Search results for '{{ search }}'"
+    "searchResults": "Search results for '{{ search }}'",
+    "rssFeed": "RSS feed",
+    "explore": "Explore"
   },
   "cookies": {
     "weUseCookies": "We use cookies to keep you logged in and to maintain your music queue.",
@@ -1802,7 +1804,8 @@
     "newsletterEnterCode": "Verification code",
     "newsletterVerifyAndSubscribe": "Verify & subscribe",
     "newsletterResend": "Resend code",
-    "newsletterResendSuccess": "Code resent!"
+    "newsletterResendSuccess": "Code resent!",
+    "exploreMusic": "Explore music"
   },
   "mobileApp.searchScreen": {
     "bestSelling": "Best Selling",

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -1805,7 +1805,8 @@
     "newsletterVerifyAndSubscribe": "Verify & subscribe",
     "newsletterResend": "Resend code",
     "newsletterResendSuccess": "Code resent!",
-    "exploreMusic": "Explore music"
+    "exploreMusic": "Explore music",
+    "refreshReleases": "Refresh"
   },
   "mobileApp.searchScreen": {
     "bestSelling": "Best Selling",


### PR DESCRIPTION
- Respect `prefers-reduced-motion` for parallax clouds on home page
- Ensure text on home page hero is not visually obscured by clouds
- One `h1` on home page
- One `h1` on releases page
- Add `aria-label` to releases RSS feed button
- Remove duplicate heading id's and aria-describedby references to them.
- Remove redundant role="list" on ul elements
- Don't refresh releases automatically
- Add refresh button to refresh releases manually
- Fix home page title to be "Mirlo" instead of "Mirlo on Mirlo"

New heading and refresh button on HomeReleases:

<img width="1064" height="1986" alt="image" src="https://github.com/user-attachments/assets/cfe4b1ce-858f-4072-a53f-c5678602d6cb" />


