### PR TITLE
Subscription deletion

### DIFF
--- a/src/jobs/send-subscription-renewal-reminders.ts
+++ b/src/jobs/send-subscription-renewal-reminders.ts
@@ -48,6 +48,9 @@ const sendSubscriptionRenewalReminders = async () => {
       where: {
         amount: { gt: 0 },
         deletedAt: null,
+        // Skip subscriptions the user has cancelled but that are still running
+        // out their paid period — they won't renew, so don't remind.
+        deleteReason: null,
         artistSubscriptionTier: {
           isDefaultTier: false,
           interval: "YEAR", // Only year-long subscriptions

--- a/src/routers/v1/artists/{id}/subscribe.ts
+++ b/src/routers/v1/artists/{id}/subscribe.ts
@@ -7,7 +7,10 @@ import {
   userLoggedInWithoutRedirect,
 } from "../../../../auth/passport";
 import logger from "../../../../logger";
-import { deleteStripeSubscriptions } from "../../../../utils/artist";
+import {
+  cancelStripeSubscriptionsAtPeriodEnd,
+  deleteStripeSubscriptions,
+} from "../../../../utils/artist";
 import { AppError } from "../../../../utils/error";
 import { createCheckoutSessionForSubscription } from "../../../../utils/stripe/sessions";
 
@@ -128,11 +131,13 @@ export default function () {
       });
       logger.info(`Generated a Stripe checkout session ${session.id}`);
 
-      res.status(200).json(
-        useEmbedded
-          ? { clientSecret: session.client_secret, stripeAccountId }
-          : { sessionUrl: session.url, stripeAccountId }
-      );
+      res
+        .status(200)
+        .json(
+          useEmbedded
+            ? { clientSecret: session.client_secret, stripeAccountId }
+            : { sessionUrl: session.url, stripeAccountId }
+        );
     } catch (e) {
       next(e);
     }
@@ -193,27 +198,38 @@ export default function () {
         });
       }
 
