### PR TITLE
fix(client): player muted by default

### DIFF
--- a/client/src/components/Player/AudioWrapper.tsx
+++ b/client/src/components/Player/AudioWrapper.tsx
@@ -152,7 +152,6 @@ export const AudioWrapper: React.FC<{
               playerRef.current.pause();
             }
           } else {
-            playerRef.current.setAttribute("muted", "");
             playerRef.current.playsInline = true;
             playerRef.current.play().catch(() => {
               dispatch({ type: "setPlaying", playing: false });


### PR DESCRIPTION
Firefox Nightly respects the `muted` attribute on the `video` element, which appears to be set the second time you press play anywhere on the site.

It looks like this was intentional in cda9189366cfee86169e5aa5cb136d2de1df6002. @simonv3 I'm not sure what purpose the `muted` attribute is serving here, do you have any idea?