### PR TITLE
fix(images): version image URLs so re-uploads aren't served from cache

### DIFF
--- a/src/utils/artist.ts
+++ b/src/utils/artist.ts
@@ -729,14 +729,38 @@ export const singleInclude = (queryOptions?: {
 
 export const addSizesToImage = (
   bucket: string,
-  image?: { url: string[] } | null
+  image?: { url: string[]; updatedAt?: Date | string } | null
 ) => {
-  return image
-    ? {
-        ...image,
-        sizes: image && convertURLArrayToSizes(image?.url, bucket),
-      }
-    : null;
+  if (!image) {
+    return null;
+  }
+
+  const sizes = convertURLArrayToSizes(image.url, bucket) as Record<
+    string,
+    string
+  >;
+
+  // Re-uploading an image reuses the same object key, so its URLs never change
+  // and browsers/the CDN keep serving the previous file. Stamping the record's
+  // updatedAt onto each size gives every upload a distinct URL, without
+  // touching storage or invalidating anything. See #2362 and #2377.
+  const version = image.updatedAt
+    ? new Date(image.updatedAt).getTime()
+    : undefined;
+
+  if (!version) {
+    return { ...image, sizes };
+  }
+
+  const versionedSizes = Object.keys(sizes).reduce<Record<string, string>>(
+    (aggr, size) => {
+      aggr[size] = `${sizes[size]}?${version}`;
+      return aggr;
+    },
+    {}
+  );
+
+  return { ...image, sizes: versionedSizes };
 };
 
 /**


### PR DESCRIPTION
Fixes the stale-image problem reported in #2362, and I think #2377 as well.

## What's happening

Re-uploading a cover, artist avatar or label logo writes to the same storage key, so `convertURLArrayToSizes` produces exactly the same URLs as before. Browsers and the CDN have no reason to refetch, so the old image keeps showing. The manage pages look right because they render the freshly uploaded file directly.

That also explains the detail in #2362 that background images *do* refresh: `ArtistBackground`, `UserBanner`, `ArtistHeaderSection` and `ArtistMerchListItem` already append `?${updatedAt}` by hand. Nothing else does.

## What this changes

`addSizesToImage` is the single place every serializer goes through for covers, avatars, banners, merch and subscription-tier images, and it already receives the image record. It now stamps that record's `updatedAt` onto each generated size URL, so every upload produces a distinct URL. No storage changes and no cache invalidation needed.

## Notes

The four components listed above will now append their own `?${updatedAt}` on top of the versioned URL. That is harmless, since the query string is opaque to the CDN and the URL still resolves, but those hand-rolled appends are redundant now and could come out in a follow-up. I left them alone to keep this to one function.

I wasn't able to run the stack locally, so this is reasoned from the code rather than verified against a running instance.

Happy to move the versioning into `convertURLArrayToSizes` instead, or scope it to covers only, if you'd prefer either.