### PR TITLE
chore: migrate track purchases to new flow

### DIFF
--- a/client/cypress/e2e/customer-purchase-track.cy.ts
+++ b/client/cypress/e2e/customer-purchase-track.cy.ts
@@ -1,0 +1,121 @@
+/// <reference types="cypress" />
+
+const customerEmail = "track-purchase-customer@example.com";
+const customerPassword = "test1234";
+const artistOwnerEmail = "track-purchase-artist-owner@example.com";
+const artistOwnerPassword = "test1234";
+
+const artistSlug = "track-purchase-artist";
+const releaseSlug = "track-purchase-release";
+
+// Covers the track migration onto the unified POST /v1/purchase flow: a
+// single, individually-sellable track should submit `{ items: [{ type:
+// "track", id }] }`, the same way the album purchase already does for
+// `{ type: "trackGroup" }` (see customer-purchase-pricing.cy.ts).
+describe("customer purchase - single track", () => {
+  let trackId: number;
+
+  before(() => {
+    cy.task("clearTables");
+
+    cy.task("createUser", {
+      email: customerEmail,
+      password: customerPassword,
+      emailConfirmationToken: null,
+      name: "Track Purchase Customer",
+      currency: "usd",
+    })
+      .then(() => {
+        return cy.task("createUser", {
+          email: artistOwnerEmail,
+          password: artistOwnerPassword,
+          emailConfirmationToken: null,
+          name: "Track Purchase Artist Owner",
+          currency: "usd",
+        });
+      })
+      .then((owner) => {
+        const typedOwner = owner as { user: { id: number } };
+
+        return cy.task("createArtist", {
+          userId: typedOwner.user.id,
+          name: "Track Purchase Artist",
+          urlSlug: artistSlug,
+        });
+      })
+      .then((artist) => {
+        const typedArtist = artist as { id: number };
+
+        // The buy/name-your-price button label is driven by the trackGroup's
+        // minPrice, not the individual track's — keep it non-zero here so the
+        // button reads "Buy" rather than "name your price" (#see PurchaseAlbumModal).
+        return cy.task("createTrackGroup", {
+          artistId: typedArtist.id,
+          title: "Track Purchase Release",
+          urlSlug: releaseSlug,
+          minPrice: 300,
+          published: true,
+          isGettable: true,
+        });
+      })
+      .then((trackGroup) => {
+        const typedTrackGroup = trackGroup as { id: number };
+
+        return cy.task("createTrack", {
+          trackGroupId: typedTrackGroup.id,
+          title: "Individually Sellable Track",
+          minPrice: 300,
+          allowIndividualSale: true,
+        });
+      })
+      .then((track) => {
+        const typedTrack = track as { id: number };
+        trackId = typedTrack.id;
+      });
+  });
+
+  beforeEach(() => {
+    cy.login({ email: customerEmail, password: customerPassword });
+
+    cy.intercept("GET", "/v1/users/*/stripe/checkAccountStatus", {
+      statusCode: 200,
+      body: {
+        result: {
+          chargesEnabled: true,
+          detailsSubmitted: true,
+          stripeAccountId: "acct_test_123",
+        },
+      },
+    }).as("stripeStatus");
+
+    cy.intercept("POST", "/v1/purchase", (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          redirectUrl: "/",
+        },
+      });
+    }).as("purchaseTrack");
+  });
+
+  it("purchases the track (not the trackGroup) via the unified endpoint", () => {
+    cy.visit(`/${artistSlug}/release/${releaseSlug}/tracks/${trackId}`);
+
+    cy.contains("button", "Buy").click();
+    cy.wait("@stripeStatus");
+
+    cy.get('[role="dialog"]').within(() => {
+      cy.get("#priceInput").should("have.value", "3");
+      cy.contains("button", "Buy").click();
+    });
+
+    cy.wait("@purchaseTrack")
+      .its("request.body")
+      .should((body) => {
+        expect(body.artistId).to.exist;
+        expect(body.items).to.have.length(1);
+        expect(body.items[0].type).to.eq("track");
+        expect(body.items[0].id).to.eq(trackId);
+      });
+  });
+});