-      await deleteStripeSubscriptions({
-        artistSubscriptionTier: { artistId: Number(artistId) },
-        userId: loggedInUser.id,
-      });
-
-      await prisma.artistUserSubscription.update({
-        where: {
-          userId_artistSubscriptionTierId: {
-            artistSubscriptionTierId: subscription.artistSubscriptionTierId,
-            userId: loggedInUser.id,
-          },
-        },
-        data: { deleteReason: "USER_CANCELLED", stripeSubscriptionKey: null },
-      });
-
-      await prisma.artistUserSubscription.deleteMany({
-        where: {
+      if (subscription.stripeSubscriptionKey) {
+        // Paid subscription: let it run until the end of the period the user
+        // already paid for. Stripe stops billing and fires
+        // `customer.subscription.deleted` at period end, which sets `deletedAt`
+        // and actually revokes access. We keep the row (and its
+        // stripeSubscriptionKey) so that webhook can match it; access checks
+        // filter on `deletedAt: null`, so the subscription stays active until
+        // then. We record the reason now rather than future-dating `deletedAt`.
+        await cancelStripeSubscriptionsAtPeriodEnd({
           artistSubscriptionTier: { artistId: Number(artistId) },
           userId: loggedInUser.id,
-        },
-      });
+        });
+
+        await prisma.artistUserSubscription.update({
+          where: { id: subscription.id },
+          data: { deleteReason: "USER_CANCELLED" },
+        });
+      } else {
+        // Free/follow tier: nothing is billed, so there is no period to honour.
+        // Remove it immediately.
+        await prisma.artistUserSubscription.update({
+          where: { id: subscription.id },
+          data: { deleteReason: "USER_CANCELLED" },
+        });
+
+        await prisma.artistUserSubscription.deleteMany({
+          where: {
+            artistSubscriptionTier: { artistId: Number(artistId) },
+            userId: loggedInUser.id,
+          },
+        });
+      }
 
       res.status(200).json({ message: "success" });
     } catch (e) {

--- a/src/routers/v1/webhooks/stripe/connect.ts
+++ b/src/routers/v1/webhooks/stripe/connect.ts
@@ -9,6 +9,7 @@ import {
   handlePaymentIntentFailed,
   handlePaymentIntentSucceeded,
   handleSetupIntentSucceeded,
+  handleSubscriptionDeleted,
   verifyStripeSignature,
 } from "../../../../utils/stripe";
 import {
@@ -80,6 +81,14 @@ export default function () {
           const failedPaymentIntent = event.data.object;
 
           handlePaymentIntentFailed(failedPaymentIntent, event.account);
+          break;
+        case "customer.subscription.deleted":
+          // Fires when a subscription actually ends — at the close of a paid
+          // period we scheduled for cancellation, or after Stripe's dunning
+          // retries are exhausted. This is when access is revoked.
+          const deletedSubscription = event.data.object;
+
+          await handleSubscriptionDeleted(deletedSubscription);
           break;
         case "account.updated":
           const accountUpdate = event.data.object;

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -480,6 +480,58 @@ export const deleteStripeSubscriptions = async (
   });
 };
 
+// Schedules connected-account subscriptions to cancel at the end of the
+// current paid period instead of immediately. Stripe stops creating new
+// invoices and fires `customer.subscription.deleted` once the period ends,
+// which is when we flip `deletedAt` (see handleSubscriptionDeleted). Rows
+// without a stripeSubscriptionKey (free/follow tiers) are skipped — there is
+// no paid period to honour, so callers should delete those immediately.
+export const cancelStripeSubscriptionsAtPeriodEnd = async (
+  where: Prisma.ArtistUserSubscriptionWhereInput
+) => {
+  const stripeSubscriptions = await prisma.artistUserSubscription.findMany({
+    where,
+    include: {
+      artistSubscriptionTier: true,
+    },
+  });
+  await Promise.all(
+    stripeSubscriptions.map(async (sub) => {
+      if (sub.stripeSubscriptionKey) {
+        const artistUser = await prisma.user.findFirst({
+          where: {
+            artists: {
+              some: {
+                id: sub.artistSubscriptionTier.artistId,
+              },
+            },
+          },
+        });
+        try {
+          if (artistUser?.stripeAccountId) {
+            await stripe.subscriptions.update(
+              sub.stripeSubscriptionKey,
+              { cancel_at_period_end: true },
+              { stripeAccount: artistUser.stripeAccountId }
+            );
+          } else {
+            await stripe.subscriptions.update(sub.stripeSubscriptionKey, {
+              cancel_at_period_end: true,
+            });
+          }
+        } catch (e) {
+          console.error(
+            "Fail silently on scheduling stripe cancellation at period end",
+            e
+          );
+        }
+      }
+    })
+  ).catch((e) => {
+    console.error("truely a failure");
+  });
+};
+
 /**
  * Common includes when returning a single artist
  */

--- a/src/utils/stripe/index.ts
+++ b/src/utils/stripe/index.ts
@@ -824,6 +824,40 @@ export const handlePaymentIntentFailed = async (
   }
 };
 
