### PR TITLE
fix: optionally capture user name for subscription tiers

### DIFF
--- a/client/src/components/Artist/ArtistVariableSupport.tsx
+++ b/client/src/components/Artist/ArtistVariableSupport.tsx
@@ -27,9 +27,17 @@ const ArtistVariableSupport: React.FC<{
   const { handleSubmit, register, formState, getValues } = useForm({
     defaultValues: {
       amount: tier.minAmount ? tier.minAmount / 100 : 0,
+      name: "",
     },
   });
-  const { refreshLoggedInUser } = useAuthContext();
+  const { user, refreshLoggedInUser } = useAuthContext();
+  // Offer logged-out buyers (and accounts without a name) an optional display
+  // name so the artist sees who's supporting them — shown explicitly rather
+  // than scraped from Stripe's billing details.
+  const needsName = !user?.name;
+  // Open the pre-checkout modal whenever there's something to collect (a
+  // variable amount and/or a name); otherwise subscribe straight through.
+  const needsModal = tier.allowVariable || needsName;
   const [open, setOpen] = React.useState(false);
   const [isCheckingForSubscription, setIsCheckingForSubscription] =
     React.useState(false);
@@ -51,12 +59,13 @@ const ArtistVariableSupport: React.FC<{
     try {
       setIsCheckingForSubscription(true);
       const response = await api.post<
-        { tierId: number; amount?: number; embedded: boolean },
+        { tierId: number; amount?: number; embedded: boolean; name?: string },
         { clientSecret: string; stripeAccountId: string }
       >(`artists/${tier.artistId}/subscribe`, {
         tierId: tier.id,
         amount: tier.allowVariable ? getValues("amount") * 100 : tier.minAmount,
         embedded: true,
+        ...(needsName && { name: getValues("name") }),
       });
       if (response.clientSecret) {
         setOpen(false);
@@ -90,9 +99,7 @@ const ArtistVariableSupport: React.FC<{
         size="big"
         rounded
         uppercase
-        onClick={() =>
-          tier.allowVariable ? setOpen(true) : subscribeToTier(tier)
-        }
+        onClick={() => (needsModal ? setOpen(true) : subscribeToTier(tier))}
         isLoading={isCheckingForSubscription}
         disabled={isCheckingForSubscription}
         className={css`
@@ -105,32 +112,43 @@ const ArtistVariableSupport: React.FC<{
         size="small"
         open={open}
         onClose={() => setOpen(false)}
-        title={t("howMuch") ?? ""}
+        title={(tier.allowVariable ? t("howMuch") : t("letsSupport")) ?? ""}
       >
         <form
           onSubmit={handleSubmit(() => subscribeToTier(tier))}
           className="flex flex-col gap-3"
         >
-          <strong>{t("chooseAnAmount")}</strong>
-          <div className="flex items-center gap-2 ">
-            <span className="whitespace-nowrap">
-              {getCurrencySymbol(artist?.user?.currency ?? "usd")}
-            </span>
-            <InputEl
-              {...register("amount", {
-                min: tier.minAmount ? tier.minAmount / 100 : undefined,
-                required: true,
-              })}
-            />
-            <span className="whitespace-nowrap">
-              {t(tier.interval === "MONTH" ? "monthly" : "yearly")}
-            </span>
-            {!!tier.minAmount && formState.errors?.amount && (
-              <small>
-                {t("mustBeAtLeast", { minAmount: tier.minAmount / 100 })}
-              </small>
-            )}
-          </div>
+          {tier.allowVariable && (
+            <>
+              <strong>{t("chooseAnAmount")}</strong>
+              <div className="flex items-center gap-2 ">
+                <span className="whitespace-nowrap">
+                  {getCurrencySymbol(artist?.user?.currency ?? "usd")}
+                </span>
+                <InputEl
+                  {...register("amount", {
+                    min: tier.minAmount ? tier.minAmount / 100 : undefined,
+                    required: true,
+                  })}
+                />
+                <span className="whitespace-nowrap">
+                  {t(tier.interval === "MONTH" ? "monthly" : "yearly")}
+                </span>
+                {!!tier.minAmount && formState.errors?.amount && (
+                  <small>
+                    {t("mustBeAtLeast", { minAmount: tier.minAmount / 100 })}
+                  </small>
+                )}
+              </div>
+            </>
+          )}
+          {needsName && (
+            <label className="flex flex-col gap-1">
+              <span>{t("yourNameLabel", { artistName: artist?.name })}</span>
+              <InputEl {...register("name")} />
+              <small>{t("yourNameHint")}</small>
+            </label>
+          )}
           <ArtistButton
             isLoading={isCheckingForSubscription}
             disabled={isCheckingForSubscription || !isEmpty(formState.errors)}

--- a/client/src/translation/en.json
+++ b/client/src/translation/en.json
@@ -657,6 +657,8 @@
     "configurePayment": "Configure payment processor",
     "howMuch": "Your subscription amount",
     "mustBeAtLeast": "Must be at least {{minAmount}}",
+    "yourNameLabel": "What should {{artistName}} call you? (optional)",
+    "yourNameHint": "Shown to the artist alongside your support.",
     "letsSupport": "Support this artist",
     "cancelSubscription": "Cancel subscription",
     "subscriptionPaymentFailed": "Your last payment for this subscription failed. Please cancel it and choose again.",

--- a/src/routers/v1/artists/{id}/subscribe.ts
+++ b/src/routers/v1/artists/{id}/subscribe.ts
@@ -39,7 +39,7 @@ export default function () {
 
   async function POST(req: Request, res: Response, next: NextFunction) {
     const { id: artistId } = req.params as unknown as Params;
-    let { tierId, email, amount, embedded } = req.body;
+    let { tierId, email, amount, embedded, name } = req.body;
 
     const loggedInUser = req.user;
 
@@ -124,15 +124,18 @@ export default function () {
         artistId: newTier.artistId,
         tier: newTier,
         amount,
+        userName: name,
         embedded: useEmbedded,
       });
       logger.info(`Generated a Stripe checkout session ${session.id}`);
 
-      res.status(200).json(
-        useEmbedded
-          ? { clientSecret: session.client_secret, stripeAccountId }
-          : { sessionUrl: session.url, stripeAccountId }
-      );
+      res
+        .status(200)
+        .json(
+          useEmbedded
+            ? { clientSecret: session.client_secret, stripeAccountId }
+            : { sessionUrl: session.url, stripeAccountId }
+        );
     } catch (e) {
       next(e);
     }

--- a/src/utils/stripe/index.ts
+++ b/src/utils/stripe/index.ts
@@ -445,6 +445,7 @@ type SessionMetaData = {
   tierId: string;
   userEmail: string;
   userId: string;
+  userName: string;
   trackGroupId: string;
   stripeAccountId: string;
   gaveGift: string;
@@ -476,6 +477,7 @@ export const handleCheckoutSession = async (
       artistId,
     } = metadata;
     let { userId, userEmail } = metadata;
+    const { userName } = metadata;
     userEmail = userEmail || (session.customer_details?.email ?? "");
     logger.info(
       `checkout.session: ${session.id}, stripeAccountId: ${stripeAccountId}, ${JSON.stringify(metadata)}`
@@ -491,10 +493,14 @@ export const handleCheckoutSession = async (
       { stripeAccount: stripeAccountId }
     );
 
-    // If the user doesn't exist, we create one with an existing userEmail
+    // If the user doesn't exist, we create one with an existing userEmail.
+    // `userName` is the buyer's self-chosen display name (subscriptions only);
+    // we deliberately do NOT fall back to Stripe's billing name — a blank field
+    // means the supporter chose not to share a display name.
     let { userId: actualUserId, newUser } = await findOrCreateUserBasedOnEmail(
       userEmail,
-      userId
+      userId,
+      userName
     );
     logger.info(`checkout.session: ${session.id} Processing session`);
     if (purchaseType === "tip") {

--- a/src/utils/stripe/sessions.ts
+++ b/src/utils/stripe/sessions.ts
@@ -707,6 +707,7 @@ export const createCheckoutSessionForSubscription = async ({
   artistId,
   tier,
   amount,
+  userName,
   embedded = false,
 }: {
   loggedInUser?: User;
@@ -715,6 +716,8 @@ export const createCheckoutSessionForSubscription = async ({
   artistId: number;
   tier: Prisma.ArtistSubscriptionTierGetPayload<{ include: { artist: true } }>;
   amount: number;
+  /** Optional self-chosen display name, captured when the buyer has no account name. */
+  userName?: string;
   // In-app callers opt in to embedded so the Stripe form renders inline
   // (#1168). External callers (links from email, third-party embeds, etc.)
   // leave this off and get a hosted Stripe checkout URL they can redirect to.
@@ -805,6 +808,7 @@ export const createCheckoutSessionForSubscription = async ({
         tierId: tier.id,
         userId: loggedInUser?.id ?? null,
         userEmail: email ?? null,
+        ...(userName?.trim() && { userName: userName.trim() }),
         stripeAccountId,
       },
       mode: "subscription",

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -63,10 +63,13 @@ export const getUserCountry = async (userId: number) => {
 
 export const findOrCreateUserBasedOnEmail = async (
   userEmail: string,
-  userId?: string | number
+  userId?: string | number,
+  /** Optional self-chosen display name. Only set when the user has none — never overwrites an existing name. */
+  name?: string
 ) => {
   let newUser = false;
   let user: User | undefined | null;
+  const trimmedName = name?.trim() || undefined;
 
   if (!userId && userEmail) {
     newUser = true; // If this is true the user wasn't logged in when making the purchase
@@ -80,6 +83,7 @@ export const findOrCreateUserBasedOnEmail = async (
       user = await prisma.user.create({
         data: {
           email: userEmail,
+          ...(trimmedName && { name: trimmedName }),
         },
       });
     }
@@ -89,6 +93,16 @@ export const findOrCreateUserBasedOnEmail = async (
       where: { id: Number(userId) },
     });
   }
+
+  // Backfill a name for users who don't have one yet (a returning guest, or a
+  // logged-in account created without a name). Never overwrite an existing name.
+  if (user && trimmedName && !user.name) {
+    user = await prisma.user.update({
+      where: { id: user.id },
+      data: { name: trimmedName },
+    });
+  }
+
   return { userId, newUser, user };
 };
 

--- a/test/utils/user.spec.ts
+++ b/test/utils/user.spec.ts
@@ -1,0 +1,69 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+import { describe, it } from "mocha";
+
+import { findOrCreateUserBasedOnEmail } from "../../src/utils/user";
+import { clearTables, createUser } from "../utils";
+
+import prisma from "@mirlo/prisma";
+
+import assert from "assert";
+
+describe("findOrCreateUserBasedOnEmail", () => {
+  beforeEach(async () => {
+    try {
+      await clearTables();
+    } catch (e) {
+      console.error(e);
+    }
+  });
+
+  it("sets the name when creating a new guest user", async () => {
+    const { user } = await findOrCreateUserBasedOnEmail(
+      "guest@test.com",
+      undefined,
+      "Jane Supporter"
+    );
+    assert.equal(user?.name, "Jane Supporter");
+
+    const inDb = await prisma.user.findFirst({
+      where: { email: "guest@test.com" },
+    });
+    assert.equal(inDb?.name, "Jane Supporter");
+  });
+
+  it("backfills a name for an existing user that has none", async () => {
+    const { user: existing } = await createUser({
+      email: "noname@test.com",
+      name: null,
+    });
+    assert.equal(existing.name, null);
+
+    const { user } = await findOrCreateUserBasedOnEmail(
+      "noname@test.com",
+      undefined,
+      "Backfilled Name"
+    );
+    assert.equal(user?.name, "Backfilled Name");
+  });
+
+  it("never overwrites an existing name", async () => {
+    const { user: existing } = await createUser({
+      email: "named@test.com",
+      name: "Original Name",
+    });
+
+    const { user } = await findOrCreateUserBasedOnEmail(
+      "named@test.com",
+      existing.id,
+      "Should Not Apply"
+    );
+    assert.equal(user?.name, "Original Name");
+  });
+
+  it("does not require a name", async () => {
+    const { user } = await findOrCreateUserBasedOnEmail("plain@test.com");
+    assert.ok(user, "user should be created");
+    assert.equal(user?.name, null);
+  });
+});


### PR DESCRIPTION
Right now if a user subscribes a user financially, there's no way to capture their name. This way we can let them optionally set their name before continuing on the flow. 

This makes cross referencing members easier. 