--- a/client/src/components/TrackGroup/BuyTrackGroup.test.tsx
+++ b/client/src/components/TrackGroup/BuyTrackGroup.test.tsx
@@ -1,0 +1,142 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en" },
+  }),
+  initReactI18next: { type: "3rdParty", init: vi.fn() },
+}));
+
+// The Stripe account status is fetched via useQuery — bypass the network and
+// return a connected, chargeable account for every test in this file.
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: () => ({
+      data: { chargesEnabled: true, stripeAccountId: "acct_1" },
+      isPending: false,
+    }),
+  };
+});
+
+vi.mock("./utils", () => ({
+  testOwnership: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("state/AuthContext", () => ({
+  useAuthContext: () => ({
+    user: { id: 1, email: "buyer@test.com", artistUserSubscriptions: [] },
+  }),
+}));
+
+const startPurchase = vi.fn().mockResolvedValue(undefined);
+const purchaseState: {
+  checkout: null | { clientSecret: string; stripeAccountId: string };
+} = { checkout: null };
+vi.mock("components/common/Purchase/usePurchase", () => ({
+  usePurchase: () => ({
+    checkout: purchaseState.checkout,
+    startPurchase,
+  }),
+}));
+
+vi.mock("components/common/Purchase/PurchaseElements", () => ({
+  default: () => <div data-testid="purchase-elements" />,
+}));
+
+vi.mock("components/common/stripe/EmbeddedStripe", () => ({
+  default: () => <div data-testid="embedded-stripe" />,
+}));
+
+import BuyTrackGroup from "./BuyTrackGroup";
+
+const baseArtist = {
+  id: 10,
+  name: "Test Artist",
+  urlSlug: "test-artist",
+  userId: 10,
+  user: { currency: "usd" },
+};
+
+const baseTrackGroup = {
+  id: 100,
+  title: "Test Album",
+  urlSlug: "test-album",
+  artistId: 10,
+  artist: baseArtist,
+  minPrice: 500,
+  suggestedPrice: 500,
+  currency: "usd",
+  platformPercent: 8,
+  isPreorder: false,
+} as any;
+
+function renderComponent(
+  props: Partial<React.ComponentProps<typeof BuyTrackGroup>>
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <BuyTrackGroup trackGroup={baseTrackGroup} {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+async function submitForm(container: HTMLElement) {
+  const form = container.querySelector("form");
+  if (!form) throw new Error("form not found");
+  fireEvent.submit(form);
+  await waitFor(() => expect(startPurchase).toHaveBeenCalled());
+}
+
+describe("BuyTrackGroup", () => {
+  beforeEach(() => {
+    startPurchase.mockClear();
+    purchaseState.checkout = null;
+  });
+
+  test("submitting without a track purchases the trackGroup via the unified endpoint", async () => {
+    const { container } = renderComponent({});
+    await submitForm(container);
+
+    expect(startPurchase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artistId: 10,
+        items: [expect.objectContaining({ type: "trackGroup", id: 100 })],
+      })
+    );
+  });
+
+  test("submitting with a track purchases the track (not the trackGroup) via the unified endpoint", async () => {
+    const track = { id: 200, minPrice: 300 } as any;
+    const { container } = renderComponent({ track });
+    await submitForm(container);
+
+    expect(startPurchase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artistId: 10,
+        items: [expect.objectContaining({ type: "track", id: 200 })],
+      })
+    );
+  });
+
+  test("renders the Payment Element once usePurchase reports a checkout in progress", async () => {
+    purchaseState.checkout = {
+      clientSecret: "secret_1",
+      stripeAccountId: "acct_1",
+    };
+    renderComponent({});
+
+    expect(await screen.findByTestId("purchase-elements")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/TrackGroup/BuyTrackGroup.tsx
+++ b/client/src/components/TrackGroup/BuyTrackGroup.tsx
@@ -78,17 +78,17 @@ const BuyTrackGroup: React.FC<{
   const isPledgeMode =
     !!trackGroup.fundraiser?.isAllOrNothing &&
     (trackGroup.fundraiser?.status ?? "ACTIVE") === "ACTIVE";
-  // DEPRECATED — Flow A (per-resource Checkout Session + EmbeddedStripeForm).
-  // Track purchases (plan Phase 4) and fundraiser pledges (Phase 5) are not yet
-  // resolved by `POST /v1/purchase`, so they stay on the deprecated
-  // `tracks/:id/purchase` / `trackGroups/:id/purchase` endpoints. Remove this
-  // branch once both are migrated onto usePurchase/PurchaseModal — album
-  // (trackGroup) purchases already are.
-  const usesLegacyFlow = !!track || isPledgeMode;
+  // DEPRECATED — Remove this branch once pledges are migrated onto
+  // usePurchase/PurchaseModal — album and track purchases already are.
+  const usesLegacyFlow = isPledgeMode;
 
-  const checkoutCompletePath = `${getArtistUrl(
-    trackGroup.artist
-  )}/checkout-complete?purchaseType=trackGroup&trackGroupId=${trackGroup.id}`;
+  const checkoutCompletePath = (() => {
+    const params = new URLSearchParams();
+    params.set("purchaseType", track ? "track" : "trackGroup");
+    params.set("trackGroupId", trackGroup.id.toString());
+    if (track) params.set("trackId", track.id.toString());
+    return `${getArtistUrl(trackGroup.artist)}/checkout-complete?${params.toString()}`;
+  })();
 
   const purchaseAlbum = React.useCallback(
     async (data: FormData) => {
@@ -140,15 +140,13 @@ const BuyTrackGroup: React.FC<{
           return;
         }
 
-        // Album (trackGroup) → unified POST /v1/purchase. The modal/return-url
-        // handles completion; the post-payment full-page redirect resets the
-        // player, covering what onPurchaseComplete did inline (#1630).
+        // Album (trackGroup) or single track → unified POST /v1/purchase.
         await startPurchase({
           artistId: trackGroup.artistId ?? trackGroup.artist.id,
           items: [
             {
-              type: "trackGroup",
-              id: trackGroup.id,
+              type: track ? "track" : "trackGroup",
+              id: track ? track.id : trackGroup.id,
               // determinePrice expects the chosen price in cents.
               price: data.chosenPrice
                 ? String(Number(data.chosenPrice) * 100)

--- a/client/src/components/common/Purchase/usePurchase.ts
+++ b/client/src/components/common/Purchase/usePurchase.ts
@@ -6,6 +6,7 @@ import useErrorHandler from "services/useErrorHandler";
 /** A single item in a purchase cart. Mirrors `POST /v1/purchase`'s `items`. */
 export type PurchaseItem =
   | { type: "trackGroup"; id: number; price?: string; message?: string }
+  | { type: "track"; id: number; price?: string; message?: string }
   | { type: "merch"; id: string; quantity?: number; message?: string }
   | { type: "tip"; amount: number; message?: string };
 

--- a/src/routers/v1/api-doc.ts
+++ b/src/routers/v1/api-doc.ts
@@ -142,7 +142,7 @@ const apiDoc = {
             properties: {
               type: {
                 type: "string",
-                enum: ["trackGroup", "merch", "tip", "subscription"],
+                enum: ["trackGroup", "track", "merch", "tip", "subscription"],
               },
               id: {
                 type: ["number", "string"],

--- a/src/routers/v1/purchase/index.ts
+++ b/src/routers/v1/purchase/index.ts
@@ -9,7 +9,10 @@ import { subscribeUserToArtist } from "../../../utils/artist";
 import { buildCheckoutRedirectUrl, originOf } from "../../../utils/clientUrl";
 import { AppError } from "../../../utils/error";
 import { getClient } from "../../../utils/getClient";
-import { handleTrackGroupPurchase } from "../../../utils/handleFinishedTransactions";
+import {
+  handleTrackGroupPurchase,
+  handleTrackPurchase,
+} from "../../../utils/handleFinishedTransactions";
 import { resolvePayee } from "../../../utils/payments/payee";
 import {
   initiatePayment,
@@ -21,6 +24,7 @@ import { findUserDiscountPercentsForArtist } from "../../../utils/user";
 
 type PurchaseItem =
   | { type: "trackGroup"; id: number; price?: string; message?: string }
+  | { type: "track"; id: number; price?: string; message?: string }
   | { type: "merch"; id: string; quantity?: number; message?: string }
   | { type: "tip"; amount: number; message?: string }
   | { type: "subscription"; tierId: number; amount?: number };
@@ -44,6 +48,97 @@ type PostBody = {
    * page when omitted.
    */
   successUrl?: string;
+};
+
+// trackGroup and track purchases resolve identically (payee, follow-on-buy,
+// user discount, free-vs-paid) — only the Prisma fetch and free-purchase
+// handler differ per type, so callers do those and hand the shared shape in.
+type DigitalReleaseArtist = Parameters<typeof subscribeUserToArtist>[0] &
+  Parameters<typeof resolvePayee>[0]["artist"] & { urlSlug: string | null };
+
+const resolveDigitalPurchaseItem = async <T extends "trackGroup" | "track">({
+  type,
+  id,
+  loggedInUser,
+  readerId,
+  price,
+  message,
+  minPrice,
+  artist,
+  paymentToUser,
+  releaseUrlSlug,
+  releaseId,
+  handleFreePurchase,
+}: {
+  type: T;
+  id: number;
+  loggedInUser?: Express.User;
+  readerId?: string;
+  price?: string;
+  message?: string;
+  minPrice: number | null;
+  artist: DigitalReleaseArtist;
+  paymentToUser?: { stripeAccountId: string | null } | null;
+  /** The release (trackGroup) the download link points at — same for both a trackGroup and one of its tracks. */
+  releaseUrlSlug: string | null;
+  releaseId: number;
+  handleFreePurchase: () => Promise<unknown>;
+}): Promise<
+  | { kind: "free"; redirectUrl: string }
+  | { kind: "paid"; stripeAccountId?: string; item: ResolvedItem }
+> => {
+  const payee = resolvePayee({
+    artist,
+    releasePaymentToUser: paymentToUser,
+  }) as {
+    stripeAccountId: string | null;
+  };
+  const stripeAccountId = payee.stripeAccountId ?? undefined;
+
+  if (loggedInUser) {
+    await subscribeUserToArtist(artist, loggedInUser);
+  }
+
+  let discountPercent = 0;
+  if (loggedInUser) {
+    const discounts = await findUserDiscountPercentsForArtist(
+      loggedInUser.id,
+      artist.id
+    );
+    discountPercent = discounts.reduce(
+      (max, d) => Math.max(max, d.digitalDiscountPercent ?? 0),
+      0
+    );
+  }
+
+  const { isPriceZero, priceNumber } = determinePrice(price, minPrice);
+
+  // Free online purchase — handle immediately, no PaymentIntent needed
+  if (isPriceZero && !readerId && loggedInUser) {
+    await handleFreePurchase();
+    return {
+      kind: "free",
+      redirectUrl: `/${artist.urlSlug ?? artist.id}/release/${
+        releaseUrlSlug ?? releaseId
+      }/download?email=${loggedInUser.email}`,
+    };
+  }
+
+  const discountedAmount = discountPercent
+    ? Math.round(priceNumber * (1 - discountPercent / 100))
+    : priceNumber;
+
+  return {
+    kind: "paid",
+    stripeAccountId,
+    item: {
+      type,
+      id: String(id),
+      quantity: 1,
+      amount: discountedAmount,
+      message,
+    },
+  };
 };
 
 /**
@@ -184,54 +279,73 @@ export default function () {
             });
           }
 
-          resolvedStripeAccountId =
-            resolvePayee({
-              artist: tg.artist,
-              releasePaymentToUser: tg.paymentToUser,
-            }).stripeAccountId ?? undefined;
+          const result = await resolveDigitalPurchaseItem({
+            type: "trackGroup",
+            id: tg.id,
+            loggedInUser,
+            readerId,
+            price: item.price,
+            message: item.message,
+            minPrice: tg.minPrice,
+            artist: tg.artist,
+            paymentToUser: tg.paymentToUser,
+            releaseUrlSlug: tg.urlSlug,
+            releaseId: tg.id,
+            handleFreePurchase: () =>
+              handleTrackGroupPurchase(loggedInUser!.id, tg.id),
+          });
 
-          if (loggedInUser) {
-            await subscribeUserToArtist(tg.artist, loggedInUser);
+          if (result.kind === "free") {
+            return res.status(200).json({ redirectUrl: result.redirectUrl });
           }
-
-          let discountPercent = 0;
-          if (loggedInUser) {
-            const discounts = await findUserDiscountPercentsForArtist(
-              loggedInUser.id,
-              tg.artistId
-            );
-            discountPercent = discounts.reduce(
-              (max, d) => Math.max(max, d.digitalDiscountPercent ?? 0),
-              0
-            );
-          }
-
-          const { isPriceZero, priceNumber } = determinePrice(
-            item.price,
-            tg.minPrice
-          );
-
-          // Free online purchase — handle immediately, no PaymentIntent needed
-          if (isPriceZero && !readerId && loggedInUser) {
-            await handleTrackGroupPurchase(loggedInUser.id, tg.id);
-            return res.status(200).json({
-              redirectUrl: `/${tg.artist.urlSlug ?? tg.artist.id}/release/${
-                tg.urlSlug ?? tg.id
-              }/download?email=${loggedInUser.email}`,
+          resolvedStripeAccountId = result.stripeAccountId;
+          resolvedItems.push(result.item);
+        } else if (item.type === "track") {
+          const track = await prisma.track.findFirst({
+            where: { id: item.id, trackGroup: { artistId } },
+            include: {
+              trackGroup: {
+                include: {
+                  artist: {
+                    include: {
+                      user: true,
+                      paymentToUser: true,
+                      subscriptionTiers: true,
+                    },
+                  },
+                  paymentToUser: { select: { stripeAccountId: true } },
+                },
+              },
+            },
+          });
+          if (!track) {
+            throw new AppError({
+              httpCode: 404,
+              description: `Track ${item.id} not found`,
             });
           }
 
-          const discountedAmount = discountPercent
-            ? Math.round(priceNumber * (1 - discountPercent / 100))
-            : priceNumber;
-
-          resolvedItems.push({
-            type: "trackGroup",
-            id: String(item.id),
-            quantity: 1,
-            amount: discountedAmount,
+          const result = await resolveDigitalPurchaseItem({
+            type: "track",
+            id: track.id,
+            loggedInUser,
+            readerId,
+            price: item.price,
             message: item.message,
+            minPrice: track.minPrice,
+            artist: track.trackGroup.artist,
+            paymentToUser: track.trackGroup.paymentToUser,
+            releaseUrlSlug: track.trackGroup.urlSlug,
+            releaseId: track.trackGroup.id,
+            handleFreePurchase: () =>
+              handleTrackPurchase(loggedInUser!.id, track.id),
           });
+
+          if (result.kind === "free") {
+            return res.status(200).json({ redirectUrl: result.redirectUrl });
+          }
+          resolvedStripeAccountId = result.stripeAccountId;
+          resolvedItems.push(result.item);
         } else if (item.type === "merch") {
           const merch = await prisma.merch.findFirst({
             where: {

--- a/src/routers/v1/tracks/{id}/purchase.ts
+++ b/src/routers/v1/tracks/{id}/purchase.ts
@@ -146,6 +146,9 @@ export default function () {
 
   POST.apiDoc = {
     summary: "Purchase a Track",
+    deprecated: true,
+    description:
+      'Deprecated — use POST /v1/purchase with items: [{ type: "track", id }] instead.',
     parameters: [
       {
         in: "path",

--- a/src/utils/payments/purchase.ts
+++ b/src/utils/payments/purchase.ts
@@ -11,7 +11,7 @@ import { resolvePayee } from "./payee";
 import { getPaymentProcessor } from "./PaymentProcessor";
 
 export type ResolvedItem = {
-  type: "trackGroup" | "merch" | "tip";
+  type: "trackGroup" | "track" | "merch" | "tip";
   id?: string;
   quantity: number;
   amount: number;
@@ -105,6 +105,7 @@ export const initiatePayment = async ({
     ...(successUrl && { successUrl }),
     ...(purchaseType === "trackGroup" &&
       items[0]?.id && { trackGroupId: items[0].id }),
+    ...(purchaseType === "track" && items[0]?.id && { trackId: items[0].id }),
     items: JSON.stringify(items),
   };
 

--- a/src/utils/stripe/index.ts
+++ b/src/utils/stripe/index.ts
@@ -964,7 +964,8 @@ export const completePurchaseFromIntent = async (
   const metadata = (intent.metadata ?? {}) as unknown as SessionMetaData & {
     items?: string;
   };
-  const { purchaseType, userId, userEmail, trackGroupId, artistId } = metadata;
+  const { purchaseType, userId, userEmail, trackGroupId, trackId, artistId } =
+    metadata;
 
   // Adapt the PaymentIntent into the shape the existing handlers expect. All
   // handlers use optional chaining so missing session fields fall back to
@@ -988,6 +989,12 @@ export const completePurchaseFromIntent = async (
       Number(trackGroupId),
       sessionAdapter,
       newUser
+    );
+  } else if (purchaseType === "track" && trackId) {
+    await handleTrackPurchase(
+      Number(actualUserId),
+      Number(trackId),
+      sessionAdapter
     );
   } else if (purchaseType === "tip" && artistId) {
     await handleArtistGift(

--- a/test/routers/purchase.spec.ts
+++ b/test/routers/purchase.spec.ts
@@ -17,6 +17,7 @@ import * as terminalUtils from "../../src/utils/stripe/terminal";
 import {
   clearTables,
   createArtist,
+  createTrack,
   createTrackGroup,
   createMerch,
   createTier,
@@ -242,6 +243,109 @@ describe("purchase", () => {
 
       assert.equal(response.statusCode, 200);
       assert.ok(response.body.clientSecret);
+    });
+
+    it("should return 404 when track does not belong to the given artist", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@test.com",
+      });
+      const { user: otherUser } = await createUser({ email: "other@test.com" });
+      const { accessToken } = await createUser({ email: "buyer@test.com" });
+      const artist = await createArtist(artistUser.id);
+      const otherArtist = await createArtist(otherUser.id, {
+        urlSlug: "other-artist-2",
+      });
+      const tgFromOther = await createTrackGroup(otherArtist.id, {
+        minPrice: 1000,
+      });
+      const trackFromOther = await createTrack(tgFromOther.id, {
+        minPrice: 1000,
+      });
+
+      const response = await requestApp
+        .post("purchase")
+        .send({
+          artistId: artist.id,
+          items: [{ type: "track", id: trackFromOther.id }],
+        })
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+      assert.equal(response.statusCode, 404);
+    });
+
+    it("should return 200 with redirectUrl for a free track when user is logged in", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@test.com",
+      });
+      const { user: buyer, accessToken } = await createUser({
+        email: "buyer@test.com",
+      });
+      const artist = await createArtist(artistUser.id);
+      const tg = await createTrackGroup(artist.id, { minPrice: 0 });
+      const track = await createTrack(tg.id, { minPrice: 0 });
+
+      const response = await requestApp
+        .post("purchase")
+        .send({
+          artistId: artist.id,
+          items: [{ type: "track", id: track.id }],
+        })
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.ok(response.body.redirectUrl, "should return a redirectUrl");
+      assert.ok(response.body.redirectUrl.includes("download"));
+
+      const purchase = await prisma.userTrackPurchase.findFirst({
+        where: { userId: buyer.id, trackId: track.id },
+      });
+      assert.ok(purchase, "purchase record should be created in DB");
+    });
+
+    it("should return 200 with clientSecret for a paid online track purchase", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@test.com",
+        stripeAccountId: "acct_track_online",
+      });
+      const { accessToken } = await createUser({ email: "buyer@test.com" });
+      const artist = await createArtist(artistUser.id);
+      const tg = await createTrackGroup(artist.id, { minPrice: 0 });
+      const track = await createTrack(tg.id, { minPrice: 500 });
+
+      const response = await requestApp
+        .post("purchase")
+        .send({
+          artistId: artist.id,
+          items: [{ type: "track", id: track.id, price: "500" }],
+        })
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.ok(response.body.clientSecret);
+    });
+
+    it("should return 400 when the price offered is below a track's minPrice", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@test.com",
+        stripeAccountId: "acct_track_min",
+      });
+      const { accessToken } = await createUser({ email: "buyer@test.com" });
+      const artist = await createArtist(artistUser.id);
+      const tg = await createTrackGroup(artist.id, { minPrice: 0 });
+      const track = await createTrack(tg.id, { minPrice: 500 });
+
+      const response = await requestApp
+        .post("purchase")
+        .send({
+          artistId: artist.id,
+          items: [{ type: "track", id: track.id, price: "100" }],
+        })
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 400);
     });
 
     it("should return 200 with a hosted redirectUrl when hosted is true", async () => {
@@ -502,6 +606,40 @@ describe("purchase", () => {
       assert.equal(metadata.purchaseType, "trackGroup");
       // trackGroupId points at the first trackGroup in the cart.
       assert.equal(metadata.trackGroupId, String(tg1.id));
+    });
+
+    it("tags a single online track purchase with purchaseType 'track' and its trackId", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@test.com",
+        stripeAccountId: "acct_meta_track",
+      });
+      const { user: buyer } = await createUser({ email: "buyer@test.com" });
+      const artist = await createArtist(artistUser.id);
+      const tg = await createTrackGroup(artist.id, { minPrice: 0 });
+      const track = await createTrack(tg.id, { minPrice: 500 });
+
+      const createStub = stubStripeForOnline();
+
+      const result = await initiatePayment({
+        artistId: artist.id,
+        items: [
+          { type: "track", id: String(track.id), quantity: 1, amount: 500 },
+        ],
+        userEmail: buyer.email,
+        userId: String(buyer.id),
+      });
+
+      assert.ok(
+        "clientSecret" in result,
+        "an online purchase returns a secret"
+      );
+      const metadata = metadataOf(createStub);
+      assert.equal(metadata.purchaseType, "track");
+      assert.equal(metadata.trackId, String(track.id));
+      assert.ok(
+        !("trackGroupId" in metadata),
+        "a single-track purchase carries no trackGroupId"
+      );
     });
 
     it("tags a single online tip as purchaseType 'tip' and omits trackGroupId", async () => {

--- a/test/utils/completePurchaseFromIntent.track.spec.ts
+++ b/test/utils/completePurchaseFromIntent.track.spec.ts
@@ -1,0 +1,99 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import assert from "assert";
+
+import { describe, it } from "mocha";
+import sinon from "sinon";
+import Stripe from "stripe";
+
+import * as sendMail from "../../src/jobs/send-mail";
+import { completePurchaseFromIntent } from "../../src/utils/stripe";
+import {
+  clearTables,
+  createArtist,
+  createTrack,
+  createTrackGroup,
+  createUser,
+} from "../utils";
+
+import prisma from "@mirlo/prisma";
+
+// Covers the webhook-side routing added when track purchases moved onto the
+// unified POST /v1/purchase flow: a succeeded PaymentIntent tagged
+// purchaseType "track" (+ trackId) should record a UserTrackPurchase, the
+// same way purchaseType "trackGroup" already records a UserTrackGroupPurchase.
+describe("completePurchaseFromIntent - track routing", () => {
+  beforeEach(async () => {
+    try {
+      await clearTables();
+    } catch (e) {
+      console.error(e);
+    }
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("records a UserTrackPurchase for a succeeded PaymentIntent tagged purchaseType 'track'", async () => {
+    sinon.stub(sendMail, "default").resolves();
+
+    const { user: artistUser } = await createUser({
+      email: "artist@test.com",
+    });
+    const { user: buyer } = await createUser({ email: "buyer@test.com" });
+    const artist = await createArtist(artistUser.id);
+    const tg = await createTrackGroup(artist.id, { minPrice: 0 });
+    const track = await createTrack(tg.id, { minPrice: 500 });
+
+    const intent = {
+      id: "pi_track_webhook_test",
+      amount_received: 500,
+      currency: "usd",
+      metadata: {
+        purchaseType: "track",
+        trackId: String(track.id),
+        artistId: String(artist.id),
+        userId: String(buyer.id),
+        userEmail: buyer.email,
+      },
+    } as unknown as Stripe.PaymentIntent;
+
+    await completePurchaseFromIntent(intent, "acct_track_webhook");
+
+    const purchase = await prisma.userTrackPurchase.findFirst({
+      where: { userId: buyer.id, trackId: track.id },
+      include: { transaction: true },
+    });
+    assert.ok(purchase, "a UserTrackPurchase should have been created");
+    assert.equal(purchase?.transaction?.amount, 500);
+  });
+
+  it("does nothing when purchaseType is 'track' but trackId is missing", async () => {
+    const { user: artistUser } = await createUser({
+      email: "artist@test.com",
+    });
+    const { user: buyer } = await createUser({ email: "buyer@test.com" });
+    const artist = await createArtist(artistUser.id);
+
+    const intent = {
+      id: "pi_track_missing_id",
+      amount_received: 500,
+      currency: "usd",
+      metadata: {
+        purchaseType: "track",
+        artistId: String(artist.id),
+        userId: String(buyer.id),
+        userEmail: buyer.email,
+      },
+    } as unknown as Stripe.PaymentIntent;
+
+    await completePurchaseFromIntent(intent, "acct_track_webhook_2");
+
+    const count = await prisma.userTrackPurchase.count({
+      where: { userId: buyer.id },
+    });
+    assert.equal(count, 0);
+  });
+});


### PR DESCRIPTION
A smallish change to include track purchases in the ability to parse payment intents for track purchases themselves. 