### PR TITLE
Scope Mirlo widget elapsed timer to the actually-playing track

### DIFF
--- a/client/src/components/Widget/PostWidget/usePostWidgetData.test.ts
+++ b/client/src/components/Widget/PostWidget/usePostWidgetData.test.ts
@@ -1,0 +1,112 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import api from "services/api";
+import { usePlayerSyncState } from "utils/playerSync";
+import { isEmbeddedInMirlo } from "utils/widgetContext";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { usePostWidgetData } from "./usePostWidgetData";
+
+const mockCurrentTrack = vi.hoisted(() => ({
+  value: undefined as Track | undefined,
+}));
+
+vi.mock("components/Player/useCurrentTrackHook", () => ({
+  default: () => ({ currentTrack: mockCurrentTrack.value }),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useParams: () => ({ id: "post-1" }) };
+});
+
+vi.mock("services/api", () => ({
+  default: { get: vi.fn() },
+}));
+
+vi.mock("utils/playerSync", () => ({
+  usePlayerSyncState: vi.fn(),
+}));
+
+vi.mock("utils/widgetContext", () => ({
+  isEmbeddedInMirlo: vi.fn(),
+}));
+
+const makePost = (): Post => ({
+  id: 1,
+  title: "Widget post",
+  content: "",
+  publishedAt: "2026-06-24T00:00:00.000Z",
+  isPublic: true,
+  isContentHidden: false,
+  isDraft: false,
+  tracks: [
+    { postId: 1, trackId: 11, isPlayable: true, title: "Track one" },
+    { postId: 1, trackId: 12, isPlayable: true, title: "Track two" },
+  ],
+});
+
+const mockPostFetch = () => {
+  vi.mocked(api.get).mockResolvedValue({ result: makePost() } as any);
+};
+
+describe("usePostWidgetData", () => {
+  beforeEach(() => {
+    vi.mocked(api.get).mockReset();
+    vi.mocked(isEmbeddedInMirlo).mockReset();
+    vi.mocked(usePlayerSyncState).mockReset();
+    vi.mocked(isEmbeddedInMirlo).mockReturnValue(true);
+    mockCurrentTrack.value = {
+      id: 11,
+      title: "Track one",
+      audio: { duration: 123 },
+    } as Track;
+    vi.mocked(usePlayerSyncState).mockReturnValue({
+      playing: true,
+      currentTrackId: 11,
+      currentSeconds: 37,
+    });
+    mockPostFetch();
+  });
+
+  test("uses broadcast elapsed seconds when the synced track belongs to the post", async () => {
+    const { result } = renderHook(() => usePostWidgetData());
+
+    await waitFor(() => {
+      expect(result.current.elapsedSeconds).toBe(37);
+    });
+    expect(result.current.currentTrack?.id).toBe(11);
+  });
+
+  test("resets embedded elapsed seconds and hides the current track when the synced track belongs to another widget", async () => {
+    mockCurrentTrack.value = {
+      id: 999,
+      title: "External track",
+      audio: { duration: 456 },
+    } as Track;
+    vi.mocked(usePlayerSyncState).mockReturnValue({
+      playing: true,
+      currentTrackId: 999,
+      currentSeconds: 37,
+    });
+
+    const { result } = renderHook(() => usePostWidgetData());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.elapsedSeconds).toBe(0);
+    expect(result.current.currentTrack).toBeUndefined();
+  });
+
+  test("uses local current seconds outside embedded Mirlo widgets", async () => {
+    vi.mocked(isEmbeddedInMirlo).mockReturnValue(false);
+    const { result } = renderHook(() => usePostWidgetData());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    act(() => result.current.setCurrentSeconds(42));
+
+    expect(result.current.elapsedSeconds).toBe(42);
+  });
+});

