### PR TITLE
fix: adjust platform percent in subscription

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -31,4 +31,4 @@ jobs:
         run: |
           TRANSIFEX_TOKEN=$TRANSIFEX_TOKEN
           TRANSIFEX_SECRET=$TRANSIFEX_SECRET 
-          npx txjs-cli push src/translation/en.json --parser=i18next
+          npx txjs-cli push src/translation/en.json --parser=i18next --purge

--- a/client/src/components/Artist/ArtistSupportBox.tsx
+++ b/client/src/components/Artist/ArtistSupportBox.tsx
@@ -320,6 +320,8 @@ const ArtistSupportBox: React.FC<{
         onClose={reset}
         clientSecret={checkout?.clientSecret}
         stripeAccountId={checkout?.stripeAccountId}
+        requiresShipping={checkout?.requiresShipping}
+        allowedCountries={checkout?.allowedCountries}
         returnUrl={`${window.location.origin}${buildCheckoutCompletePath(
           artist,
           {

--- a/client/src/components/Artist/ArtistVariableSupport.tsx
+++ b/client/src/components/Artist/ArtistVariableSupport.tsx
@@ -186,6 +186,8 @@ const ArtistVariableSupport: React.FC<{
         onClose={reset}
         clientSecret={checkout?.clientSecret}
         stripeAccountId={checkout?.stripeAccountId}
+        requiresShipping={checkout?.requiresShipping}
+        allowedCountries={checkout?.allowedCountries}
         returnUrl={
           artist
             ? `${window.location.origin}${buildCheckoutCompletePath(artist, {

--- a/client/src/components/common/Purchase/PurchaseElements.tsx
+++ b/client/src/components/common/Purchase/PurchaseElements.tsx
@@ -57,6 +57,8 @@ const PurchaseElements: React.FC<{
         // this here (the one place that actually has the clientSecret) beats
         // threading a caller-computed `isSetup` flag through every component.
         isSetup={clientSecret.startsWith("seti_")}
+        clientSecret={clientSecret}
+        stripeAccountId={stripeAccountId}
       />
     </Elements>
   );

--- a/client/src/components/common/Purchase/PurchasePaymentForm.test.tsx
+++ b/client/src/components/common/Purchase/PurchasePaymentForm.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en" },
+  }),
+  initReactI18next: { type: "3rdParty", init: vi.fn() },
+}));
+
+const callOrder: string[] = [];
+const confirmSetup = vi.fn(() => {
+  callOrder.push("confirmSetup");
+  return Promise.resolve({ setupIntent: { status: "succeeded" } });
+});
+const confirmPayment = vi.fn();
+const addressValue: {
+  value: { name: string; address: Record<string, unknown> };
+} = {
+  value: {
+    name: "Buyer Name",
+    address: { line1: "123 Main St", country: "US" },
+  },
+};
+const getElement = vi.fn(() => ({
+  getValue: () => Promise.resolve(addressValue),
+}));
+
+vi.mock("@stripe/react-stripe-js", () => ({
+  useStripe: () => ({ confirmSetup, confirmPayment }),
+  useElements: () => ({ getElement }),
+  PaymentElement: ({ onReady, onChange }: any) => (
+    <div
+      data-testid="payment-element"
+      onClick={() => {
+        onReady();
+        onChange({ complete: true });
+      }}
+    />
+  ),
+  AddressElement: ({ onChange }: any) => (
+    <div
+      data-testid="address-element"
+      onClick={() => onChange({ complete: true })}
+    />
+  ),
+}));
+
+const putMock = vi.fn((..._args: unknown[]) => {
+  callOrder.push("put");
+  return Promise.resolve({ result: { id: "seti_123" } });
+});
+vi.mock("services/api", () => ({
+  default: { put: (...args: unknown[]) => putMock(...args) },
+}));
+
+const handler = vi.fn();
+vi.mock("services/useErrorHandler", () => ({
+  default: () => handler,
+}));
+
+import PurchasePaymentForm from "./PurchasePaymentForm";
+
+async function readyTheForm() {
+  fireEvent.click(screen.getByTestId("payment-element"));
+  await waitFor(() => expect(screen.getByRole("button")).toBeInTheDocument());
+}
+
+describe("PurchasePaymentForm", () => {
+  beforeEach(() => {
+    callOrder.length = 0;
+    confirmSetup.mockClear();
+    confirmPayment.mockClear();
+    getElement.mockClear();
+    putMock.mockClear();
+    handler.mockClear();
+    putMock.mockImplementation(() => {
+      callOrder.push("put");
+      return Promise.resolve({ result: { id: "seti_123" } });
+    });
+  });
+
+  test("PUTs the collected shipping address before confirming a subscription SetupIntent", async () => {
+    render(
+      <PurchasePaymentForm
+        returnUrl="https://example.com/return"
+        buttonLabel="Pay"
+        onSuccess={vi.fn()}
+        requiresShipping
+        isSetup
+        clientSecret="seti_123_secret_abc"
+        stripeAccountId="acct_1"
+      />
+    );
+
+    await readyTheForm();
+    fireEvent.click(screen.getByTestId("address-element"));
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => expect(confirmSetup).toHaveBeenCalled());
+
+    expect(putMock).toHaveBeenCalledWith(
+      "purchase/seti_123?stripeAccountId=acct_1",
+      { shippingAddress: addressValue.value }
+    );
+    // The address must be saved (SetupIntents have no native shipping field)
+    // before confirmSetup — not passed through confirmParams like confirmPayment.
+    expect(callOrder).toEqual(["put", "confirmSetup"]);
+    expect(confirmSetup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        confirmParams: { return_url: "https://example.com/return" },
+      })
+    );
+  });
+
+  test("does not call the shipping PUT when requiresShipping is false", async () => {
+    render(
+      <PurchasePaymentForm
+        returnUrl="https://example.com/return"
+        buttonLabel="Pay"
+        onSuccess={vi.fn()}
+        isSetup
+        clientSecret="seti_456_secret_abc"
+        stripeAccountId="acct_1"
+      />
+    );
+
+    await readyTheForm();
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => expect(confirmSetup).toHaveBeenCalled());
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  test("shows an error and does not confirm when the shipping PUT fails", async () => {
+    putMock.mockRejectedValue(new Error("network error"));
+
+    render(
+      <PurchasePaymentForm
+        returnUrl="https://example.com/return"
+        buttonLabel="Pay"
+        onSuccess={vi.fn()}
+        requiresShipping
+        isSetup
+        clientSecret="seti_789_secret_abc"
+        stripeAccountId="acct_1"
+      />
+    );
+
+    await readyTheForm();
+    fireEvent.click(screen.getByTestId("address-element"));
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => expect(putMock).toHaveBeenCalled());
+    expect(confirmSetup).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalled();
+  });
+});

