### PR TITLE
feat: add umami as a cookie-less on-site tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+*.tsbuildinfo
 .env
 /data
 error.log

--- a/client/.env.example
+++ b/client/.env.example
@@ -8,3 +8,9 @@ VITE_CLIENT_DOMAIN=http://localhost:8080
 
 VITE_CLOUDFLARE_CLIENT_KEY=1x00000000000000000000AA
 
+# Umami analytics — leave unset in dev so no events are recorded.
+# In production this is set at build time (Render env vars on the api
+# service, since that's what builds the client).
+# VITE_UMAMI_WEBSITE_ID=
+# VITE_UMAMI_SRC=https://stats.mirlo.space/script.js
+

--- a/client/src/analytics.ts
+++ b/client/src/analytics.ts
@@ -1,0 +1,20 @@
+/**
+ * Loads the Umami tracking script (self-hosted, see render.yaml).
+ *
+ * Only runs when VITE_UMAMI_WEBSITE_ID is set — it's unset in local dev so
+ * no events are recorded there. Umami automatically tracks SPA route
+ * changes by hooking the History API, so loading the script once is enough.
+ */
+export const initAnalytics = () => {
+  const websiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID;
+  if (!websiteId) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.defer = true;
+  script.src =
+    import.meta.env.VITE_UMAMI_SRC ?? "https://stats.mirlo.space/script.js";
+  script.dataset.websiteId = websiteId;
+  document.head.appendChild(script);
+};

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -17,10 +17,13 @@ import { SnackBarContextProvider } from "state/SnackbarContext";
 import { UploadContextProvider } from "state/UploadContext";
 import { ConfirmContextProvider } from "utils/useConfirm";
 
+import { initAnalytics } from "./analytics";
 import { GlobalStateProvider } from "./state/GlobalState";
 
 import { QueryClientWrapper } from "queries/QueryClientWrapper";
 import { ConfirmDialog } from "components/common/ConfirmDialog";
+
+initAnalytics();
 
 const router = createBrowserRouter(routes);
 

--- a/render.yaml
+++ b/render.yaml
@@ -17,6 +17,10 @@ services:
         value: true
       - key: NODE_ENV
         value: production
+      # Baked into the client at build time; the website ID comes from the
+      # Umami dashboard after adding mirlo.space as a website there.
+      - key: VITE_UMAMI_WEBSITE_ID
+        sync: false
       - key: NODE_OPTIONS
         value: --max-old-space-size=1512
       - key: DATABASE_URL
@@ -71,6 +75,38 @@ services:
       name: data
       mountPath: /data
       sizeGB: 600 # optional
+
+  # Umami analytics (https://umami.is)
+  # Runs against a separate `umami` database inside the existing blackbrd
+  # Postgres instance. Umami is itself a Prisma app, so it must NOT share
+  # Mirlo's database — both would write to the same _prisma_migrations table.
+  # Blueprints don't support string interpolation, so the dockerCommand
+  # rewrites the blackbrd connection string to point at /umami at startup.
+  # One-time setup:
+  #   1. psql <blackbrd external connection string>
+  #   2. CREATE DATABASE umami;
+  # Default login is admin / umami — change it immediately after first deploy.
+  - type: web
+    name: umami
+    runtime: image
+    image:
+      url: ghcr.io/umami-software/umami:postgresql-latest
+    dockerCommand: sh -c 'export DATABASE_URL="${BASE_DATABASE_URL%/*}/umami" && npm run start-docker'
+    plan: starter
+    region: oregon
+    autoDeploy: false
+    healthCheckPath: /api/heartbeat
+    envVars:
+      - key: BASE_DATABASE_URL
+        fromDatabase:
+          name: blackbrd
+          property: connectionString
+      - key: DATABASE_TYPE
+        value: postgresql
+      - key: APP_SECRET
+        generateValue: true
+      - key: DISABLE_TELEMETRY
+        value: 1
 
   # A worker
   - type: worker


### PR DESCRIPTION
@timglorioso @LouisLouiseKay what do you think? this adds our own [umami](https://umami.is/) instance for analytics. Things are stored on our own postgres database (shared with the main database). It would bump our monthly cost $7/mo with the starter render instance. Seems worth it to me to get insight of where traffic is coming from. Note that this is different from analytics for artists which I think is something we should build out ourselves rather than using a third party instance. 