### PR TITLE
fix: manage purchases and sales access

### DIFF
--- a/src/routers/v1/manage/purchases/index.ts
+++ b/src/routers/v1/manage/purchases/index.ts
@@ -3,13 +3,14 @@ import { NextFunction, Request, Response } from "express";
 
 import { assertLoggedIn } from "../../../../auth/getLoggedInUser";
 import { userAuthenticated } from "../../../../auth/passport";
+import { Prisma } from "@mirlo/prisma/client";
+import {
+  buyerUserSelect,
+  resolveManagedArtistIds,
+} from "../../../../utils/artist";
 import { getDateRange } from "../../../../utils/dateRange";
 import { downloadCSVFile } from "../../../../utils/download";
 import { serializeMerchPurchase } from "../../../../serializers/merchPurchase";
-
-type Params = {
-  merchId: string;
-};
 
 export default function () {
   const operations = {
@@ -31,21 +32,11 @@ export default function () {
       datePurchased?: string;
     };
 
-    let profileIds: string | string[] | number[] | undefined = artistIds;
-
     try {
-      if (!profileIds) {
-        profileIds = (
-          await prisma.profile.findMany({
-            where: {
-              userId: user.id,
-            },
-          })
-        ).map((a) => a.id);
-      } else if (typeof profileIds === "string") {
-        // If profileIds is a string, split it into an array
-        profileIds = profileIds.split(",");
-      }
+      const managedArtistIds = await resolveManagedArtistIds(
+        user.id,
+        artistIds
+      );
 
       let sinceDate: string | undefined;
       let untilDate: string | undefined;
@@ -56,8 +47,8 @@ export default function () {
         untilDate = dateRange.lt;
       }
 
-      const whereClause: any = {
-        merch: { profile: { id: { in: profileIds.map((a) => Number(a)) } } },
+      const whereClause: Prisma.MerchPurchaseWhereInput = {
+        merch: { profile: { id: { in: managedArtistIds } } },
       };
 
       if (sinceDate && untilDate) {
@@ -85,7 +76,7 @@ export default function () {
             },
           },
           transaction: true,
-          user: true,
+          user: { select: buyerUserSelect },
         },
         orderBy: {
           createdAt: "desc",

--- a/src/routers/v1/manage/purchases/{purchaseId}/index.ts
+++ b/src/routers/v1/manage/purchases/{purchaseId}/index.ts
@@ -6,6 +6,7 @@ import {
   userAuthenticated,
 } from "../../../../../auth/passport";
 import { serializeMerchPurchase } from "../../../../../serializers/merchPurchase";
+import { buyerUserSelect } from "../../../../../utils/artist";
 
 type Params = {
   purchaseId: string;
@@ -95,7 +96,7 @@ export default function () {
               profile: { omit: { apPrivateKey: true } },
             },
           },
-          user: true,
+          user: { select: buyerUserSelect },
         },
       });
 

--- a/src/routers/v1/manage/sales.ts
+++ b/src/routers/v1/manage/sales.ts
@@ -1,8 +1,8 @@
-import prisma from "@mirlo/prisma";
 import { Request, Response } from "express";
 
 import { assertLoggedIn } from "../../../auth/getLoggedInUser";
 import { userAuthenticated } from "../../../auth/passport";
+import { resolveManagedArtistIds } from "../../../utils/artist";
 import { getDateRange } from "../../../utils/dateRange";
 import { downloadCSVFile } from "../../../utils/download";
 import { findSales } from "../artists/{id}/supporters";
@@ -35,20 +35,12 @@ export default function () {
       // When the caller hasn't narrowed to a specific artist, "my sales" means
       // sales of artists I own AND sales routed to me as a release's payee
       // (e.g. a label). When they filter to a specific artist, show only that
-      // artist's sales.
+      // artist's sales — and only if they own or can manage that artist.
       const usingDefaultScope = !artistIds;
-      if (!artistIds) {
-        artistIds = (
-          await prisma.profile.findMany({
-            where: {
-              userId: user.id,
-            },
-          })
-        ).map((a) => a.id);
-      } else if (typeof artistIds === "string") {
-        // If artistIds is a string, split it into an array
-        artistIds = artistIds.split(",");
-      }
+      const managedArtistIds = await resolveManagedArtistIds(
+        user.id,
+        artistIds
+      );
 
       if (typeof trackGroupIds === "string") {
         // If trackGroupIds is a string, split it into an array
@@ -65,7 +57,7 @@ export default function () {
       }
 
       const results = await findSales({
-        artistId: artistIds.map((a) => Number(a)),
+        artistId: managedArtistIds,
         sinceDate,
         untilDate,
         filters: trackGroupIds

--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -138,6 +138,47 @@ export const whereForAllArtistsThisLabelCanEdit = (
   ],
 });
 
+/**
+ * Artist IDs for manage purchases/sales scoping.
+ *
+ * - No `requestedArtistIds`: owned artists only (`userId`) — matches historical
+ *   default list behavior.
+ * - With `requestedArtistIds`: intersect with artists the user owns or can
+ *   manage as a label (never expands to artists they cannot manage).
+ */
+export const resolveManagedArtistIds = async (
+  userId: number,
+  requestedArtistIds?: string | string[] | number[]
+): Promise<number[]> => {
+  let requested: number[] | undefined;
+  if (requestedArtistIds !== undefined) {
+    const raw =
+      typeof requestedArtistIds === "string"
+        ? requestedArtistIds.split(",")
+        : requestedArtistIds;
+    requested = raw.map((a) => Number(a)).filter((n) => Number.isFinite(n));
+  }
+
+  const managed = await prisma.profile.findMany({
+    where: {
+      ...(requested !== undefined
+        ? whereForAllArtistsThisLabelCanEdit(userId)
+        : { userId }),
+      ...(requested !== undefined ? { id: { in: requested } } : {}),
+    },
+    select: { id: true },
+  });
+
+  return managed.map((a) => a.id);
+};
+
+/** Buyer fields safe to return on manage purchase/fulfillment endpoints. */
+export const buyerUserSelect = {
+  id: true,
+  name: true,
+  email: true,
+} as const;
+
 export const whereForAllArtistsThisLabelCanAddReleasesFor = (
   userId: number
 ): Prisma.ProfileWhereInput => ({

--- a/test/routers/manage/purchases.spec.ts
+++ b/test/routers/manage/purchases.spec.ts
@@ -1,0 +1,293 @@
+import assert from "node:assert";
+
+import * as dotenv from "dotenv";
+dotenv.config();
+import { describe, it, beforeEach } from "mocha";
+import prisma from "@mirlo/prisma";
+
+import {
+  clearTables,
+  createUser,
+  createArtist,
+  createMerch,
+  createArtistLabel,
+} from "../../utils";
+import { requestApp } from "../utils";
+
+describe("manage/purchases", () => {
+  beforeEach(async () => {
+    try {
+      await clearTables();
+    } catch (e) {
+      console.error(e);
+    }
+  });
+
+  describe("GET /", () => {
+    it("should return 401 if not authenticated", async () => {
+      const response = await requestApp
+        .get("manage/purchases")
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 401);
+    });
+
+    it("should return purchases for artists owned by the user", async () => {
+      const { user, accessToken } = await createUser({
+        email: "artist@test.com",
+      });
+      const buyer = await createUser({
+        email: "buyer@test.com",
+        password: "super-secret-password",
+      });
+
+      const artist = await createArtist(user.id);
+      const merch = await createMerch(artist.id);
+
+      const transaction = await prisma.userTransaction.create({
+        data: {
+          userId: buyer.user.id,
+          amount: 1500,
+          currency: "usd",
+        },
+      });
+
+      await prisma.merchPurchase.create({
+        data: {
+          merchId: merch.id,
+          userId: buyer.user.id,
+          quantity: 1,
+          fulfillmentStatus: "NO_PROGRESS",
+          transactionId: transaction.id,
+        },
+      });
+
+      const response = await requestApp
+        .get("manage/purchases")
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body.results.length, 1);
+      assert.equal(response.body.results[0].user.email, "buyer@test.com");
+      assert.equal(response.body.results[0].user.id, buyer.user.id);
+      assert.equal(response.body.results[0].user.password, undefined);
+      assert.equal(
+        response.body.results[0].user.emailConfirmationToken,
+        undefined
+      );
+      assert.equal(
+        response.body.results[0].user.passwordResetConfirmationToken,
+        undefined
+      );
+    });
+
+    it("should not return purchases for artists not owned or managed by the user", async () => {
+      const owner = await createUser({ email: "owner@test.com" });
+      const attacker = await createUser({ email: "attacker@test.com" });
+      const buyer = await createUser({
+        email: "buyer@test.com",
+        password: "super-secret-password",
+      });
+
+      const artist = await createArtist(owner.user.id);
+      const merch = await createMerch(artist.id);
+
+      const transaction = await prisma.userTransaction.create({
+        data: {
+          userId: buyer.user.id,
+          amount: 1500,
+          currency: "usd",
+        },
+      });
+
+      await prisma.merchPurchase.create({
+        data: {
+          merchId: merch.id,
+          userId: buyer.user.id,
+          quantity: 1,
+          fulfillmentStatus: "NO_PROGRESS",
+          transactionId: transaction.id,
+        },
+      });
+
+      const response = await requestApp
+        .get(`manage/purchases?artistIds=${artist.id}`)
+        .set("Cookie", [`jwt=${attacker.accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body.results.length, 0);
+      assert.equal(response.body.total, 0);
+    });
+
+    it("should not return purchases for artists a user can manage but doesn't own when artist ids are not provided", async () => {
+      const label = await createUser({
+        email: "label@test.com",
+        isLabelAccount: true,
+      });
+      const owner = await createUser({ email: "owner@test.com" });
+      const buyer = await createUser({ email: "buyer@test.com" });
+
+      const artist = await createArtist(owner.user.id);
+      await createArtistLabel({
+        artistId: artist.id,
+        labelUserId: label.user.id,
+        canLabelManageArtist: true,
+        isLabelApproved: true,
+        isArtistApproved: true,
+      });
+
+      const merch = await createMerch(artist.id);
+      const transaction = await prisma.userTransaction.create({
+        data: {
+          userId: buyer.user.id,
+          amount: 900,
+          currency: "usd",
+        },
+      });
+
+      await prisma.merchPurchase.create({
+        data: {
+          merchId: merch.id,
+          userId: buyer.user.id,
+          quantity: 1,
+          fulfillmentStatus: "NO_PROGRESS",
+          transactionId: transaction.id,
+        },
+      });
+
+      const response = await requestApp
+        .get("manage/purchases")
+        .set("Cookie", [`jwt=${label.accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body.results.length, 0);
+    });
+
+    it("should return purchases for artists a user can manage but doesn't own when artist ids are provided", async () => {
+      const label = await createUser({
+        email: "label@test.com",
+        isLabelAccount: true,
+      });
+      const owner = await createUser({ email: "owner@test.com" });
+      const buyer = await createUser({ email: "buyer@test.com" });
+
+      const artist = await createArtist(owner.user.id);
+      await createArtistLabel({
+        artistId: artist.id,
+        labelUserId: label.user.id,
+        canLabelManageArtist: true,
+        isLabelApproved: true,
+        isArtistApproved: true,
+      });
+
+      const merch = await createMerch(artist.id);
+      const transaction = await prisma.userTransaction.create({
+        data: {
+          userId: buyer.user.id,
+          amount: 900,
+          currency: "usd",
+        },
+      });
+
+      await prisma.merchPurchase.create({
+        data: {
+          merchId: merch.id,
+          userId: buyer.user.id,
+          quantity: 1,
+          fulfillmentStatus: "NO_PROGRESS",
+          transactionId: transaction.id,
+        },
+      });
+
+      const response = await requestApp
+        .get(`manage/purchases?artistIds=${artist.id}`)
+        .set("Cookie", [`jwt=${label.accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body.results.length, 1);
+      assert.equal(response.body.results[0].user.email, "buyer@test.com");
+      assert.equal(response.body.results[0].user.password, undefined);
+    });
+  });
+
+  describe("GET /:purchaseId", () => {
+    it("should not leak buyer secrets on a single purchase", async () => {
+      const { user, accessToken } = await createUser({
+        email: "artist@test.com",
+      });
+      const buyer = await createUser({
+        email: "buyer@test.com",
+        password: "super-secret-password",
+      });
+
+      const artist = await createArtist(user.id);
+      const merch = await createMerch(artist.id);
+
+      const transaction = await prisma.userTransaction.create({
+        data: {
+          userId: buyer.user.id,
+          amount: 1500,
+          currency: "usd",
+        },
+      });
+
+      const purchase = await prisma.merchPurchase.create({
+        data: {
+          merchId: merch.id,
+          userId: buyer.user.id,
+          quantity: 1,
+          fulfillmentStatus: "NO_PROGRESS",
+          transactionId: transaction.id,
+        },
+      });
+
+      const response = await requestApp
+        .get(`manage/purchases/${purchase.id}`)
+        .set("Cookie", [`jwt=${accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body.result.user.email, "buyer@test.com");
+      assert.equal(response.body.result.user.password, undefined);
+      assert.equal(response.body.result.user.emailConfirmationToken, undefined);
+    });
+
+    it("should 404 for another artist's purchase", async () => {
+      const owner = await createUser({ email: "owner@test.com" });
+      const attacker = await createUser({ email: "attacker@test.com" });
+      const buyer = await createUser({ email: "buyer@test.com" });
+
+      const artist = await createArtist(owner.user.id);
+      const merch = await createMerch(artist.id);
+
+      const transaction = await prisma.userTransaction.create({
+        data: {
+          userId: buyer.user.id,
+          amount: 1500,
+          currency: "usd",
+        },
+      });
+
+      const purchase = await prisma.merchPurchase.create({
+        data: {
+          merchId: merch.id,
+          userId: buyer.user.id,
+          quantity: 1,
+          fulfillmentStatus: "NO_PROGRESS",
+          transactionId: transaction.id,
+        },
+      });
+
+      const response = await requestApp
+        .get(`manage/purchases/${purchase.id}`)
+        .set("Cookie", [`jwt=${attacker.accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 404);
+    });
+  });
+});

--- a/test/routers/manage/sales.spec.ts
+++ b/test/routers/manage/sales.spec.ts
@@ -381,5 +381,28 @@ describe("manage/sales", () => {
       assert.equal(labelResponse.statusCode, 200);
       assert.equal(labelResponse.body.results.length, 0);
     });
+
+    it("should not return another artist's sales via artistIds", async () => {
+      const owner = await createUser({ email: "owner@test.com" });
+      const attacker = await createUser({ email: "attacker@test.com" });
+      const buyer = await createUser({ email: "buyer@test.com" });
+
+      const artist = await createArtist(owner.user.id);
+      const trackGroup = await createTrackGroup(artist.id);
+
+      await createUserTrackGroupPurchase(buyer.user.id, trackGroup.id, {
+        amount: 2500,
+      });
+
+      const response = await requestApp
+        .get(`manage/sales?artistIds=${artist.id}`)
+        .set("Cookie", [`jwt=${attacker.accessToken}`])
+        .set("Accept", "application/json");
+
+      assert.equal(response.statusCode, 200);
+      assert.equal(response.body.results.length, 0);
+      assert.equal(response.body.total, 0);
+      assert.equal(response.body.totalAmount, 0);
+    });
   });
 });


### PR DESCRIPTION
- user only sees sales for managed or owned artists when querying by artist
- purchases limit buyer information included