### PR TITLE
fix: improvements to which data shows in federated feeds

### DIFF
--- a/prisma/seeds/artists.ts
+++ b/prisma/seeds/artists.ts
@@ -16,6 +16,8 @@ export const artists: Prisma.ProfileCreateInput[] = [
         linkType: "Website",
       },
     ],
+    federatedStreaming: true,
+    federatedStreamingOptInDate: new Date("2026-07-12T08:00:00Z"),
   },
   {
     name: "Robin",

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -111,23 +111,47 @@ export default function () {
         createdAt: "desc",
       };
 
+      const validTracks: Prisma.TrackWhereInput = {
+        deletedAt: null,
+        isPreview: true,
+        audio: {
+          uploadState: "SUCCESS",
+        },
+      };
+
+      const validTrackGroups: Prisma.TrackGroupWhereInput =
+        whereForPublishedTrackGroups();
+
       const artists = await prisma.profile.findMany({
-        where: federatedArtist,
+        where: {
+          ...federatedArtist,
+          // only if they have some trackGroup
+          trackGroups: {
+            some: {
+              ...validTrackGroups,
+              // only if they have some track
+              tracks: {
+                some: validTracks,
+              },
+            },
+          },
+        },
         skip: skipQuery ? Number(skipQuery) : undefined,
         take: take ? Number(take) : undefined,
         orderBy: orderByClause as Prisma.ProfileOrderByWithRelationInput,
         include: {
           trackGroups: {
-            where: whereForPublishedTrackGroups(),
+            where: {
+              ...validTrackGroups,
+              // only if they have some track
+              tracks: {
+                some: validTracks,
+              },
+            },
             include: {
               cover: true,
               tracks: {
-                where: {
-                  deletedAt: null,
-                  audio: {
-                    uploadState: "SUCCESS",
-                  },
-                },
+                where: validTracks,
                 include: {
                   audio: { select: { duration: true } },
                 },

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -113,7 +113,6 @@ export default function () {
 
       const validTracks: Prisma.TrackWhereInput = {
         deletedAt: null,
-        isPreview: true,
         audio: {
           uploadState: "SUCCESS",
         },

--- a/src/routers/v1/sm/canimus.json/index.ts
+++ b/src/routers/v1/sm/canimus.json/index.ts
@@ -118,21 +118,20 @@ export default function () {
         },
       };
 
-      const validTrackGroups: Prisma.TrackGroupWhereInput =
-        whereForPublishedTrackGroups();
+      const validTrackGroups: Prisma.TrackGroupWhereInput = {
+        ...whereForPublishedTrackGroups(),
+        // only if they have some track
+        tracks: {
+          some: validTracks,
+        },
+      };
 
       const artists = await prisma.profile.findMany({
         where: {
           ...federatedArtist,
           // only if they have some trackGroup
           trackGroups: {
-            some: {
-              ...validTrackGroups,
-              // only if they have some track
-              tracks: {
-                some: validTracks,
-              },
-            },
+            some: validTrackGroups,
           },
         },
         skip: skipQuery ? Number(skipQuery) : undefined,
@@ -140,13 +139,7 @@ export default function () {
         orderBy: orderByClause as Prisma.ProfileOrderByWithRelationInput,
         include: {
           trackGroups: {
-            where: {
-              ...validTrackGroups,
-              // only if they have some track
-              tracks: {
-                some: validTracks,
-              },
-            },
+            where: validTrackGroups,
             include: {
               cover: true,
               tracks: {

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -155,14 +155,17 @@ export const whereForAllArtistsThisLabelCanAddReleasesFor = (
 
 export const artistDeleted: Prisma.ProfileWhereInput = {
   deletedAt: { not: null },
+  isLabelProfile: false,
 };
 
 export const federatedArtist: Prisma.ProfileWhereInput = {
   federatedStreaming: true,
+  isLabelProfile: false,
 };
 
 export const federatedArtistAtSomePoint: Prisma.ProfileWhereInput = {
   federatedStreamingOptInDate: { not: null },
+  isLabelProfile: false,
 };
 
 export const artistNoLongerFederated: Prisma.ProfileWhereInput = {

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -155,17 +155,14 @@ export const whereForAllArtistsThisLabelCanAddReleasesFor = (
 
 export const artistDeleted: Prisma.ProfileWhereInput = {
   deletedAt: { not: null },
-  isLabelProfile: false,
 };
 
 export const federatedArtist: Prisma.ProfileWhereInput = {
   federatedStreaming: true,
-  isLabelProfile: false,
 };
 
 export const federatedArtistAtSomePoint: Prisma.ProfileWhereInput = {
   federatedStreamingOptInDate: { not: null },
-  isLabelProfile: false,
 };
 
 export const artistNoLongerFederated: Prisma.ProfileWhereInput = {

--- a/src/utils/serialize/artist.ts
+++ b/src/utils/serialize/artist.ts
@@ -164,6 +164,7 @@ export const serializeSingleArtistIntoCanimus = (artist: LocalArtist) => {
     type: "artist",
     name: artist.name,
     url: artistUrl,
+    uid: String(artist.id),
     images: {
       cover: avatarString
         ? {

--- a/src/utils/serialize/track.ts
+++ b/src/utils/serialize/track.ts
@@ -61,6 +61,7 @@ export const serializeSingleTrackIntoCanimus = (
     type: "track",
     name: track.title,
     url: join(releaseUrl, "tracks", trackId),
+    id: trackId,
     duration: track.audio?.duration ?? metadata?.format?.duration,
     track: track.order,
     updated_date: track.updatedAt?.toISOString().split("T")[0],

--- a/src/utils/serialize/track.ts
+++ b/src/utils/serialize/track.ts
@@ -65,12 +65,14 @@ export const serializeSingleTrackIntoCanimus = (
     duration: track.audio?.duration ?? metadata?.format?.duration,
     track: track.order,
     updated_date: track.updatedAt?.toISOString().split("T")[0],
-    media: [
-      {
-        src: mediaUrl,
-        type: "audio/x-mpegurl",
-      },
-    ],
+    media: track.isPreview
+      ? [
+          {
+            src: mediaUrl,
+            type: "audio/x-mpegurl",
+          },
+        ]
+      : null,
   };
 };
 

--- a/src/utils/serialize/trackGroup.ts
+++ b/src/utils/serialize/trackGroup.ts
@@ -118,6 +118,7 @@ export const serializeSingleTrackGroupIntoCanimus = (
     type: "album",
     name: trackGroup.title,
     url: releaseUrl,
+    uid: String(trackGroup.id),
     release_date: trackGroup.releaseDate?.toISOString().split("T")[0],
     updated_date: trackGroup.updatedAt?.toISOString().split("T")[0],
     license: trackGroup.credits,

--- a/test/routers/sm/canimus.json.spec.ts
+++ b/test/routers/sm/canimus.json.spec.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 
 import prisma from "@mirlo/prisma";
+import { Prisma } from "@mirlo/prisma/client";
 import * as dotenv from "dotenv";
 dotenv.config();
 import { describe, it } from "mocha";
@@ -15,6 +16,22 @@ import {
 } from "../../utils";
 
 const baseURL = `${process.env.API_DOMAIN}/v1/`;
+
+export const createFederatedArtistWithMusic = async (
+  userId: number,
+  data?: Partial<Prisma.ProfileCreateArgs["data"]>
+) => {
+  const artist = await createArtist(userId, {
+    name: "test-artist",
+    urlSlug: "test-artist",
+    federatedStreaming: true,
+    federatedStreamingOptInDate: new Date(Date.now()),
+    ...data,
+  });
+  const trackGroup = await createTrackGroup(artist.id);
+  await createTrack(trackGroup.id);
+  return artist;
+};
 
 describe("canimus", () => {
   beforeEach(async () => {
@@ -38,14 +55,7 @@ describe("canimus", () => {
       const { user } = await createUser({
         email: "test@testcom",
       });
-      const artist = await createArtist(user.id, {
-        name: "test-artist",
-        urlSlug: "test-artist",
-        federatedStreaming: true,
-        federatedStreamingOptInDate: new Date(Date.now()),
-      });
-      const trackGroup = await createTrackGroup(artist.id);
-      await createTrack(trackGroup.id);
+      const artist = await createFederatedArtistWithMusic(user.id);
       const response = await request(baseURL)
         .get("sm/canimus.json")
         .set("Accept", "application/json");
@@ -58,15 +68,11 @@ describe("canimus", () => {
       const { user } = await createUser({
         email: "test@testcom",
       });
-      const artist = await createArtist(user.id, {
-        name: "test-artist",
-        urlSlug: "test-artist",
-        federatedStreaming: true,
-        federatedStreamingOptInDate: new Date(Date.now()),
+      const artist = await createFederatedArtistWithMusic(user.id, {
         isLabelProfile: true,
+        name: "test-label",
+        urlSlug: "test-label",
       });
-      const trackGroup = await createTrackGroup(artist.id);
-      await createTrack(trackGroup.id);
       const response = await request(baseURL)
         .get("sm/canimus.json")
         .set("Accept", "application/json");
@@ -103,7 +109,7 @@ describe("canimus", () => {
       assert.equal(response.body.deleted.length, 2);
     });
 
-    it("should GET / with 1 artist federated and 1 track and trackgroup deleted", async () => {
+    it("should GET / with 1 artist federated but no music", async () => {
       const { user } = await createUser({
         email: "test@testcom",
       });
@@ -114,6 +120,23 @@ describe("canimus", () => {
         federatedStreamingOptInDate: new Date(Date.now()),
       });
 
+      const response = await request(baseURL)
+        .get("sm/canimus.json")
+        .set("Accept", "application/json");
+      assert.equal(response.body.children.length, 0);
+      assert.equal(response.body.deleted.length, 0);
+    });
+
+    it("should GET / with 1 artist federated and 1 track and trackgroup deleted", async () => {
+      const { user } = await createUser({
+        email: "test@testcom",
+      });
+      const artist = await createArtist(user.id, {
+        name: "test-artist",
+        urlSlug: "test-artist",
+        federatedStreaming: true,
+        federatedStreamingOptInDate: new Date(Date.now()),
+      });
       const trackGroup = await createTrackGroup(artist.id);
       await prisma.trackGroup.update({
         where: { id: trackGroup.id },
@@ -123,7 +146,7 @@ describe("canimus", () => {
       const response = await request(baseURL)
         .get("sm/canimus.json")
         .set("Accept", "application/json");
-      assert.equal(response.body.children.length, 1);
+      assert.equal(response.body.children.length, 0);
       assert.equal(response.body.deleted.length, 1);
     });
 
@@ -132,12 +155,7 @@ describe("canimus", () => {
         email: "test@testcom",
       });
       const dateNow = new Date(Date.now());
-      await createArtist(user.id, {
-        name: "test-artist",
-        urlSlug: "test-artist",
-        federatedStreaming: true,
-        federatedStreamingOptInDate: new Date(Date.now() - 1000000),
-      });
+      await createFederatedArtistWithMusic(user.id);
       const artist = await createArtist(user.id, {
         name: "test-artist",
         urlSlug: "test-artist",

--- a/test/routers/sm/canimus.json.spec.ts
+++ b/test/routers/sm/canimus.json.spec.ts
@@ -54,6 +54,26 @@ describe("canimus", () => {
       assert.equal(response.body.deleted.length, 0);
     });
 
+    it("should GET / do not return labels as artists", async () => {
+      const { user } = await createUser({
+        email: "test@testcom",
+      });
+      const artist = await createArtist(user.id, {
+        name: "test-artist",
+        urlSlug: "test-artist",
+        federatedStreaming: true,
+        federatedStreamingOptInDate: new Date(Date.now()),
+        isLabelProfile: true,
+      });
+      const trackGroup = await createTrackGroup(artist.id);
+      await createTrack(trackGroup.id);
+      const response = await request(baseURL)
+        .get("sm/canimus.json")
+        .set("Accept", "application/json");
+      assert.equal(response.body.children.length, 0);
+      assert.equal(response.body.deleted.length, 0);
+    });
+
     it("should GET / with no artist federated and 2 artist deleted", async () => {
       const { user } = await createUser({
         email: "test@testcom",

--- a/test/routers/sm/canimus.json.spec.ts
+++ b/test/routers/sm/canimus.json.spec.ts
@@ -28,8 +28,8 @@ export const createFederatedArtistWithMusic = async (
     federatedStreamingOptInDate: new Date(Date.now()),
     ...data,
   });
+  // the default track group includes one test track
   const trackGroup = await createTrackGroup(artist.id);
-  await createTrack(trackGroup.id);
   return artist;
 };
 
@@ -55,13 +55,54 @@ describe("canimus", () => {
       const { user } = await createUser({
         email: "test@testcom",
       });
-      const artist = await createFederatedArtistWithMusic(user.id);
+      await createFederatedArtistWithMusic(user.id);
+
       const response = await request(baseURL)
         .get("sm/canimus.json")
         .set("Accept", "application/json");
-      assert.equal(response.body.children.length, 1);
-      assert.equal(response.body.children[0].children.length, 1);
+
+      const artists = response.body.children;
+      const albums = artists[0].children;
+      const tracks = albums[0].children;
+      assert.equal(artists.length, 1);
+      assert.equal(albums.length, 1);
+      assert.equal(tracks.length, 1);
+      assert.equal(tracks[0].media.length, 1);
       assert.equal(response.body.deleted.length, 0);
+    });
+
+    it("should GET / for tracks that are 'buy only', do not include media in the feed", async () => {
+      const { user } = await createUser({
+        email: "test@testcom",
+      });
+      const artist = await createArtist(user.id, {
+        name: "buy-only-artist",
+        urlSlug: "buy-only-artist",
+        federatedStreaming: true,
+        federatedStreamingOptInDate: new Date(Date.now()),
+      });
+      const trackGroup = await createTrackGroup(artist.id, { tracks: [] });
+      await createTrack(trackGroup.id, {
+        title: "money for something",
+        audio: {
+          create: {
+            uploadState: "SUCCESS",
+          },
+        },
+        isPreview: false,
+      });
+
+      const response = await request(baseURL)
+        .get("sm/canimus.json")
+        .set("Accept", "application/json");
+
+      const artists = response.body.children;
+      const albums = artists[0].children;
+      const tracks = albums[0].children;
+      assert.equal(artists.length, 1);
+      assert.equal(albums.length, 1);
+      assert.equal(tracks.length, 1);
+      assert.equal(tracks[0].media, null);
     });
 
     it("should GET / with no artist federated and 2 artist deleted", async () => {

--- a/test/routers/sm/canimus.json.spec.ts
+++ b/test/routers/sm/canimus.json.spec.ts
@@ -64,22 +64,6 @@ describe("canimus", () => {
       assert.equal(response.body.deleted.length, 0);
     });
 
-    it("should GET / do not return labels as artists", async () => {
-      const { user } = await createUser({
-        email: "test@testcom",
-      });
-      const artist = await createFederatedArtistWithMusic(user.id, {
-        isLabelProfile: true,
-        name: "test-label",
-        urlSlug: "test-label",
-      });
-      const response = await request(baseURL)
-        .get("sm/canimus.json")
-        .set("Accept", "application/json");
-      assert.equal(response.body.children.length, 0);
-      assert.equal(response.body.deleted.length, 0);
-    });
-
     it("should GET / with no artist federated and 2 artist deleted", async () => {
       const { user } = await createUser({
         email: "test@testcom",


### PR DESCRIPTION
The Canimus format itself may end up being short lived, as we will soon transition to a new version of the protocol, but these filtering conditions will apply anyway:

- Do not include in the feed artists that are actually labels
- Include the internal immutable Mirlo uid for entities so the receiving end can more easily match indexed and remote entities
- Filter out artists that have no released music
- Filter out songs that are not available for "preview" i.e free listen