### PR TITLE
feat: select storage backend from configuration instead of NODE_ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ MAILHOG_PORT=1025
 
 STRIPE_KEY=
 
+# Which object storage to use: "minio" or "s3" (Backblaze, Hetzner, etc.).
+# Usually unnecessary: when unset, Mirlo uses an S3 service if the S3
+# credentials below are filled in, and MinIO otherwise.
+# STORAGE_BACKEND=minio
+
 S3_ACCESS_KEY_ID=
 S3_KEY_NAME=
 S3_SECRET_ACCESS_KEY=

--- a/render.yaml
+++ b/render.yaml
@@ -24,6 +24,8 @@ services:
           name: blackbrd
           property: connectionString
       - fromGroup: blackbrd
+      - key: STORAGE_BACKEND
+        value: s3
       - key: REDIS_HOST
         fromService:
           type: redis
@@ -89,6 +91,8 @@ services:
           name: blackbrd
           property: connectionString
       - fromGroup: blackbrd
+      - key: STORAGE_BACKEND
+        value: s3
       - key: REDIS_HOST
         fromService:
           type: redis
@@ -131,6 +135,8 @@ services:
           name: blackbrd
           property: connectionString
       - fromGroup: blackbrd
+      - key: STORAGE_BACKEND
+        value: s3
       - key: MINIO_ROOT_PASSWORD
         fromService:
           type: web
@@ -186,6 +192,8 @@ services:
           name: redis
           property: port
       - fromGroup: blackbrd
+      - key: STORAGE_BACKEND
+        value: s3
 
     branch: main # optional (defaults to master)
 
@@ -215,6 +223,8 @@ services:
           name: redis
           property: port
       - fromGroup: blackbrd
+      - key: STORAGE_BACKEND
+        value: s3
     branch: main # optional (defaults to master)
 
   # A Redis instance

--- a/src/utils/minio.ts
+++ b/src/utils/minio.ts
@@ -70,11 +70,28 @@ const {
   S3_ENDPOINT = "https://s3.us-east-005.backblazeb2.com",
   S3_REGION = "us-east-005",
   MINIO_API_PORT = 9000,
-  NODE_ENV,
 } = process.env;
 
-export const backendStorage: "minio" | "backblaze" =
-  NODE_ENV === "production" ? "backblaze" : "minio";
+// Storage backend selection. Set STORAGE_BACKEND=minio|s3|backblaze to choose
+// explicitly; when unset, the backend is inferred from what's configured —
+// S3 credentials present means an S3-compatible service (Backblaze, Hetzner
+// Object Storage, etc.), otherwise MinIO. Exported for tests.
+export const resolveBackendStorage = (
+  explicit: string | undefined = process.env.STORAGE_BACKEND,
+  hasS3Credentials: boolean = Boolean(S3_ACCESS_KEY_ID && S3_SECRET_ACCESS_KEY)
+): "minio" | "backblaze" => {
+  const normalized = explicit?.trim().toLowerCase();
+  if (normalized === "minio") return "minio";
+  if (normalized === "s3" || normalized === "backblaze") return "backblaze";
+  if (normalized) {
+    throw new Error(
+      `Invalid STORAGE_BACKEND "${explicit}" — expected "minio", "s3" or "backblaze"`
+    );
+  }
+  return hasS3Credentials ? "backblaze" : "minio";
+};
+
+export const backendStorage: "minio" | "backblaze" = resolveBackendStorage();
 
 // and access keys as shown below.
 export const minioClient =
@@ -108,9 +125,8 @@ export const minioPublicClient =
       })
     : undefined;
 
-// Toggle this to true if you want to test backblaze locally
-// Note: you'll need both the backblaze key id and app key
-// set for this to work.
+// To test backblaze locally, set S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY
+// (the backend auto-switches), or force it with STORAGE_BACKEND=s3.
 // FIXME: this should / could be set in the database as part
 // of the site settings.
 

--- a/test/utils/storageBackend.spec.ts
+++ b/test/utils/storageBackend.spec.ts
@@ -1,0 +1,41 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import { describe, it } from "mocha";
+
+import assert from "assert";
+
+import { resolveBackendStorage } from "../../src/utils/minio";
+
+describe("resolveBackendStorage", () => {
+  it("defaults to minio when nothing is configured", () => {
+    assert.equal(resolveBackendStorage(undefined, false), "minio");
+  });
+
+  it("auto-selects s3 when S3 credentials are configured", () => {
+    assert.equal(resolveBackendStorage(undefined, true), "backblaze");
+  });
+
+  it("explicit minio wins over configured S3 credentials", () => {
+    assert.equal(resolveBackendStorage("minio", true), "minio");
+    assert.equal(resolveBackendStorage("MinIO", true), "minio");
+  });
+
+  it("accepts s3 and backblaze as aliases", () => {
+    assert.equal(resolveBackendStorage("s3", false), "backblaze");
+    assert.equal(resolveBackendStorage("backblaze", false), "backblaze");
+    assert.equal(resolveBackendStorage("S3", false), "backblaze");
+  });
+
+  it("throws on an unrecognized value instead of silently defaulting", () => {
+    assert.throws(
+      () => resolveBackendStorage("minoi", false),
+      /Invalid STORAGE_BACKEND/
+    );
+  });
+
+  it("treats empty/whitespace as unset", () => {
+    assert.equal(resolveBackendStorage("", true), "backblaze");
+    assert.equal(resolveBackendStorage("  ", false), "minio");
+  });
+});


### PR DESCRIPTION
Previously NODE_ENV=production hardcoded Backblaze/S3, which silently broke MinIO installs that followed the deployment docs. The backend is now chosen by STORAGE_BACKEND=minio|s3|backblaze when set (invalid values fail at startup), and otherwise inferred: S3 credentials configured means an S3-compatible service, anything else means MinIO.

Production behavior is unchanged — render.yaml pins STORAGE_BACKEND=s3 explicitly, and would auto-detect s3 from its credentials anyway. Local dev keeps MinIO, and testing S3 locally now just requires filling in the S3_* variables.