### PR TITLE
feat(client): indicate available lyrics in player

### DIFF
--- a/client/src/components/Widget/TrackTitleContent.tsx
+++ b/client/src/components/Widget/TrackTitleContent.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { getArtistUrl, getReleaseUrl } from "utils/artist";
 
 import { WidgetLink } from "./utils";
+import { MdLyrics } from "react-icons/md";
 
 export const TrackTitleContent: React.FC<{
   track: Track;
@@ -59,7 +60,15 @@ export const TrackTitleContent: React.FC<{
   ) : null;
 
   const titleNode = titleLinkTo ? (
-    <Link to={titleLinkTo}>{track.title ?? ""}</Link>
+    <Link className="hover:underline! ms-1" to={titleLinkTo}>
+      {track.title ?? ""}
+      {track.lyrics && (
+        <>
+          <MdLyrics aria-hidden className="inline-block ms-1" />
+          <span className="sr-only">, {tTrackGroup("viewLyrics")}</span>
+        </>
+      )}
+    </Link>
   ) : (
     (track.title ?? "")
   );
@@ -79,7 +88,7 @@ export const TrackTitleContent: React.FC<{
   return (
     <>
       <div
-        className={`leading-tight truncate break-normal ${
+        className={`leading-normal truncate break-normal ${titleLinkTo && "-ms-1"} ${
           compactTitle
             ? "text-base max-sm:text-xs font-semibold"
             : "text-lg max-sm:text-base max-xs:text-sm font-bold"


### PR DESCRIPTION
achieved by putting lyrics icon next to the now playing track title, which links to the track page which contains the lyrics

<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/c5db8e01-6b7d-4418-82e9-3bb11c85fc19" />
