### PR TITLE
Fix album link opening in new tab in persistent player

### DIFF
--- a/client/src/components/Widget/TrackTitleContent.tsx
+++ b/client/src/components/Widget/TrackTitleContent.tsx
@@ -35,7 +35,16 @@ export const TrackTitleContent: React.FC<{
     ? "Drafts"
     : track.trackGroup.title || tTrackGroup("untitled");
 
-  const trackGroupLink = (
+  // WidgetLink always opens in a new tab, which is correct when this content is
+  // rendered inside an embeddable widget (or a widget preview). The persistent
+  // player, however, sets useTrackArtistLinks to indicate we're navigating inside
+  // the main Mirlo app itself, where the artist and track title links already stay
+  // in the current tab — so the album link should match instead of standing out.
+  const trackGroupLink = useTrackArtistLinks ? (
+    <Link to={getReleaseUrl(track.trackGroup.artist, track.trackGroup)}>
+      {trackGroupLabel}
+    </Link>
+  ) : (
     <WidgetLink
       to={getReleaseUrl(track.trackGroup.artist, track.trackGroup)}
       embeddedInMirlo={embeddedInMirlo}


### PR DESCRIPTION
The artist and track title links in the bottom player bar navigate in the current tab, but the album name link opened a new tab because it was rendered through WidgetLink, which always sets target="_blank". That's correct when TrackTitleContent is used inside an embeddable widget, but the player passes useTrackArtistLinks to indicate it's part of the main Mirlo app, not a widget embed, and the other two links already respect that.

Route the album link through the same in-app Link component in that case, so all three links behave consistently. Widget embed contexts are unaffected since useTrackArtistLinks is never set there.

Fixes #2375