+// Fires when Stripe ends a subscription — either because we scheduled it to
+// cancel at period end (user cancellation, see subscribe.ts) or because Stripe
+// exhausted its dunning retries after repeated payment failures. This is the
+// single place we set `deletedAt`, so access (gated on `deletedAt: null`)
+// continues through any paid-up period and is revoked exactly when Stripe
+// considers the subscription over.
+export const handleSubscriptionDeleted = async (
+  subscription: Stripe.Subscription
+) => {
+  logger.info(`customer.subscription.deleted: ${subscription.id}`);
+
+  // Honour any reason we recorded at cancellation time; only override it when
+  // Stripe tells us the subscription died because billing ultimately failed.
+  const deleteReason =
+    subscription.cancellation_details?.reason === "payment_failed"
+      ? "PAYMENT_FAILURE"
+      : undefined;
+
+  const result = await prisma.artistUserSubscription.updateMany({
+    where: {
+      stripeSubscriptionKey: subscription.id,
+      deletedAt: null,
+    },
+    data: {
+      deletedAt: new Date(),
+      ...(deleteReason ? { deleteReason } : {}),
+    },
+  });
+
+  logger.info(
+    `customer.subscription.deleted: ${subscription.id} marked ${result.count} subscription(s) deleted`
+  );
+};
+
 type MerchPurchaseItem = {
   type: "merch";
   id: string;

--- a/test/routers/artists/{id}.subscribe.spec.ts
+++ b/test/routers/artists/{id}.subscribe.spec.ts
@@ -4,7 +4,10 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 import { describe, it } from "mocha";
+import sinon from "sinon";
 
+import { cancelStripeSubscriptionsAtPeriodEnd } from "../../../src/utils/artist";
+import { stripe } from "../../../src/utils/stripe";
 import { clearTables, createArtist, createUser } from "../../utils";
 import { requestApp } from "../utils";
 
@@ -51,6 +54,10 @@ describe("artists/{id}/subscribe", () => {
     } catch (e) {
       console.error(e);
     }
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   describe("POST", () => {
@@ -172,6 +179,114 @@ describe("artists/{id}/subscribe", () => {
         },
       });
       assert.equal(subscriptions.length, 0);
+    });
+  });
+
+  describe("DELETE", () => {
+    it("should return 404 when the user has no subscription", async () => {
+      const { artist, followerAccessToken } = await createTestData();
+
+      const response = await requestApp
+        .delete(`artists/${artist.id}/subscribe`)
+        .set("Accept", "application/json")
+        .set("Cookie", [`jwt=${followerAccessToken}`]);
+
+      assert.equal(response.status, 404);
+    });
+
+    it("keeps a paid subscription active until period end rather than removing it", async () => {
+      const { artist, followerUser, followerAccessToken } =
+        await createTestData();
+      const paidTier = artist.subscriptionTiers![1]; // Tier 2, minAmount 4
+
+      const subscription = await prisma.artistUserSubscription.create({
+        data: {
+          artistSubscriptionTierId: paidTier.id,
+          userId: followerUser.id,
+          amount: 500,
+          stripeSubscriptionKey: "sub_paid_123",
+        },
+      });
+
+      const response = await requestApp
+        .delete(`artists/${artist.id}/subscribe`)
+        .set("Accept", "application/json")
+        .set("Cookie", [`jwt=${followerAccessToken}`]);
+
+      assert.equal(response.status, 200);
+
+      // The subscription is still active (deletedAt null, so the soft-delete
+      // read filter still returns it), with the reason recorded now and the
+      // Stripe key kept so the customer.subscription.deleted webhook — which
+      // fires at period end — can match it and finally set deletedAt.
+      const after = await prisma.artistUserSubscription.findFirst({
+        where: { id: subscription.id },
+      });
+      assert.ok(after, "subscription should still be active until period end");
+      assert.equal(after?.deleteReason, "USER_CANCELLED");
+      assert.equal(after?.stripeSubscriptionKey, "sub_paid_123");
+    });
+
+    it("removes a free subscription immediately", async () => {
+      const { artist, followerUser, followerAccessToken } =
+        await createTestData();
+      const freeTier = artist.subscriptionTiers![0]; // default tier, no Stripe key
+
+      const subscription = await prisma.artistUserSubscription.create({
+        data: {
+          artistSubscriptionTierId: freeTier.id,
+          userId: followerUser.id,
+          amount: 0,
+        },
+      });
+
+      const response = await requestApp
+        .delete(`artists/${artist.id}/subscribe`)
+        .set("Accept", "application/json")
+        .set("Cookie", [`jwt=${followerAccessToken}`]);
+
+      assert.equal(response.status, 200);
+
+      // A free tier has no paid period to honour, so it is soft-deleted now
+      // and no longer appears as an active subscription.
+      const after = await prisma.artistUserSubscription.findFirst({
+        where: { id: subscription.id },
+      });
+      assert.equal(after, null, "free subscription should no longer be active");
+    });
+
+    it("cancelStripeSubscriptionsAtPeriodEnd asks Stripe to cancel at period end", async () => {
+      // Exercised directly (in-process) so we can assert the Stripe params —
+      // the HTTP handler above runs in a separate container where stubs don't
+      // apply.
+      const { artist, followerUser } = await createTestData();
+      const paidTier = artist.subscriptionTiers![1];
+
+      await prisma.artistUserSubscription.create({
+        data: {
+          artistSubscriptionTierId: paidTier.id,
+          userId: followerUser.id,
+          amount: 500,
+          stripeSubscriptionKey: "sub_paid_456",
+        },
+      });
+
+      const updateStub = sinon
+        .stub(stripe.subscriptions, "update")
+        .resolves({} as any);
+
+      await cancelStripeSubscriptionsAtPeriodEnd({
+        artistSubscriptionTier: { artistId: artist.id },
+        userId: followerUser.id,
+      });
+
+      assert.equal(updateStub.calledOnce, true);
+      assert.equal(updateStub.getCall(0).args[0], "sub_paid_456");
+      assert.deepEqual(updateStub.getCall(0).args[1], {
+        cancel_at_period_end: true,
+      });
+      // Connected-account subscriptions are cancelled on the artist's account
+      assert.deepEqual(updateStub.getCall(0).args[2], { stripeAccount: "23" });
     });
   });
 });