--- a/client/src/components/common/Purchase/PurchasePaymentForm.tsx
+++ b/client/src/components/common/Purchase/PurchasePaymentForm.tsx
@@ -13,6 +13,7 @@ import {
 import LoadingBlocks from "components/Artist/LoadingBlocks";
 import React from "react";
 import { useTranslation } from "react-i18next";
+import api from "services/api";
 import useErrorHandler from "services/useErrorHandler";
 
 import { Button } from "../Button";
@@ -43,6 +44,9 @@ const PurchasePaymentForm: React.FC<{
   allowedCountries?: string[];
   /** The clientSecret is a SetupIntent's (subscription sign-up) rather than a PaymentIntent's — confirm with `confirmSetup`, not `confirmPayment`. */
   isSetup?: boolean;
+  /** Needed (alongside stripeAccountId) only when isSetup && requiresShipping, to PUT the collected address onto the SetupIntent before confirming — SetupIntents have no native `shipping` field, unlike PaymentIntents. */
+  clientSecret?: string;
+  stripeAccountId?: string;
 }> = ({
   returnUrl,
   buttonLabel,
@@ -50,6 +54,8 @@ const PurchasePaymentForm: React.FC<{
   requiresShipping,
   allowedCountries,
   isSetup,
+  clientSecret,
+  stripeAccountId,
 }) => {
   const stripe = useStripe();
   const elements = useElements();
@@ -94,6 +100,29 @@ const PurchasePaymentForm: React.FC<{
     // SetupIntent has no `shipping`), so the call itself can't be unified —
     // only the params shared between both branches are, here.
     const confirmParams = { return_url: returnUrl, shipping };
+
+    // A SetupIntent has no native `shipping` field for confirmSetup to carry
+    // (unlike confirmPayment above), so a `collectAddress` tier's address is
+    // saved via a separate call first — read back from the SetupIntent's
+    // metadata once it succeeds (see attachSetupIntentShippingAddress).
+    if (isSetup && requiresShipping && shipping) {
+      if (!clientSecret || !stripeAccountId) {
+        handler(new Error("Missing clientSecret/stripeAccountId for shipping"));
+        setIsLoading(false);
+        return;
+      }
+      try {
+        const setupIntentId = clientSecret.split("_secret_")[0];
+        await api.put(
+          `purchase/${setupIntentId}?stripeAccountId=${encodeURIComponent(stripeAccountId)}`,
+          { shippingAddress: shipping }
+        );
+      } catch (e) {
+        handler(e);
+        setIsLoading(false);
+        return;
+      }
+    }
 
     if (onSuccess) {
       // Async completion: only redirect if the payment method requires it.

--- a/client/src/pages/checkout/Index.test.tsx
+++ b/client/src/pages/checkout/Index.test.tsx
@@ -22,8 +22,18 @@ vi.mock("@stripe/react-stripe-js", () => ({
 }));
 
 vi.mock("components/common/Purchase/PurchasePaymentForm", () => ({
-  default: ({ returnUrl }: { returnUrl: string }) => (
-    <div data-testid="payment-form" data-return-url={returnUrl} />
+  default: ({
+    returnUrl,
+    isSetup,
+  }: {
+    returnUrl: string;
+    isSetup?: boolean;
+  }) => (
+    <div
+      data-testid="payment-form"
+      data-return-url={returnUrl}
+      data-is-setup={String(!!isSetup)}
+    />
   ),
 }));
 
@@ -61,7 +71,7 @@ function renderAt(path: string) {
   );
 }
 
-const PATH = "/checkout?paymentIntentId=pi_1&stripeAccountId=acct_1";
+const PATH = "/checkout?intentId=pi_1&stripeAccountId=acct_1";
 
 describe("Checkout", () => {
   beforeEach(() => {
@@ -92,8 +102,34 @@ describe("Checkout", () => {
       "data-return-url",
       "https://wp-site.com/thanks"
     );
+    expect(screen.getByTestId("payment-form")).toHaveAttribute(
+      "data-is-setup",
+      "false"
+    );
     // Buyer sees who they're paying and how much (the t() mock returns the key).
     expect(screen.getByText("payingArtistAmount")).toBeInTheDocument();
+  });
+
+  test("passes isSetup to the payment form for a subscription's SetupIntent", async () => {
+    mockIntentFetch({
+      id: "seti_1",
+      status: "requires_payment_method",
+      clientSecret: "seti_1_secret_abc",
+      successUrl: "https://wp-site.com/thanks",
+      amount: null,
+      currency: null,
+      artistName: "Test Artist",
+    });
+
+    renderAt("/checkout?intentId=seti_1&stripeAccountId=acct_1");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("payment-form")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("payment-form")).toHaveAttribute(
+      "data-is-setup",
+      "true"
+    );
   });
 
   test("bounces to successUrl when the intent already succeeded", async () => {

--- a/client/src/pages/checkout/Index.tsx
+++ b/client/src/pages/checkout/Index.tsx
@@ -17,21 +17,23 @@ const stripeKey = import.meta.env.VITE_PUBLISHABLE_STRIPE_KEY;
  * Mirlo-hosted checkout page. External API consumers send a buyer here (via the
  * `redirectUrl` returned by `POST /v1/purchase` with `hosted: true`) so they can
  * complete payment without building their own Stripe UI. It fetches the
- * PaymentIntent's clientSecret + return target from the API and renders the
- * shared Payment Element full-page. On success Stripe redirects to the
- * server-supplied `successUrl` (or Mirlo's home as a fallback).
+ * intent's clientSecret + return target from the API — a PaymentIntent for a
+ * one-time purchase, or a SetupIntent for a subscription sign-up/switch — and
+ * renders the shared Payment/Setup Element full-page. On success Stripe
+ * redirects to the server-supplied `successUrl` (or Mirlo's home as a
+ * fallback).
  */
 function Index() {
   const { t } = useTranslation("translation", { keyPrefix: "hostedCheckout" });
   const [searchParams] = useSearchParams();
-  const paymentIntentId = searchParams.get("paymentIntentId") ?? "";
+  const intentId = searchParams.get("intentId") ?? "";
   const stripeAccountId = searchParams.get("stripeAccountId") ?? "";
 
   const {
     data: intent,
     isLoading,
     isError,
-  } = useQuery(queryPurchaseIntent({ paymentIntentId, stripeAccountId }));
+  } = useQuery(queryPurchaseIntent({ intentId, stripeAccountId }));
 
   // Load Stripe.js once per connected account (created once, not per render).
   const stripePromise = React.useMemo(
@@ -42,7 +44,7 @@ function Index() {
     [stripeAccountId]
   );
 
-  if (!paymentIntentId || !stripeAccountId) {
+  if (!intentId || !stripeAccountId) {
     return (
       <WidthWrapper variant="small" className="mt-8">
         <Box>{t("missingParameters")}</Box>
@@ -77,6 +79,10 @@ function Index() {
   }
 
   const returnUrl = intent.successUrl ?? window.location.origin;
+  // SetupIntent client secrets are always `seti_`-prefixed (see
+  // PurchaseElements.tsx) — a subscription sign-up/switch confirms with
+  // `confirmSetup`, not `confirmPayment`.
+  const isSetup = intent.clientSecret.startsWith("seti_");
 
   const total =
     intent.amount != null
@@ -108,7 +114,11 @@ function Index() {
         stripe={stripePromise}
         options={{ clientSecret: intent.clientSecret }}
       >
-        <PurchasePaymentForm returnUrl={returnUrl} buttonLabel={t("payNow")} />
+        <PurchasePaymentForm
+          returnUrl={returnUrl}
+          buttonLabel={t("payNow")}
+          isSetup={isSetup}
+        />
       </Elements>
     </WidthWrapper>
   );

--- a/client/src/queries/purchase.ts
+++ b/client/src/queries/purchase.ts
@@ -15,29 +15,33 @@ export type PurchaseIntent = {
 
 const fetchPurchaseIntent: QueryFunction<
   PurchaseIntent,
-  ["fetchPurchaseIntent", { paymentIntentId: string; stripeAccountId: string }]
-> = ({ queryKey: [_, { paymentIntentId, stripeAccountId }], signal }) => {
+  ["fetchPurchaseIntent", { intentId: string; stripeAccountId: string }]
+> = ({ queryKey: [_, { intentId, stripeAccountId }], signal }) => {
   return api
     .get<{
       result: PurchaseIntent;
-    }>(`v1/purchase/${paymentIntentId}?stripeAccountId=${encodeURIComponent(stripeAccountId)}`, { signal })
+    }>(
+      `v1/purchase/${intentId}?stripeAccountId=${encodeURIComponent(stripeAccountId)}`,
+      { signal }
+    )
     .then((r) => r.result);
 };
 
 export function queryPurchaseIntent(opts: {
-  paymentIntentId: string;
+  /** A PaymentIntent (pi_*) or SetupIntent (seti_*) id. */
+  intentId: string;
   stripeAccountId: string;
 }) {
   return queryOptions({
     queryKey: [
       "fetchPurchaseIntent",
       {
-        paymentIntentId: opts.paymentIntentId,
+        intentId: opts.intentId,
         stripeAccountId: opts.stripeAccountId,
       },
     ],
     queryFn: fetchPurchaseIntent,
-    enabled: !!opts.paymentIntentId && !!opts.stripeAccountId,
+    enabled: !!opts.intentId && !!opts.stripeAccountId,
     // A one-shot fetch of an intent's secret/status: never goes stale within a
     // page session, and a transient failure isn't worth retrying here.
     staleTime: Infinity,

--- a/src/routers/v1/purchase/index.ts
+++ b/src/routers/v1/purchase/index.ts
@@ -341,6 +341,23 @@ export default function () {
           userName: subItem.userName,
         });
 
+        // Hosted checkout: same handoff as the one-time-payment path below —
+        // hand external integrators a single redirect to Mirlo's own pay page
+        // instead of a clientSecret they'd have to drive Stripe.js with
+        // themselves. Doesn't apply to `{ success: true }` (an in-place tier
+        // switch): there's no payment step left to redirect the buyer through.
+        if (hosted && mirloClient && "clientSecret" in result) {
+          const redirectUrl = buildCheckoutRedirectUrl(
+            mirloClient.applicationUrl,
+            "checkout",
+            new URLSearchParams({
+              intentId: result.setupIntentId,
+              stripeAccountId: result.stripeAccountId,
+            })
+          );
+          return res.status(200).json({ redirectUrl });
+        }
+
         return res.status(200).json(result);
       }
 
@@ -508,7 +525,7 @@ export default function () {
           mirloClient.applicationUrl,
           "checkout",
           new URLSearchParams({
-            paymentIntentId: result.paymentIntentId,
+            intentId: result.paymentIntentId,
             stripeAccountId: result.stripeAccountId,
           })
         );

--- a/src/routers/v1/purchase/{id}/index.ts
+++ b/src/routers/v1/purchase/{id}/index.ts
@@ -8,10 +8,12 @@ import {
 } from "../../../../auth/passport";
 import { AppError } from "../../../../utils/error";
 import { getPaymentProcessor } from "../../../../utils/payments/PaymentProcessor";
+import { attachSetupIntentShippingAddress } from "../../../../utils/stripe";
 
 export default function () {
   const operations = {
     GET: [userLoggedInWithoutRedirect, GET],
+    PUT: [userLoggedInWithoutRedirect, PUT],
     DELETE: [userAuthenticated, DELETE],
   };
 
@@ -122,6 +124,109 @@ export default function () {
         },
       },
       400: { description: "Missing parameters" },
+      default: {
+        description: "An error occurred",
+        schema: { additionalProperties: true },
+      },
+    },
+  };
+
+  /**
+   * Persists the buyer's shipping address onto a not-yet-confirmed
+   * subscription SetupIntent, ahead of the frontend calling Stripe's
+   * confirmSetup. SetupIntents have no native `shipping` field (unlike
+   * PaymentIntents, which carry it straight through confirmPayment), so this
+   * is the mechanism for a `collectAddress` tier's address to survive to
+   * `finalizeSubscriptionSetup` once `setup_intent.succeeded` fires.
+   */
+  async function PUT(req: Request, res: Response, next: NextFunction) {
+    const { id } = req.params;
+    const { stripeAccountId } = req.query as { stripeAccountId?: string };
+    const { shippingAddress } = req.body as {
+      shippingAddress?: { name?: string; address: Record<string, unknown> };
+    };
+
+    try {
+      if (!id) {
+        throw new AppError({ httpCode: 400, description: "id is required" });
+      }
+      if (!stripeAccountId) {
+        throw new AppError({
+          httpCode: 400,
+          description: "stripeAccountId query param is required",
+        });
+      }
+      if (!id.startsWith("seti_")) {
+        throw new AppError({
+          httpCode: 400,
+          description: "Only a SetupIntent (seti_*) accepts a shipping address",
+        });
+      }
+      if (!shippingAddress?.address) {
+        throw new AppError({
+          httpCode: 400,
+          description: "shippingAddress is required",
+        });
+      }
+
+      await attachSetupIntentShippingAddress({
+        setupIntentId: id,
+        stripeAccountId,
+        shippingAddress,
+      });
+
+      res.status(200).json({ result: { id } });
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  PUT.apiDoc = {
+    summary: "Attach a shipping address to a pending subscription SetupIntent",
+    description:
+      "SetupIntents have no native `shipping` field the way PaymentIntents " +
+      "do, so a `collectAddress` subscription tier's AddressElement value is " +
+      "saved here — before the frontend calls Stripe's confirmSetup — so it " +
+      "can be read back from the SetupIntent's metadata once " +
+      "`setup_intent.succeeded` fires and the subscription is registered.",
+    parameters: [
+      {
+        in: "path",
+        name: "id",
+        required: true,
+        type: "string",
+        description: "SetupIntent ID (seti_*)",
+      },
+      {
+        in: "query",
+        name: "stripeAccountId",
+        required: true,
+        type: "string",
+        description: "Artist's connected Stripe account ID",
+      },
+      {
+        in: "body",
+        name: "body",
+        required: true,
+        schema: {
+          type: "object",
+          required: ["shippingAddress"],
+          properties: {
+            shippingAddress: {
+              type: "object",
+              required: ["address"],
+              properties: {
+                name: { type: "string" },
+                address: { type: "object" },
+              },
+            },
+          },
+        },
+      },
+    ],
+    responses: {
+      200: { description: "Shipping address attached" },
+      400: { description: "Missing or invalid parameters" },
       default: {
         description: "An error occurred",
         schema: { additionalProperties: true },

--- a/src/utils/payments/stripeProcessor.ts
+++ b/src/utils/payments/stripeProcessor.ts
@@ -179,6 +179,10 @@ export class StripePaymentProcessor implements PaymentProcessor {
         // charge — "increasing the monthly fee the next time they subscribe."
         proration_behavior: "none",
         cancel_at_period_end: false,
+        // Tiers can carry different platform fees (see applyPlatformFee.ts),
+        // so a tier switch must re-pin the fee to the new tier's — otherwise
+        // Stripe keeps charging the old tier's percentage indefinitely.
+        application_fee_percent: tier.platformPercent ?? 7,
       },
       { stripeAccount: accountId }
     );

--- a/src/utils/payments/subscription.ts
+++ b/src/utils/payments/subscription.ts
@@ -105,7 +105,12 @@ export const initiateOnlineSubscription = async ({
   /** Self-chosen display name, captured when the buyer has no account name yet. */
   userName?: string;
 }): Promise<
-  { success: true } | { clientSecret: string | null; stripeAccountId: string }
+  | { success: true }
+  | {
+      clientSecret: string | null;
+      stripeAccountId: string;
+      setupIntentId: string;
+    }
 > => {
   const { tier, resolvedAmount } = await resolveTierAndAmount(
     artistId,
@@ -163,7 +168,7 @@ export const initiateOnlineSubscription = async ({
     return { success: true };
   }
 
-  const { clientSecret } =
+  const { setupIntentId, clientSecret } =
     await getPaymentProcessor().createOnlineSubscriptionSetup({
       tierId,
       artistId,
@@ -178,7 +183,7 @@ export const initiateOnlineSubscription = async ({
         : undefined,
     });
 
-  return { clientSecret, stripeAccountId };
+  return { clientSecret, stripeAccountId, setupIntentId };
 };
 
 type CancellableSubscription = Prisma.ProfileUserSubscriptionGetPayload<{

--- a/src/utils/payments/subscription.ts
+++ b/src/utils/payments/subscription.ts
@@ -147,9 +147,17 @@ export const initiateOnlineSubscription = async ({
       currency,
     });
 
+    const platformPercent = tier.platformPercent ?? 7;
     await prisma.profileUserSubscription.update({
       where: { id: existingSubscription.id },
-      data: { artistSubscriptionTierId: tier.id, amount: resolvedAmount },
+      data: {
+        artistSubscriptionTierId: tier.id,
+        amount: resolvedAmount,
+        // Keep in step with the new tier's fee — mirrors the
+        // application_fee_percent update in updateSubscriptionTier, since the
+        // next invoice bills at this percentage going forward.
+        platformCut: Math.round((resolvedAmount * platformPercent) / 100),
+      },
     });
 
     return { success: true };

--- a/src/utils/payments/subscription.ts
+++ b/src/utils/payments/subscription.ts
@@ -13,6 +13,17 @@ import { AppError } from "../error";
 import { getPaymentProcessor } from "./PaymentProcessor";
 import { resolveArtistPaymentContext } from "./purchase";
 
+// Countries a `collectAddress` tier's AddressElement offers — shared with the
+// legacy Checkout Session flow (src/utils/stripe/sessions.ts) so both paths
+// present the same picker.
+export const SUBSCRIPTION_SHIPPING_ALLOWED_COUNTRIES = [
+  "US",
+  "GB",
+  "CA",
+  "AU",
+  "NZ",
+];
+
 // Shared by the terminal and online paths below. Validates the tier first so
 // a missing tier 404s even when the artist hasn't finished setting up a
 // payment processor (resolveArtistPaymentContext, called after this).
@@ -110,6 +121,9 @@ export const initiateOnlineSubscription = async ({
       clientSecret: string | null;
       stripeAccountId: string;
       setupIntentId: string;
+      /** The tier needs a shipping address — the frontend renders an AddressElement and PUTs it to /v1/purchase/:id before confirming. */
+      requiresShipping: boolean;
+      allowedCountries?: string[];
     }
 > => {
   const { tier, resolvedAmount } = await resolveTierAndAmount(
@@ -183,7 +197,15 @@ export const initiateOnlineSubscription = async ({
         : undefined,
     });
 
-  return { clientSecret, stripeAccountId, setupIntentId };
+  return {
+    clientSecret,
+    stripeAccountId,
+    setupIntentId,
+    requiresShipping: !!tier.collectAddress,
+    allowedCountries: tier.collectAddress
+      ? SUBSCRIPTION_SHIPPING_ALLOWED_COUNTRIES
+      : undefined,
+  };
 };
 
 type CancellableSubscription = Prisma.ProfileUserSubscriptionGetPayload<{

--- a/src/utils/stripe/index.ts
+++ b/src/utils/stripe/index.ts
@@ -563,6 +563,8 @@ export const handleSetupIntentSucceeded = async (
     currency: string;
     stripeAccountId: string;
     oldTierId?: string;
+    /** JSON-stringified `{ name?, address }`, set via `PUT /v1/purchase/:id` before confirmation — see attachSetupIntentShippingAddress. */
+    shippingAddress?: string;
   };
   const { fundraiserId, userId, userEmail, userName } = metadata;
 
@@ -616,6 +618,21 @@ export const handleSetupIntentSucceeded = async (
       return;
     }
 
+    let shippingAddress: {
+      name?: string;
+      address: Record<string, unknown>;
+    } | null = null;
+    if (metadata.shippingAddress) {
+      try {
+        shippingAddress = JSON.parse(metadata.shippingAddress);
+      } catch (e) {
+        logger.error(
+          `handleSetupIntentSucceeded: could not parse shippingAddress metadata on ${intent.id}`,
+          e
+        );
+      }
+    }
+
     await finalizeSubscriptionSetup({
       stripeAccountId,
       paymentMethodId,
@@ -625,8 +642,34 @@ export const handleSetupIntentSucceeded = async (
       userId: Number(actualUserId),
       userEmail,
       oldTierId: oldTierId ? Number(oldTierId) : undefined,
+      shippingAddress,
     });
   }
+};
+
+/**
+ * Attaches the buyer's shipping address to a not-yet-confirmed subscription
+ * SetupIntent's metadata, so `handleSetupIntentSucceeded` can read it back
+ * once the SetupIntent succeeds and pass it to `finalizeSubscriptionSetup`.
+ * SetupIntents (unlike PaymentIntents) have no native `shipping` field —
+ * confirmSetup can't carry it the way confirmPayment does — so this is the
+ * mechanism for a `collectAddress` tier's address to survive to registration.
+ * Called from `PUT /v1/purchase/:id`, before the frontend calls confirmSetup.
+ */
+export const attachSetupIntentShippingAddress = async ({
+  setupIntentId,
+  stripeAccountId,
+  shippingAddress,
+}: {
+  setupIntentId: string;
+  stripeAccountId: string;
+  shippingAddress: { name?: string; address: Record<string, unknown> };
+}) => {
+  await stripe.setupIntents.update(
+    setupIntentId,
+    { metadata: { shippingAddress: JSON.stringify(shippingAddress) } },
+    { stripeAccount: stripeAccountId }
+  );
 };
 
 /**
@@ -651,6 +694,7 @@ export const finalizeSubscriptionSetup = async ({
   userId,
   userEmail,
   oldTierId,
+  shippingAddress = null,
 }: {
   stripeAccountId: string;
   paymentMethodId: string;
@@ -660,6 +704,8 @@ export const finalizeSubscriptionSetup = async ({
   userId: number;
   userEmail?: string;
   oldTierId?: number;
+  /** Collected via the tier's AddressElement when `tier.collectAddress` is set — see attachSetupIntentShippingAddress. */
+  shippingAddress?: { name?: string; address: Record<string, unknown> } | null;
 }) => {
   // Independent lookups: which tier, and which Stripe customer, don't depend
   // on each other.
@@ -722,7 +768,7 @@ export const finalizeSubscriptionSetup = async ({
     amount,
     paymentProcessorKey: subscription.id,
     platformCut: Math.round((amount * platformPercent) / 100),
-    shippingAddress: null,
+    shippingAddress,
   });
 
   if (oldTierId && oldTierId !== tier.id) {

--- a/test/routers/purchase.spec.ts
+++ b/test/routers/purchase.spec.ts
@@ -94,11 +94,12 @@ describe("purchase", () => {
       const artist = await createArtist(artistUser.id);
       const tier = await createTier(artist.id, { minAmount: 500 });
 
-      sinon.stub(stripeUtils.stripe.setupIntents, "create").resolves({
-        id: "seti_online_new",
-        client_secret: "seti_online_new_secret",
-      } as unknown as Stripe.Response<Stripe.SetupIntent>);
-
+      // Note: this request goes over HTTP to the separate api-test server
+      // process (see `requestApp`/API_DOMAIN in test/routers/utils.ts), so a
+      // sinon stub set up here — in the test process — would never be seen by
+      // it; the call for real reaches the stripe-mock service instead. Assert
+      // on the shape of a SetupIntent secret rather than a specific stubbed
+      // value.
       const response = await requestApp
         .post("purchase")
         .send({
@@ -109,7 +110,97 @@ describe("purchase", () => {
         .set("Accept", "application/json");
 
       assert.equal(response.statusCode, 200);
-      assert.equal(response.body.clientSecret, "seti_online_new_secret");
+      assert.ok(
+        response.body.clientSecret?.startsWith("seti_"),
+        "clientSecret should be a SetupIntent secret"
+      );
+    });
+
+    it("should return a hosted redirectUrl (not a raw clientSecret) for a first-time online subscription when hosted is true", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@test.com",
+        stripeAccountId: "acct_sub_hosted",
+      });
+      const { accessToken } = await createUser({ email: "buyer@test.com" });
+      const artist = await createArtist(artistUser.id);
+      const tier = await createTier(artist.id, { minAmount: 500 });
+
+      sinon.stub(stripeUtils.stripe.setupIntents, "create").resolves({
+        id: "seti_hosted_new",
+        client_secret: "seti_hosted_new_secret",
+      } as unknown as Stripe.Response<Stripe.SetupIntent>);
+
+      const response = await requestApp
+        .post("purchase")
+        .send({
+          artistId: artist.id,
+          items: [{ type: "subscription", tierId: tier.id }],
+          hosted: true,
+        })
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.ok(response.body.redirectUrl, "should return a redirectUrl");
+      assert.ok(response.body.redirectUrl.includes("/checkout"));
+      assert.ok(response.body.redirectUrl.includes("intentId="));
+      assert.ok(response.body.redirectUrl.includes("stripeAccountId="));
+      assert.ok(
+        !response.body.clientSecret,
+        "should not leak clientSecret in hosted mode"
+      );
+    });
+
+    it("should return success:true (not a hosted redirectUrl) when a tier switch is repriced in place, even with hosted: true", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@test.com",
+        stripeAccountId: "acct_sub_hosted_switch",
+      });
+      const { user: buyer, accessToken } = await createUser({
+        email: "buyer@test.com",
+      });
+      const artist = await createArtist(artistUser.id);
+      const oldTier = await createTier(artist.id, { minAmount: 500 });
+      const newTier = await createTier(artist.id, {
+        minAmount: 1000,
+        collectAddress: false,
+      });
+
+      await prisma.profileUserSubscription.create({
+        data: {
+          artistSubscriptionTierId: oldTier.id,
+          userId: buyer.id,
+          amount: 500,
+          stripeSubscriptionKey: "sub_hosted_switch_existing",
+        },
+      });
+
+      sinon.stub(stripeUtils.stripe.subscriptions, "retrieve").resolves({
+        items: { data: [{ id: "si_existing_item" }] },
+      } as unknown as Stripe.Response<Stripe.Subscription>);
+      sinon
+        .stub(stripeUtils.stripe.subscriptions, "update")
+        .resolves({} as unknown as Stripe.Response<Stripe.Subscription>);
+      sinon.stub(stripeUtils.stripe.products, "create").resolves({
+        id: "prod_new_tier",
+      } as unknown as Stripe.Response<Stripe.Product>);
+
+      const response = await requestApp
+        .post("purchase")
+        .send({
+          artistId: artist.id,
+          items: [{ type: "subscription", tierId: newTier.id }],
+          hosted: true,
+        })
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body.success, true);
+      assert.ok(
+        !response.body.redirectUrl,
+        "there's no payment step left to send the buyer through, so no redirectUrl is needed"
+      );
     });
 
     it("should return 401 when a readerId is supplied without being logged in", async () => {
@@ -381,7 +472,7 @@ describe("purchase", () => {
       // Hosted mode returns a redirect to Mirlo's pay page, not a raw secret.
       assert.ok(response.body.redirectUrl, "should return a redirectUrl");
       assert.ok(response.body.redirectUrl.includes("/checkout"));
-      assert.ok(response.body.redirectUrl.includes("paymentIntentId="));
+      assert.ok(response.body.redirectUrl.includes("intentId="));
       assert.ok(response.body.redirectUrl.includes("stripeAccountId="));
       assert.ok(
         !response.body.clientSecret,

--- a/test/routers/purchase.spec.ts
+++ b/test/routers/purchase.spec.ts
@@ -944,6 +944,7 @@ describe("purchase", () => {
       const newTier = await createTier(artist.id, {
         minAmount: 1000,
         collectAddress: false,
+        platformPercent: 12,
       });
 
       const existing = await prisma.profileUserSubscription.create({
@@ -951,6 +952,7 @@ describe("purchase", () => {
           artistSubscriptionTierId: oldTier.id,
           userId: buyer.id,
           amount: 500,
+          platformCut: 35,
           stripeSubscriptionKey: "sub_existing_123",
         },
       });
@@ -975,6 +977,11 @@ describe("purchase", () => {
       assert.deepEqual(result, { success: true });
       assert.equal(updateStub.calledOnce, true);
       assert.equal(updateStub.getCall(0).args[1]?.proration_behavior, "none");
+      assert.equal(
+        updateStub.getCall(0).args[1]?.application_fee_percent,
+        12,
+        "the new tier's platform fee percentage should be applied to the repriced subscription"
+      );
 
       const after = await prisma.profileUserSubscription.findFirst({
         where: { id: existing.id },
@@ -982,6 +989,11 @@ describe("purchase", () => {
       assert.ok(after, "the same subscription row should still exist");
       assert.equal(after?.artistSubscriptionTierId, newTier.id);
       assert.equal(after?.amount, 1000);
+      assert.equal(
+        after?.platformCut,
+        120,
+        "platformCut should be recalculated from the new tier's fee percentage, not left at the old tier's"
+      );
       assert.equal(
         after?.stripeSubscriptionKey,
         "sub_existing_123",

--- a/test/routers/purchase.spec.ts
+++ b/test/routers/purchase.spec.ts
@@ -114,6 +114,44 @@ describe("purchase", () => {
         response.body.clientSecret?.startsWith("seti_"),
         "clientSecret should be a SetupIntent secret"
       );
+      assert.ok(
+        !response.body.requiresShipping,
+        "a tier without collectAddress should not ask the frontend for an address"
+      );
+    });
+
+    it("should return requiresShipping + allowedCountries for a collectAddress tier's first-time subscription", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@test.com",
+        stripeAccountId: "acct_sub_address",
+      });
+      const { accessToken } = await createUser({ email: "buyer@test.com" });
+      const artist = await createArtist(artistUser.id);
+      const tier = await createTier(artist.id, {
+        minAmount: 500,
+        collectAddress: true,
+      });
+
+      const response = await requestApp
+        .post("purchase")
+        .send({
+          artistId: artist.id,
+          items: [{ type: "subscription", tierId: tier.id }],
+        })
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.ok(
+        response.body.clientSecret?.startsWith("seti_"),
+        "clientSecret should be a SetupIntent secret"
+      );
+      assert.equal(response.body.requiresShipping, true);
+      assert.ok(
+        Array.isArray(response.body.allowedCountries) &&
+          response.body.allowedCountries.length > 0,
+        "should include a non-empty allowedCountries list"
+      );
     });
 
     it("should return a hosted redirectUrl (not a raw clientSecret) for a first-time online subscription when hosted is true", async () => {
@@ -1213,6 +1251,57 @@ describe("purchase", () => {
         "the old tier's subscription row should be gone after the switch is confirmed"
       );
     });
+
+    it("persists a shippingAddress when the tier collects one", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@test.com",
+        stripeAccountId: "acct_sub_finalize_address",
+      });
+      const { user: buyer } = await createUser({ email: "buyer@test.com" });
+      const artist = await createArtist(artistUser.id);
+      const tier = await createTier(artist.id, {
+        minAmount: 500,
+        collectAddress: true,
+      });
+
+      sinon.stub(stripeUtils.stripe.customers, "list").resolves({
+        data: [],
+      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Customer>>);
+      sinon.stub(stripeUtils.stripe.customers, "create").resolves({
+        id: "cus_address",
+      } as unknown as Stripe.Response<Stripe.Customer>);
+      sinon
+        .stub(stripeUtils.stripe.paymentMethods, "attach")
+        .resolves({} as unknown as Stripe.Response<Stripe.PaymentMethod>);
+      sinon.stub(stripeUtils.stripe.products, "create").resolves({
+        id: "prod_address_tier",
+      } as unknown as Stripe.Response<Stripe.Product>);
+      sinon.stub(stripeUtils.stripe.subscriptions, "create").resolves({
+        id: "sub_address_123",
+      } as unknown as Stripe.Response<Stripe.Subscription>);
+
+      const shippingAddress = {
+        name: "Buyer Name",
+        address: { line1: "123 Main St", city: "Anytown", country: "US" },
+      };
+
+      await finalizeSubscriptionSetup({
+        stripeAccountId: "acct_sub_finalize_address",
+        paymentMethodId: "pm_test",
+        tierId: tier.id,
+        amount: 500,
+        currency: "usd",
+        userId: buyer.id,
+        userEmail: buyer.email,
+        shippingAddress,
+      });
+
+      const subscription = await prisma.profileUserSubscription.findFirst({
+        where: { userId: buyer.id, artistSubscriptionTierId: tier.id },
+      });
+      assert.ok(subscription, "the subscription should be registered");
+      assert.deepEqual(subscription?.shippingAddress, shippingAddress);
+    });
   });
 
   describe("handleSetupIntentSucceeded (direct) — first-time subscription sign-up", () => {
@@ -1281,6 +1370,73 @@ describe("purchase", () => {
       assert.ok(subscription, "the subscription should be registered");
       assert.equal(subscription?.stripeSubscriptionKey, "sub_anon_new");
     });
+
+    it("parses the JSON-stringified shippingAddress metadata and persists it on the subscription", async () => {
+      const { user: artistUser } = await createUser({
+        email: "artist@test.com",
+        stripeAccountId: "acct_sub_anon_address",
+      });
+      const artist = await createArtist(artistUser.id);
+      const tier = await createTier(artist.id, {
+        minAmount: 500,
+        collectAddress: true,
+      });
+
+      const shippingAddress = {
+        name: "Shipping Buyer",
+        address: { line1: "456 Oak Ave", city: "Someplace", country: "GB" },
+      };
+      const metadata = {
+        tierId: String(tier.id),
+        amount: "500",
+        currency: "usd",
+        stripeAccountId: "acct_sub_anon_address",
+        userEmail: "anon-shipping@test.com",
+        shippingAddress: JSON.stringify(shippingAddress),
+      };
+
+      sinon.stub(stripeUtils.stripe.setupIntents, "retrieve").resolves({
+        id: "seti_anon_address",
+        payment_method: "pm_anon_address",
+        metadata,
+      } as unknown as Stripe.Response<Stripe.SetupIntent>);
+      sinon
+        .stub(stripeUtils.stripe.customers, "list")
+        .resolves({ data: [] } as unknown as Stripe.Response<
+          Stripe.ApiList<Stripe.Customer>
+        >);
+      sinon.stub(stripeUtils.stripe.customers, "create").resolves({
+        id: "cus_anon_address",
+      } as unknown as Stripe.Response<Stripe.Customer>);
+      sinon
+        .stub(stripeUtils.stripe.paymentMethods, "attach")
+        .resolves({} as unknown as Stripe.Response<Stripe.PaymentMethod>);
+      sinon.stub(stripeUtils.stripe.products, "create").resolves({
+        id: "prod_anon_address",
+      } as unknown as Stripe.Response<Stripe.Product>);
+      sinon.stub(stripeUtils.stripe.subscriptions, "create").resolves({
+        id: "sub_anon_address",
+      } as unknown as Stripe.Response<Stripe.Subscription>);
+
+      await stripeUtils.handleSetupIntentSucceeded({
+        id: "seti_anon_address",
+        metadata,
+      } as unknown as Stripe.SetupIntent);
+
+      const newUser = await prisma.user.findFirst({
+        where: { email: "anon-shipping@test.com" },
+      });
+      assert.ok(
+        newUser,
+        "a new user should be created for the anonymous buyer"
+      );
+
+      const subscription = await prisma.profileUserSubscription.findFirst({
+        where: { userId: newUser?.id, artistSubscriptionTierId: tier.id },
+      });
+      assert.ok(subscription, "the subscription should be registered");
+      assert.deepEqual(subscription?.shippingAddress, shippingAddress);
+    });
   });
 
   describe("GET /v1/purchase/:id", () => {
@@ -1324,6 +1480,55 @@ describe("purchase", () => {
       assert.equal(response.statusCode, 200);
       assert.ok(response.body.result.id, "should return a result id");
       assert.ok(response.body.result.status, "should return a result status");
+    });
+  });
+
+  describe("PUT /v1/purchase/:id — attach a subscription's shipping address", () => {
+    it("should return 400 when stripeAccountId query param is missing", async () => {
+      const response = await requestApp
+        .put("purchase/seti_shipping_test")
+        .send({ shippingAddress: { address: { country: "US" } } })
+        .set("Accept", "application/json");
+      assert.equal(response.statusCode, 400);
+    });
+
+    it("should return 400 for a non-SetupIntent id", async () => {
+      const response = await requestApp
+        .put("purchase/pi_shipping_test")
+        .query({ stripeAccountId: "acct_test" })
+        .send({ shippingAddress: { address: { country: "US" } } })
+        .set("Accept", "application/json");
+      assert.equal(response.statusCode, 400);
+    });
+
+    it("should return 400 when shippingAddress is missing", async () => {
+      const response = await requestApp
+        .put("purchase/seti_shipping_test")
+        .query({ stripeAccountId: "acct_test" })
+        .send({})
+        .set("Accept", "application/json");
+      assert.equal(response.statusCode, 400);
+    });
+
+    it("should return 200 when the shipping address is attached to a SetupIntent", async () => {
+      const response = await requestApp
+        .put("purchase/seti_shipping_test")
+        .query({ stripeAccountId: "acct_test" })
+        .send({
+          shippingAddress: {
+            name: "Buyer Name",
+            address: {
+              line1: "123 Main St",
+              city: "Anytown",
+              state: "CA",
+              postal_code: "12345",
+              country: "US",
+            },
+          },
+        })
+        .set("Accept", "application/json");
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body.result.id, "seti_shipping_test");
     });
   });
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -169,6 +169,7 @@ export const createTier = async (
       artistId: artistId,
       isDefaultTier: data?.isDefaultTier,
       collectAddress: data?.collectAddress,
+      platformPercent: data?.platformPercent,
     },
   });
   return tier;


### PR DESCRIPTION
Closes a couple of bugs along the subscription process that have been there for a while but some were also introduced in the big transition.
* Missing a mirlo hosted checkout page for subscriptions
* Platform percent should be for whatever the current percentage the artist set on the tier.
* Shipping addresses were excluded from the new pop up