--- a/client/src/components/Widget/PostWidget/usePostWidgetData.ts
+++ b/client/src/components/Widget/PostWidget/usePostWidgetData.ts
@@ -14,8 +14,19 @@ export const usePostWidgetData = () => {
 
   const embeddedInMirlo = isEmbeddedInMirlo();
   const playerSyncState = usePlayerSyncState();
+  const playableTracks = post?.tracks?.filter((t) => t.isPlayable);
+  const ownTrackIds = new Set(playableTracks?.map((t) => t.trackId) ?? []);
+  const syncedTrackId = playerSyncState?.currentTrackId ?? null;
+  const hasSyncedTrack =
+    syncedTrackId !== null && ownTrackIds.has(syncedTrackId);
+  const scopedCurrentTrack =
+    embeddedInMirlo && (!hasSyncedTrack || currentTrack?.id !== syncedTrackId)
+      ? undefined
+      : currentTrack;
   const elapsedSeconds = embeddedInMirlo
-    ? (playerSyncState?.currentSeconds ?? 0)
+    ? hasSyncedTrack
+      ? (playerSyncState?.currentSeconds ?? 0)
+      : 0
     : currentSeconds;
 
   React.useEffect(() => {
@@ -33,12 +44,10 @@ export const usePostWidgetData = () => {
     callback();
   }, [params.id]);
 
-  const playableTracks = post?.tracks?.filter((t) => t.isPlayable);
-
   return {
     post,
     isLoading,
-    currentTrack,
+    currentTrack: scopedCurrentTrack,
     currentSeconds,
     setCurrentSeconds,
     elapsedSeconds,

--- a/client/src/components/Widget/TrackGroupWidget/useTrackGroupWidgetData.test.ts
+++ b/client/src/components/Widget/TrackGroupWidget/useTrackGroupWidgetData.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import api from "services/api";
+import { useAuthContext } from "state/AuthContext";
+import { usePlayerSyncState } from "utils/playerSync";
+import { isEmbeddedInMirlo } from "utils/widgetContext";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { useTrackGroupWidgetData } from "./useTrackGroupWidgetData";
+
+const mockCurrentTrack = vi.hoisted(() => ({
+  value: undefined as Track | undefined,
+}));
+
+vi.mock("components/Player/useCurrentTrackHook", () => ({
+  default: () => ({ currentTrack: mockCurrentTrack.value }),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useParams: () => ({ id: "track-group-1" }) };
+});
+
+vi.mock("services/api", () => ({
+  default: { get: vi.fn() },
+}));
+
+vi.mock("state/AuthContext", () => ({
+  useAuthContext: vi.fn(),
+}));
+
+vi.mock("utils/injectedData", () => ({
+  getInjectedArtist: vi.fn(),
+  getInjectedTrackGroup: vi.fn(),
+}));
+
+vi.mock("utils/playerSync", () => ({
+  usePlayerSyncState: vi.fn(),
+}));
+
+vi.mock("utils/widgetContext", () => ({
+  isEmbeddedInMirlo: vi.fn(),
+}));
+
+const artist = {
+  id: 5,
+  name: "Widget Artist",
+  userId: 50,
+} as Artist;
+
+const makeTrackGroup = (): TrackGroup =>
+  ({
+    id: 1,
+    title: "Widget release",
+    artistId: artist.id,
+    artist,
+    tracks: [
+      { id: 21, title: "Track one", isPreview: true },
+      { id: 22, title: "Track two", isPreview: true },
+    ] as Track[],
+  }) as TrackGroup;
+
+const mockTrackGroupFetch = () => {
+  vi.mocked(api.get).mockImplementation(
+    async (endpoint: string): Promise<any> => {
+      if (endpoint === "trackGroups/track-group-1") {
+        return { result: makeTrackGroup() };
+      }
+      if (endpoint === `artists/${artist.id}`) {
+        return { result: artist };
+      }
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    }
+  );
+};
+
+describe("useTrackGroupWidgetData", () => {
+  beforeEach(() => {
+    vi.mocked(api.get).mockReset();
+    vi.mocked(useAuthContext).mockReset();
+    vi.mocked(isEmbeddedInMirlo).mockReset();
+    vi.mocked(usePlayerSyncState).mockReset();
+    vi.mocked(useAuthContext).mockReturnValue({ user: null } as any);
+    vi.mocked(isEmbeddedInMirlo).mockReturnValue(true);
+    mockCurrentTrack.value = {
+      id: 21,
+      title: "Track one",
+      isPreview: true,
+      audio: { duration: 123 },
+    } as Track;
+    vi.mocked(usePlayerSyncState).mockReturnValue({
+      playing: true,
+      currentTrackId: 21,
+      currentSeconds: 37,
+    });
+    mockTrackGroupFetch();
+  });
+
+  test("uses broadcast elapsed seconds when the synced track belongs to the track group", async () => {
+    const { result } = renderHook(() => useTrackGroupWidgetData());
+
+    await waitFor(() => {
+      expect(result.current.elapsedSeconds).toBe(37);
+    });
+    expect(result.current.currentTrack?.id).toBe(21);
+  });
+
+  test("resets embedded elapsed seconds and hides the current track when the synced track belongs to another widget", async () => {
+    mockCurrentTrack.value = {
+      id: 999,
+      title: "External track",
+      isPreview: true,
+      audio: { duration: 456 },
+    } as Track;
+    vi.mocked(usePlayerSyncState).mockReturnValue({
+      playing: true,
+      currentTrackId: 999,
+      currentSeconds: 37,
+    });
+
+    const { result } = renderHook(() => useTrackGroupWidgetData());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.elapsedSeconds).toBe(0);
+    expect(result.current.currentTrack).toBeUndefined();
+  });
+
+  test("uses local current seconds outside embedded Mirlo widgets", async () => {
+    vi.mocked(isEmbeddedInMirlo).mockReturnValue(false);
+    const { result } = renderHook(() => useTrackGroupWidgetData());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    act(() => result.current.setCurrentSeconds(42));
+
+    expect(result.current.elapsedSeconds).toBe(42);
+  });
+});

--- a/client/src/components/Widget/TrackGroupWidget/useTrackGroupWidgetData.ts
+++ b/client/src/components/Widget/TrackGroupWidget/useTrackGroupWidgetData.ts
@@ -20,9 +20,6 @@ export const useTrackGroupWidgetData = () => {
 
   const embeddedInMirlo = isEmbeddedInMirlo();
   const playerSyncState = usePlayerSyncState();
-  const elapsedSeconds = embeddedInMirlo
-    ? (playerSyncState?.currentSeconds ?? 0)
-    : currentSeconds;
 
   React.useEffect(() => {
     const callback = async () => {
@@ -61,13 +58,28 @@ export const useTrackGroupWidgetData = () => {
   const playableTracks = trackGroup?.tracks.filter((track) =>
     isTrackOwnedOrPreview(track, user, trackGroup)
   );
+  const ownTrackIds = new Set(
+    trackGroup?.tracks.map((track) => track.id) ?? []
+  );
+  const syncedTrackId = playerSyncState?.currentTrackId ?? null;
+  const hasSyncedTrack =
+    syncedTrackId !== null && ownTrackIds.has(syncedTrackId);
+  const scopedCurrentTrack =
+    embeddedInMirlo && (!hasSyncedTrack || currentTrack?.id !== syncedTrackId)
+      ? undefined
+      : currentTrack;
+  const elapsedSeconds = embeddedInMirlo
+    ? hasSyncedTrack
+      ? playerSyncState?.currentSeconds ?? 0
+      : 0
+    : currentSeconds;
 
   return {
     trackGroup,
     artist,
     isLoading,
     user,
-    currentTrack,
+    currentTrack: scopedCurrentTrack,
     currentSeconds,
     setCurrentSeconds,
     elapsedSeconds,


### PR DESCRIPTION
## Summary

Embedded track-group and post widgets no longer display another widget's playing track. When the parent player switches to a track that belongs to a different widget, each widget's data hook now scopes both the elapsed time and the current track to the track it owns, so unrelated widgets stop showing a stray `0:00 / <other track>` line.

## Why this matters

With several embedded widgets on a page, the shared player sync broadcast a single current track, and each widget's hook returned that global track even when it belonged to a different widget, so unrelated widgets rendered a misleading playing state. Scoping the returned current track against the synced track id in both the track-group and post hooks fixes the cross-widget bleed. Reported in #2227.

## Testing

Added hook tests for the track-group and post widgets asserting the current track and timer are cleared when the synced track does not belong to the widget.

Closes #2227