--- a/test/routers/webhooks/stripe.spec.ts
+++ b/test/routers/webhooks/stripe.spec.ts
@@ -587,6 +587,128 @@ describe("Stripe Webhooks - Failed Payments", () => {
     });
   });
 
+  describe("customer.subscription.deleted webhook", () => {
+    it("sets deletedAt and preserves the cancellation reason when a cancelled subscription's period ends", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@artist.com",
+      });
+      const { user: subscriber } = await createUser({
+        email: "subscriber@subscriber.com",
+      });
+      const artist = await createArtist(artistUser.id);
+      const tier = await createTier(artist.id, { name: "Premium" });
+
+      const subscription = await prisma.artistUserSubscription.create({
+        data: {
+          stripeSubscriptionKey: "sub_ending_123",
+          userId: subscriber.id,
+          artistSubscriptionTierId: tier.id,
+          amount: 500,
+          deleteReason: "USER_CANCELLED",
+        },
+      });
+
+      await stripeUtils.handleSubscriptionDeleted({
+        id: "sub_ending_123",
+        object: "subscription",
+        cancellation_details: { reason: "cancellation_requested" },
+      } as unknown as Stripe.Subscription);
+
+      // Read raw: the Prisma client soft-delete extension filters deletedAt
+      // rows out of normal finds, so we'd never see the now-deleted row.
+      const [after] = await prisma.$queryRaw<
+        { deletedAt: Date | null; deleteReason: string | null }[]
+      >`SELECT "deletedAt", "deleteReason" FROM "ArtistUserSubscription" WHERE id = ${subscription.id}`;
+      assert.ok(after.deletedAt, "deletedAt should be set at period end");
+      assert.equal(
+        after.deleteReason,
+        "USER_CANCELLED",
+        "should preserve the reason recorded at cancellation time"
+      );
+    });
+
+    it("records PAYMENT_FAILURE when Stripe ends the subscription after exhausting retries", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@artist.com",
+      });
+      const { user: subscriber } = await createUser({
+        email: "subscriber@subscriber.com",
+      });
+      const artist = await createArtist(artistUser.id);
+      const tier = await createTier(artist.id, { name: "Premium" });
+
+      const subscription = await prisma.artistUserSubscription.create({
+        data: {
+          stripeSubscriptionKey: "sub_failed_123",
+          userId: subscriber.id,
+          artistSubscriptionTierId: tier.id,
+          amount: 500,
+        },
+      });
+
+      await stripeUtils.handleSubscriptionDeleted({
+        id: "sub_failed_123",
+        object: "subscription",
+        cancellation_details: { reason: "payment_failed" },
+      } as unknown as Stripe.Subscription);
+
+      const [after] = await prisma.$queryRaw<
+        { deletedAt: Date | null; deleteReason: string | null }[]
+      >`SELECT "deletedAt", "deleteReason" FROM "ArtistUserSubscription" WHERE id = ${subscription.id}`;
+      assert.ok(after.deletedAt);
+      assert.equal(after.deleteReason, "PAYMENT_FAILURE");
+    });
+
+    it("does not touch an already-deleted subscription", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@artist.com",
+      });
+      const { user: subscriber } = await createUser({
+        email: "subscriber@subscriber.com",
+      });
+      const artist = await createArtist(artistUser.id);
+      const tier = await createTier(artist.id, { name: "Premium" });
+
+      const alreadyDeletedAt = new Date("2020-01-01T00:00:00.000Z");
+      const subscription = await prisma.artistUserSubscription.create({
+        data: {
+          stripeSubscriptionKey: "sub_already_gone",
+          userId: subscriber.id,
+          artistSubscriptionTierId: tier.id,
+          amount: 500,
+          deletedAt: alreadyDeletedAt,
+          deleteReason: "USER_CANCELLED",
+        },
+      });
+
+      await stripeUtils.handleSubscriptionDeleted({
+        id: "sub_already_gone",
+        object: "subscription",
+        cancellation_details: { reason: "payment_failed" },
+      } as unknown as Stripe.Subscription);
+
+      // The handler's deletedAt: null guard means an already-deleted row is
+      // left untouched — neither its deletedAt nor its reason should change.
+      const [after] = await prisma.$queryRaw<
+        { deletedAt: Date | null; deleteReason: string | null }[]
+      >`SELECT "deletedAt", "deleteReason" FROM "ArtistUserSubscription" WHERE id = ${subscription.id}`;
+      assert.equal(
+        new Date(after.deletedAt!).toISOString(),
+        alreadyDeletedAt.toISOString()
+      );
+      assert.equal(after.deleteReason, "USER_CANCELLED");
+    });
+
+    it("handles an unknown subscription key without throwing", async () => {
+      // No matching row exists; the handler should simply no-op
+      await stripeUtils.handleSubscriptionDeleted({
+        id: "sub_does_not_exist",
+        object: "subscription",
+        cancellation_details: { reason: "cancellation_requested" },
+      } as unknown as Stripe.Subscription);
+    });
+  });
+
   describe("webhook endpoint integration", () => {
     it("should process invoice.payment_failed event from webhook", async () => {
       const { user } = await createUser({
@@ -652,6 +774,45 @@ describe("Stripe Webhooks - Failed Payments", () => {
       assert.equal(handleInvoicePaymentFailedStub.calledOnce, true);
 
       // Assert response was sent
+      assert.equal(mockResponse.send.calledOnce, true);
+    });
+
+    it("should process customer.subscription.deleted event from webhook", async () => {
+      const verifySignatureStub = sinon
+        .stub(stripeUtils, "verifyStripeSignature")
+        .resolves({
+          type: "customer.subscription.deleted",
+          account: "acct_1234",
+          data: {
+            object: {
+              id: "sub_webhook_del",
+              object: "subscription",
+              cancellation_details: { reason: "cancellation_requested" },
+            },
+          },
+        } as unknown as Stripe.Event);
+
+      const handleSubscriptionDeletedStub = sinon.stub(
+        stripeUtils,
+        "handleSubscriptionDeleted"
+      );
+
+      const mockResponse = {
+        send: sinon.stub(),
+        status: sinon.stub().returnsThis(),
+        json: sinon.stub(),
+      };
+
+      const req = {} as unknown as Request;
+      const res = mockResponse as unknown as Response;
+      const next = () => {};
+
+      const handler = stripeConnectWebhook();
+
+      await handler.POST(req, res, next);
+
+      assert.equal(verifySignatureStub.calledOnce, true);
+      assert.equal(handleSubscriptionDeletedStub.calledOnce, true);
       assert.equal(mockResponse.send.calledOnce, true);
     });
 


### PR DESCRIPTION
The problem: 

Right now if someone cancels a subscription, it's cancelled right away. They don't get to ride it out. The norm is that subscriptions finish their term (especially for annual subscriptions).

The solution: 

Use Stripe's billing term to handle subscription cancelling. Instead of marking a subscription as cancelled right away (deletedAt w/ USER_CANCELLED reason) trigger the cancellation in stripe, and then wait for the webhook. 